### PR TITLE
feat: add nano-banana skill + contribution standards README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,224 @@
 # MinisSkills
-Skills collection for Minis.
+
+A community collection of skills for [Minis](https://minis.ai) — reusable instruction sets that extend Claude's capabilities with specialized workflows, domain knowledge, and bundled resources.
+
+---
+
+## What is a Skill?
+
+A skill is a directory containing a `SKILL.md` file (plus optional bundled resources) that Claude loads when it detects a relevant user request. Skills use a three-level loading system:
+
+1. **Metadata** (`name` + `description` in frontmatter) — always in context, used for triggering (~100 words)
+2. **SKILL.md body** — loaded into context whenever the skill triggers (keep under 500 lines)
+3. **Bundled resources** — scripts, references, and assets loaded only as needed (unlimited size)
+
+---
+
+## Directory Structure
+
+### Repository Layout
+
+```
+MinisSkills/
+├── README.md
+└── <skill-name>/           # One directory per skill (see naming rules below)
+    ├── SKILL.md            # Required
+    ├── evals/              # Optional: test cases
+    │   └── evals.json
+    ├── scripts/            # Optional: executable helper scripts
+    ├── references/         # Optional: reference docs loaded into context as needed
+    └── assets/             # Optional: templates, icons, fonts used in output
+```
+
+### Skill Directory Naming
+
+- Use **lowercase kebab-case**: `my-skill-name`
+- Be descriptive but concise (2–4 words is ideal)
+- Use the domain or action as a prefix when it helps group related skills
+- ✅ Good: `health-sleep-analysis`, `nano-banana`, `remote-dev-minis-app`
+- ❌ Avoid: `MySkill`, `skill_for_doing_things`, `s1`
+
+---
+
+## SKILL.md Format
+
+Every skill **must** have a `SKILL.md` with a YAML frontmatter block followed by Markdown instructions.
+
+### Frontmatter (Required)
+
+```yaml
+---
+name: skill-name
+description: >
+  One or two sentences describing what the skill does and — crucially — when
+  Claude should trigger it. Include specific user phrases, contexts, and
+  keywords that signal this skill is needed. Be slightly "pushy": list
+  edge cases and near-miss scenarios where this skill should still win.
+---
+```
+
+> **Why the description matters:** The `description` field is the primary trigger mechanism. Claude reads the skill name + description to decide whether to load the skill. A vague description leads to undertriggering. A good description covers both *what the skill does* and *when to use it*, with concrete phrases a real user might say.
+
+### Optional Frontmatter Fields
+
+```yaml
+---
+name: skill-name
+description: ...
+compatibility: Python 3.10+, requires ffmpeg  # tools/deps needed, if any
+---
+```
+
+### Full Anatomy
+
+```
+skill-name/
+├── SKILL.md
+│   ├── YAML frontmatter    ← name, description (required); compatibility (optional)
+│   └── Markdown body       ← instructions, examples, output formats, workflows
+└── Bundled Resources (optional)
+    ├── scripts/            ← deterministic/repetitive tasks; Claude runs without loading
+    ├── references/         ← docs loaded into context on demand; include a TOC if >300 lines
+    └── assets/             ← output templates, icons, fonts
+```
+
+---
+
+## Writing a Good Skill
+
+### Instructions Style
+
+- Write in the **imperative form**: "Fetch the file", "Parse the JSON", "Return a table"
+- **Explain the *why*** behind requirements — don't just say `MUST do X`, explain why X matters. Claude understands reasoning and applies it more flexibly than rigid rules
+- Use `ALWAYS` / `NEVER` sparingly; prefer reasoning over mandates
+- Aim for **under 500 lines** in SKILL.md; if longer, split content into `references/` files with clear pointers
+
+### Defining Output Formats
+
+Use an explicit template block when the output structure is fixed:
+
+```markdown
+## Output format
+Always use this exact structure:
+
+# [Title]
+## Summary
+## Steps
+## Result
+```
+
+### Including Examples
+
+```markdown
+## Examples
+
+**Example 1**
+Input: "convert sales_q4.csv to a bar chart by region"
+Output: a PNG file saved to the workspace, axes labeled, legend included
+```
+
+### Multi-Domain Skills
+
+When a skill covers multiple frameworks or platforms, keep `SKILL.md` lean and delegate to reference files:
+
+```
+cloud-deploy/
+├── SKILL.md          ← workflow overview + "read the relevant reference file"
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+
+### Progressive Disclosure Pattern
+
+For large skills, add a hierarchy:
+
+1. `SKILL.md` — overview, decision logic, pointers to sub-references
+2. `references/<topic>.md` — deep detail, loaded only when relevant
+3. `scripts/<task>.py` — executed directly without loading into context
+
+---
+
+## Evals (Optional but Recommended)
+
+Skills with objectively verifiable outputs benefit from test cases saved in `evals/evals.json`:
+
+```json
+{
+  "skill_name": "my-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "A realistic user prompt — include context, file names, casual phrasing",
+      "expected_output": "Description of what a correct result looks like",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Output contains a valid JSON object with keys 'name' and 'score'",
+          "type": "contains"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Tips for good eval prompts:**
+- Write them the way a real user would — casual, with typos, abbreviations, specific file names
+- Cover edge cases, not just the happy path
+- 2–5 prompts per skill is a good starting point
+
+---
+
+## Submission Checklist
+
+Before opening a pull request, verify:
+
+- [ ] Directory name is **lowercase kebab-case**
+- [ ] `SKILL.md` exists with valid YAML frontmatter (`name` + `description`)
+- [ ] `description` clearly states **what** the skill does and **when** to trigger it
+- [ ] SKILL.md body is **under 500 lines** (or uses `references/` for overflow)
+- [ ] Instructions use **imperative form** and explain the *why* behind key steps
+- [ ] No hardcoded secrets, API keys, or credentials anywhere in the skill
+- [ ] Bundled scripts are in `scripts/`, reference docs in `references/`, static assets in `assets/`
+- [ ] If evals exist, `evals/evals.json` follows the schema above
+
+---
+
+## Example Skill
+
+```
+health-sleep-analysis/
+├── SKILL.md
+├── evals/
+│   └── evals.json
+└── references/
+    └── healthkit-types.md
+```
+
+**`health-sleep-analysis/SKILL.md`:**
+
+```markdown
+---
+name: health-sleep-analysis
+description: >
+  Analyze sleep health data from Apple HealthKit, including sleep stages
+  (Deep/REM/Core/Awake), blood oxygen (SpO2), sleep duration trends, and
+  bedtime patterns. Use this skill whenever the user asks about sleep quality,
+  sleep analysis, sleep stages, blood oxygen during sleep, or any Apple Watch
+  sleep data — even if they don't use the word "analysis". Also trigger for
+  "睡眠分析", "血氧", "深睡眠", "REM睡眠".
+---
+
+# Sleep Health Analysis
+
+Fetch sleep and SpO2 data from HealthKit, then produce a structured report
+covering...
+```
+
+---
+
+## License
+
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ description: >
   (Deep/REM/Core/Awake), blood oxygen (SpO2), sleep duration trends, and
   bedtime patterns. Use this skill whenever the user asks about sleep quality,
   sleep analysis, sleep stages, blood oxygen during sleep, or any Apple Watch
-  sleep data — even if they don't use the word "analysis". Also trigger for
-  "睡眠分析", "血氧", "深睡眠", "REM睡眠".
+  sleep data — even if they don't use the word "analysis".
 ---
 
 # Sleep Health Analysis

--- a/nano-banana/SKILL.md
+++ b/nano-banana/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: nano-banana
+description: 使用 Google Nano Banana（Gemini 图像生成 API）生成或编辑图片。当用户说"生成图片"、"画一张"、"帮我做张图"、"图片编辑"、"把这张图改成"、"nano banana"、"nanobanana"、"香蕉"图像生成相关需求时，自动触发此 skill。即使用户没有明确提到 Nano Banana，只要涉及 AI 图片生成或编辑，也应主动使用此 skill。
+---
+
+# Nano Banana 图片生成 Skill
+
+基于 Google Gemini 图像生成 API（即 Nano Banana），在本地用 Python 生成或编辑图片。
+
+## 快速流程
+
+1. 检查环境（API Key + 依赖）
+2. 根据需求选择模式（文生图 / 图片编辑 / 多图混合）
+3. 选择合适的模型
+4. **直接使用 skill 内置脚本**，无需重新编写
+5. 运行脚本，保存结果到 `/var/minis/attachments/`
+6. 在对话中内联展示图片
+
+---
+
+## 环境准备
+
+### 检查 API Key
+```bash
+source /etc/profile && echo $GEMINI_API_KEY | head -c 10
+```
+
+> ⚠️ **必须用 `source /etc/profile`**，否则环境变量不生效。Key 存储在 `/etc/profile` 中的 `GEMINI_API_KEY`。
+
+如未设置，引导用户在 [Google AI Studio](https://aistudio.google.com/apikey) 获取，然后：
+```bash
+echo 'export GEMINI_API_KEY="your_key_here"' >> /etc/profile
+```
+
+### 检查依赖
+```bash
+pip show google-genai pillow 2>&1 | grep -E "^Name|not found"
+```
+
+如未安装：
+```bash
+pip install google-genai pillow
+```
+
+---
+
+## 模型选择
+
+| 模型 | 模型 ID | 适用场景 |
+|------|---------|---------|
+| **Nano Banana 2**（推荐首选） | `gemini-3.1-flash-image-preview` | 速度快、质量好、支持 2K，日常首选 |
+| **Nano Banana Pro** | `gemini-3-pro-image-preview` | 专业资产、复杂指令、高保真文字渲染 |
+| **Nano Banana（原版）** | `gemini-2.5-flash-image` | 极速低延迟，简单任务 |
+
+**默认使用 `gemini-3.1-flash-image-preview`**，除非用户明确要求其他版本。
+
+---
+
+## ⚠️ 已知 API 陷阱（必读）
+
+### 1. 宽高比 / 分辨率配置
+
+❌ **错误写法**（旧版，会报 `AttributeError`）：
+```python
+# types.ImageGenerationConfig 不存在！
+image_generation_config=types.ImageGenerationConfig(aspect_ratio="16:9")
+```
+
+✅ **正确写法**：
+```python
+# 使用 image_config=types.ImageConfig(...)
+config=types.GenerateContentConfig(
+    response_modalities=["IMAGE"],
+    image_config=types.ImageConfig(
+        aspect_ratio="16:9",  # 可选: 1:1, 4:3, 3:4, 16:9, 9:16
+        image_size="2K",      # 可选: 1K, 2K（默认 1K）
+    ),
+)
+```
+
+### 2. 环境变量加载
+
+❌ 直接 `python3 script.py` 可能读不到 Key  
+✅ 始终用 `source /etc/profile && python3 script.py`
+
+### 3. 图片保存
+
+使用 `part.as_image()` 返回 PIL Image 对象，直接 `.save(path)` 即可。无需手动处理 base64。
+
+---
+
+## 内置脚本
+
+> 直接复制使用，无需重新编写。所有脚本运行方式：
+> ```bash
+> source /etc/profile && python3 <skill-path>/nano-banana/scripts/<script>.py [args]
+> ```
+
+---
+
+### 📄 `gen.py` — 文生图（主力脚本）
+
+```python
+#!/usr/bin/env python3
+"""
+Nano Banana 文生图脚本
+用法: python3 gen.py "prompt内容" [输出路径] [宽高比] [分辨率]
+示例: python3 gen.py "一只熊猫在竹林喝茶" /var/minis/attachments/out.png 1:1 2K
+"""
+import os, sys
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+prompt      = sys.argv[1] if len(sys.argv) > 1 else "a beautiful landscape"
+output_path = sys.argv[2] if len(sys.argv) > 2 else "/var/minis/attachments/output.png"
+aspect      = sys.argv[3] if len(sys.argv) > 3 else "1:1"
+size        = sys.argv[4] if len(sys.argv) > 4 else "1K"
+
+print(f"Generating: {prompt[:60]}...")
+print(f"Output: {output_path} | {aspect} | {size}")
+
+response = client.models.generate_content(
+    model="gemini-3.1-flash-image-preview",
+    contents=[prompt],
+    config=types.GenerateContentConfig(
+        response_modalities=["IMAGE"],
+        image_config=types.ImageConfig(
+            aspect_ratio=aspect,
+            image_size=size,
+        ),
+    ),
+)
+
+saved = False
+for part in response.candidates[0].content.parts:
+    if part.inline_data is not None:
+        part.as_image().save(output_path)
+        print(f"✅ Saved: {output_path}")
+        saved = True
+    elif hasattr(part, "text") and part.text:
+        print(f"ℹ️  Model: {part.text}")
+
+if not saved:
+    print("❌ No image returned. Try rephrasing the prompt.")
+    sys.exit(1)
+```
+
+---
+
+### 📄 `edit.py` — 图片编辑（图 + 文 → 图）
+
+```python
+#!/usr/bin/env python3
+"""
+Nano Banana 图片编辑脚本
+用法: python3 edit.py <输入图片路径> "编辑指令" [输出路径]
+示例: python3 edit.py /var/minis/attachments/photo.jpg "给猫加一顶巫师帽" /var/minis/attachments/edited.png
+"""
+import os, sys, base64
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+if len(sys.argv) < 3:
+    print("Usage: edit.py <input_image> <prompt> [output_path]")
+    sys.exit(1)
+
+input_path  = sys.argv[1]
+edit_prompt = sys.argv[2]
+output_path = sys.argv[3] if len(sys.argv) > 3 else "/var/minis/attachments/edited.png"
+
+ext = input_path.lower().rsplit(".", 1)[-1]
+mime_map = {"jpg": "image/jpeg", "jpeg": "image/jpeg", "png": "image/png", "webp": "image/webp"}
+mime_type = mime_map.get(ext, "image/jpeg")
+
+with open(input_path, "rb") as f:
+    image_bytes = f.read()
+
+print(f"Editing: {input_path}")
+print(f"Instruction: {edit_prompt[:60]}...")
+
+response = client.models.generate_content(
+    model="gemini-3.1-flash-image-preview",
+    contents=[
+        types.Part.from_bytes(data=image_bytes, mime_type=mime_type),
+        edit_prompt,
+    ],
+    config=types.GenerateContentConfig(
+        response_modalities=["IMAGE", "TEXT"],
+    ),
+)
+
+for part in response.candidates[0].content.parts:
+    if part.inline_data is not None:
+        part.as_image().save(output_path)
+        print(f"✅ Saved: {output_path}")
+    elif hasattr(part, "text") and part.text:
+        print(f"ℹ️  Model: {part.text}")
+```
+
+---
+
+### 📄 `batch.py` — 批量生图（多 prompt → 多图）
+
+```python
+#!/usr/bin/env python3
+"""
+Nano Banana 批量生图脚本
+用法: python3 batch.py  (直接编辑脚本底部的 TASKS 列表)
+"""
+import os
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+# ✏️ 编辑此处定义批量任务
+TASKS = [
+    {"prompt": "a futuristic city at night", "file": "/var/minis/attachments/batch_1.png", "aspect": "16:9"},
+    {"prompt": "a cozy coffee shop interior", "file": "/var/minis/attachments/batch_2.png", "aspect": "1:1"},
+]
+
+for i, task in enumerate(TASKS):
+    print(f"[{i+1}/{len(TASKS)}] {task['file']}")
+    response = client.models.generate_content(
+        model="gemini-3.1-flash-image-preview",
+        contents=[task["prompt"]],
+        config=types.GenerateContentConfig(
+            response_modalities=["IMAGE"],
+            image_config=types.ImageConfig(
+                aspect_ratio=task.get("aspect", "1:1"),
+                image_size=task.get("size", "1K"),
+            ),
+        ),
+    )
+    for part in response.candidates[0].content.parts:
+        if part.inline_data is not None:
+            part.as_image().save(task["file"])
+            print(f"  ✅ Saved")
+        elif hasattr(part, "text") and part.text:
+            print(f"  ℹ️  {part.text}")
+
+print("All done!")
+```
+
+---
+
+## 实际操作步骤
+
+当用户发出图片生成请求时：
+
+1. **理解需求** — 判断是文生图、图片编辑还是批量生图
+2. **检查 API Key** — `source /etc/profile && echo $GEMINI_API_KEY | head -c 10`
+3. **检查脚本是否存在** — `ls <skill-path>/nano-banana/scripts/`
+4. **若脚本不存在**，用 `file_write` 将上方对应脚本写入 skill 目录
+5. **执行**：
+   - 文生图：`source /etc/profile && python3 <skill-path>/nano-banana/scripts/gen.py "prompt" /var/minis/attachments/out.png 16:9 2K`
+   - 图片编辑：`source /etc/profile && python3 <skill-path>/nano-banana/scripts/edit.py <图片路径> "指令" /var/minis/attachments/out.png`
+   - 批量：编辑 `scripts/batch.py` 中的 TASKS，再运行
+6. **展示结果** — `![描述](minis://attachments/out.png)`
+
+---
+
+## Prompt 写作技巧
+
+- **写场景描述，不要堆关键词** — "一位老年日本陶艺家在工作室专注拉坯，窗外透进柔和午后阳光，照片级写实风格" 优于 "日本 陶艺 老人 写实"
+- **明确风格** — 摄影风格加相机参数（"50mm 定焦镜头，浅景深"）；插画风格说明画风（"吉卜力风格水彩"）
+- **图中文字** — 明确说明要显示的文字内容，文字渲染效果更好
+- **迭代修改** — 用 `edit.py` 在已有图上小幅调整，比重新生成效率更高
+- **宽高比选择** — 社交媒体配图用 `16:9`，头像/封面用 `1:1`，手机壁纸用 `9:16`
+
+---
+
+## 常见问题
+
+| 问题 | 原因 & 解决方案 |
+|------|----------------|
+| `AttributeError: ImageGenerationConfig` | 旧写法已废弃，改用 `image_config=types.ImageConfig(...)` |
+| `KeyError: GEMINI_API_KEY` | 先执行 `source /etc/profile`，再运行脚本 |
+| 图片未生成，只有文字 | 确认 `response_modalities` 包含 `"IMAGE"` |
+| 图片质量不佳 | 换用 `gemini-3-pro-image-preview`，或优化 prompt |
+| 速率限制错误 | 免费套餐有限制，稍等片刻重试 |
+| 图片保存失败 | 确认 `/var/minis/attachments/` 目录存在 |
+
+---
+
+## 参考资源
+
+- 官方文档：https://ai.google.dev/gemini-api/docs/image-generation
+- API Key 获取：https://aistudio.google.com/apikey

--- a/nano-banana/SKILL.md
+++ b/nano-banana/SKILL.md
@@ -1,293 +1,166 @@
 ---
 name: nano-banana
-description: 使用 Google Nano Banana（Gemini 图像生成 API）生成或编辑图片。当用户说"生成图片"、"画一张"、"帮我做张图"、"图片编辑"、"把这张图改成"、"nano banana"、"nanobanana"、"香蕉"图像生成相关需求时，自动触发此 skill。即使用户没有明确提到 Nano Banana，只要涉及 AI 图片生成或编辑，也应主动使用此 skill。
+description: Generate or edit images using Google Nano Banana (Gemini image generation API). Trigger this skill whenever the user asks to generate an image, draw something, create artwork, edit a photo, or mentions "nano banana", "nanobanana", or any AI image generation/editing need — even if they don't explicitly mention Nano Banana. Proactively use this skill for any image creation or transformation request.
 ---
 
-# Nano Banana 图片生成 Skill
+# Nano Banana — Image Generation Skill
 
-基于 Google Gemini 图像生成 API（即 Nano Banana），在本地用 Python 生成或编辑图片。
+Generate or edit images locally using the Google Gemini image generation API (a.k.a. Nano Banana).
 
-## 快速流程
+## Quick Workflow
 
-1. 检查环境（API Key + 依赖）
-2. 根据需求选择模式（文生图 / 图片编辑 / 多图混合）
-3. 选择合适的模型
-4. **直接使用 skill 内置脚本**，无需重新编写
-5. 运行脚本，保存结果到 `/var/minis/attachments/`
-6. 在对话中内联展示图片
+1. Check environment (API key + dependencies)
+2. Identify the mode: text-to-image / image editing / batch generation
+3. Choose the right model
+4. **Use the bundled scripts directly** — no need to rewrite them
+5. Run the script and save output to `/var/minis/attachments/`
+6. Display the result inline in the conversation
 
 ---
 
-## 环境准备
+## Environment Setup
 
-### 检查 API Key
+### Check API Key
 ```bash
 source /etc/profile && echo $GEMINI_API_KEY | head -c 10
 ```
 
-> ⚠️ **必须用 `source /etc/profile`**，否则环境变量不生效。Key 存储在 `/etc/profile` 中的 `GEMINI_API_KEY`。
+> ⚠️ Always run `source /etc/profile` first — environment variables are stored there and won't be available otherwise.
 
-如未设置，引导用户在 [Google AI Studio](https://aistudio.google.com/apikey) 获取，然后：
+If not set, direct the user to [Google AI Studio](https://aistudio.google.com/apikey) to obtain a key, then:
 ```bash
 echo 'export GEMINI_API_KEY="your_key_here"' >> /etc/profile
 ```
 
-### 检查依赖
+### Check Dependencies
 ```bash
 pip show google-genai pillow 2>&1 | grep -E "^Name|not found"
 ```
 
-如未安装：
+If missing:
 ```bash
 pip install google-genai pillow
 ```
 
 ---
 
-## 模型选择
+## Model Selection
 
-| 模型 | 模型 ID | 适用场景 |
-|------|---------|---------|
-| **Nano Banana 2**（推荐首选） | `gemini-3.1-flash-image-preview` | 速度快、质量好、支持 2K，日常首选 |
-| **Nano Banana Pro** | `gemini-3-pro-image-preview` | 专业资产、复杂指令、高保真文字渲染 |
-| **Nano Banana（原版）** | `gemini-2.5-flash-image` | 极速低延迟，简单任务 |
+| Model | Model ID | Best For |
+|-------|----------|----------|
+| **Nano Banana 2** (recommended) | `gemini-3.1-flash-image-preview` | Fast, high quality, 2K support — default choice |
+| **Nano Banana Pro** | `gemini-3-pro-image-preview` | Complex prompts, professional assets, precise text rendering |
+| **Nano Banana (original)** | `gemini-2.5-flash-image` | Ultra-low latency, simple tasks |
 
-**默认使用 `gemini-3.1-flash-image-preview`**，除非用户明确要求其他版本。
+**Default to `gemini-3.1-flash-image-preview`** unless the user explicitly requests another version.
 
 ---
 
-## ⚠️ 已知 API 陷阱（必读）
+## ⚠️ Known API Pitfalls
 
-### 1. 宽高比 / 分辨率配置
+### 1. Aspect ratio / resolution config
 
-❌ **错误写法**（旧版，会报 `AttributeError`）：
+❌ **Wrong** (old API, throws `AttributeError`):
 ```python
-# types.ImageGenerationConfig 不存在！
+# types.ImageGenerationConfig does not exist!
 image_generation_config=types.ImageGenerationConfig(aspect_ratio="16:9")
 ```
 
-✅ **正确写法**：
+✅ **Correct**:
 ```python
-# 使用 image_config=types.ImageConfig(...)
 config=types.GenerateContentConfig(
     response_modalities=["IMAGE"],
     image_config=types.ImageConfig(
-        aspect_ratio="16:9",  # 可选: 1:1, 4:3, 3:4, 16:9, 9:16
-        image_size="2K",      # 可选: 1K, 2K（默认 1K）
+        aspect_ratio="16:9",  # options: 1:1, 4:3, 3:4, 16:9, 9:16
+        image_size="2K",      # options: 1K, 2K (default: 1K)
     ),
 )
 ```
 
-### 2. 环境变量加载
+### 2. Environment variable loading
 
-❌ 直接 `python3 script.py` 可能读不到 Key  
-✅ 始终用 `source /etc/profile && python3 script.py`
+❌ Running `python3 script.py` directly may not have the API key  
+✅ Always prefix with `source /etc/profile && python3 script.py`
 
-### 3. 图片保存
+### 3. Saving images
 
-使用 `part.as_image()` 返回 PIL Image 对象，直接 `.save(path)` 即可。无需手动处理 base64。
-
----
-
-## 内置脚本
-
-> 直接复制使用，无需重新编写。所有脚本运行方式：
-> ```bash
-> source /etc/profile && python3 <skill-path>/nano-banana/scripts/<script>.py [args]
-> ```
+`part.as_image()` returns a PIL Image object — call `.save(path)` directly. No need to handle base64 manually.
 
 ---
 
-### 📄 `gen.py` — 文生图（主力脚本）
+## Bundled Scripts
 
-```python
-#!/usr/bin/env python3
-"""
-Nano Banana 文生图脚本
-用法: python3 gen.py "prompt内容" [输出路径] [宽高比] [分辨率]
-示例: python3 gen.py "一只熊猫在竹林喝茶" /var/minis/attachments/out.png 1:1 2K
-"""
-import os, sys
-from google import genai
-from google.genai import types
-
-client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-
-prompt      = sys.argv[1] if len(sys.argv) > 1 else "a beautiful landscape"
-output_path = sys.argv[2] if len(sys.argv) > 2 else "/var/minis/attachments/output.png"
-aspect      = sys.argv[3] if len(sys.argv) > 3 else "1:1"
-size        = sys.argv[4] if len(sys.argv) > 4 else "1K"
-
-print(f"Generating: {prompt[:60]}...")
-print(f"Output: {output_path} | {aspect} | {size}")
-
-response = client.models.generate_content(
-    model="gemini-3.1-flash-image-preview",
-    contents=[prompt],
-    config=types.GenerateContentConfig(
-        response_modalities=["IMAGE"],
-        image_config=types.ImageConfig(
-            aspect_ratio=aspect,
-            image_size=size,
-        ),
-    ),
-)
-
-saved = False
-for part in response.candidates[0].content.parts:
-    if part.inline_data is not None:
-        part.as_image().save(output_path)
-        print(f"✅ Saved: {output_path}")
-        saved = True
-    elif hasattr(part, "text") and part.text:
-        print(f"ℹ️  Model: {part.text}")
-
-if not saved:
-    print("❌ No image returned. Try rephrasing the prompt.")
-    sys.exit(1)
+Run any script with:
+```bash
+source /etc/profile && python3 <skill-path>/nano-banana/scripts/<script>.py [args]
 ```
 
 ---
 
-### 📄 `edit.py` — 图片编辑（图 + 文 → 图）
+### 📄 `gen.py` — Text to Image
 
-```python
-#!/usr/bin/env python3
-"""
-Nano Banana 图片编辑脚本
-用法: python3 edit.py <输入图片路径> "编辑指令" [输出路径]
-示例: python3 edit.py /var/minis/attachments/photo.jpg "给猫加一顶巫师帽" /var/minis/attachments/edited.png
-"""
-import os, sys, base64
-from google import genai
-from google.genai import types
-
-client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-
-if len(sys.argv) < 3:
-    print("Usage: edit.py <input_image> <prompt> [output_path]")
-    sys.exit(1)
-
-input_path  = sys.argv[1]
-edit_prompt = sys.argv[2]
-output_path = sys.argv[3] if len(sys.argv) > 3 else "/var/minis/attachments/edited.png"
-
-ext = input_path.lower().rsplit(".", 1)[-1]
-mime_map = {"jpg": "image/jpeg", "jpeg": "image/jpeg", "png": "image/png", "webp": "image/webp"}
-mime_type = mime_map.get(ext, "image/jpeg")
-
-with open(input_path, "rb") as f:
-    image_bytes = f.read()
-
-print(f"Editing: {input_path}")
-print(f"Instruction: {edit_prompt[:60]}...")
-
-response = client.models.generate_content(
-    model="gemini-3.1-flash-image-preview",
-    contents=[
-        types.Part.from_bytes(data=image_bytes, mime_type=mime_type),
-        edit_prompt,
-    ],
-    config=types.GenerateContentConfig(
-        response_modalities=["IMAGE", "TEXT"],
-    ),
-)
-
-for part in response.candidates[0].content.parts:
-    if part.inline_data is not None:
-        part.as_image().save(output_path)
-        print(f"✅ Saved: {output_path}")
-    elif hasattr(part, "text") and part.text:
-        print(f"ℹ️  Model: {part.text}")
+```
+Usage:  gen.py "prompt" [output_path] [aspect_ratio] [resolution]
+Example: gen.py "a panda drinking tea in a bamboo forest" /var/minis/attachments/out.png 1:1 2K
 ```
 
 ---
 
-### 📄 `batch.py` — 批量生图（多 prompt → 多图）
+### 📄 `edit.py` — Image Editing (image + prompt → image)
 
-```python
-#!/usr/bin/env python3
-"""
-Nano Banana 批量生图脚本
-用法: python3 batch.py  (直接编辑脚本底部的 TASKS 列表)
-"""
-import os
-from google import genai
-from google.genai import types
-
-client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-
-# ✏️ 编辑此处定义批量任务
-TASKS = [
-    {"prompt": "a futuristic city at night", "file": "/var/minis/attachments/batch_1.png", "aspect": "16:9"},
-    {"prompt": "a cozy coffee shop interior", "file": "/var/minis/attachments/batch_2.png", "aspect": "1:1"},
-]
-
-for i, task in enumerate(TASKS):
-    print(f"[{i+1}/{len(TASKS)}] {task['file']}")
-    response = client.models.generate_content(
-        model="gemini-3.1-flash-image-preview",
-        contents=[task["prompt"]],
-        config=types.GenerateContentConfig(
-            response_modalities=["IMAGE"],
-            image_config=types.ImageConfig(
-                aspect_ratio=task.get("aspect", "1:1"),
-                image_size=task.get("size", "1K"),
-            ),
-        ),
-    )
-    for part in response.candidates[0].content.parts:
-        if part.inline_data is not None:
-            part.as_image().save(task["file"])
-            print(f"  ✅ Saved")
-        elif hasattr(part, "text") and part.text:
-            print(f"  ℹ️  {part.text}")
-
-print("All done!")
+```
+Usage:   edit.py <input_image> "edit instruction" [output_path]
+Example: edit.py /var/minis/attachments/photo.jpg "add a wizard hat to the cat" /var/minis/attachments/edited.png
 ```
 
 ---
 
-## 实际操作步骤
+### 📄 `batch.py` — Batch Generation (multiple prompts → multiple images)
 
-当用户发出图片生成请求时：
-
-1. **理解需求** — 判断是文生图、图片编辑还是批量生图
-2. **检查 API Key** — `source /etc/profile && echo $GEMINI_API_KEY | head -c 10`
-3. **检查脚本是否存在** — `ls <skill-path>/nano-banana/scripts/`
-4. **若脚本不存在**，用 `file_write` 将上方对应脚本写入 skill 目录
-5. **执行**：
-   - 文生图：`source /etc/profile && python3 <skill-path>/nano-banana/scripts/gen.py "prompt" /var/minis/attachments/out.png 16:9 2K`
-   - 图片编辑：`source /etc/profile && python3 <skill-path>/nano-banana/scripts/edit.py <图片路径> "指令" /var/minis/attachments/out.png`
-   - 批量：编辑 `scripts/batch.py` 中的 TASKS，再运行
-6. **展示结果** — `![描述](minis://attachments/out.png)`
+Edit the `TASKS` list at the top of the script, then run it.
 
 ---
 
-## Prompt 写作技巧
+## Step-by-Step
 
-- **写场景描述，不要堆关键词** — "一位老年日本陶艺家在工作室专注拉坯，窗外透进柔和午后阳光，照片级写实风格" 优于 "日本 陶艺 老人 写实"
-- **明确风格** — 摄影风格加相机参数（"50mm 定焦镜头，浅景深"）；插画风格说明画风（"吉卜力风格水彩"）
-- **图中文字** — 明确说明要显示的文字内容，文字渲染效果更好
-- **迭代修改** — 用 `edit.py` 在已有图上小幅调整，比重新生成效率更高
-- **宽高比选择** — 社交媒体配图用 `16:9`，头像/封面用 `1:1`，手机壁纸用 `9:16`
+When the user makes an image generation request:
 
----
-
-## 常见问题
-
-| 问题 | 原因 & 解决方案 |
-|------|----------------|
-| `AttributeError: ImageGenerationConfig` | 旧写法已废弃，改用 `image_config=types.ImageConfig(...)` |
-| `KeyError: GEMINI_API_KEY` | 先执行 `source /etc/profile`，再运行脚本 |
-| 图片未生成，只有文字 | 确认 `response_modalities` 包含 `"IMAGE"` |
-| 图片质量不佳 | 换用 `gemini-3-pro-image-preview`，或优化 prompt |
-| 速率限制错误 | 免费套餐有限制，稍等片刻重试 |
-| 图片保存失败 | 确认 `/var/minis/attachments/` 目录存在 |
+1. **Understand the request** — text-to-image, image editing, or batch?
+2. **Check API key** — `source /etc/profile && echo $GEMINI_API_KEY | head -c 10`
+3. **Verify scripts exist** — `ls <skill-path>/nano-banana/scripts/`
+4. **If scripts are missing**, use `file_write` to recreate them from the source in this skill
+5. **Run the appropriate script**:
+   - Text-to-image: `source /etc/profile && python3 <skill-path>/nano-banana/scripts/gen.py "prompt" /var/minis/attachments/out.png 16:9 2K`
+   - Image editing: `source /etc/profile && python3 <skill-path>/nano-banana/scripts/edit.py <image_path> "instruction" /var/minis/attachments/out.png`
+   - Batch: edit `TASKS` in `scripts/batch.py`, then run it
+6. **Display the result** — `![description](minis://attachments/out.png)`
 
 ---
 
-## 参考资源
+## Prompt Tips
 
-- 官方文档：https://ai.google.dev/gemini-api/docs/image-generation
-- API Key 获取：https://aistudio.google.com/apikey
+- **Describe a scene, don't just stack keywords** — "An elderly Japanese potter focused at the wheel, soft afternoon light through a studio window, photorealistic" beats "Japan pottery old man realistic"
+- **Specify style explicitly** — for photography add camera details ("50mm lens, shallow depth of field"); for illustration name the style ("Ghibli-style watercolor")
+- **Text in images** — spell out exactly what text should appear; the model renders it more accurately when it's explicit
+- **Iterate with edit.py** — make small adjustments on an existing image rather than regenerating from scratch
+- **Aspect ratio guide** — `16:9` for banners/social media, `1:1` for avatars/covers, `9:16` for phone wallpapers, `3:4` for portrait cards
+
+---
+
+## Troubleshooting
+
+| Issue | Cause & Fix |
+|-------|-------------|
+| `AttributeError: ImageGenerationConfig` | Deprecated API — use `image_config=types.ImageConfig(...)` instead |
+| `KeyError: GEMINI_API_KEY` | Run `source /etc/profile` before executing the script |
+| Only text returned, no image | Ensure `response_modalities` includes `"IMAGE"` |
+| Poor image quality | Switch to `gemini-3-pro-image-preview` or refine the prompt |
+| Rate limit error | Free tier has limits — wait a moment and retry |
+| Save fails | Confirm `/var/minis/attachments/` directory exists |
+
+---
+
+## References
+
+- Official docs: https://ai.google.dev/gemini-api/docs/image-generation
+- Get an API key: https://aistudio.google.com/apikey

--- a/nano-banana/scripts/batch.py
+++ b/nano-banana/scripts/batch.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Nano Banana 批量生图脚本
+用法: 编辑脚本底部的 TASKS 列表，然后运行
+      python3 batch.py
+"""
+import os
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+TASKS = [
+    {
+        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
+
+风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，蓝紫色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
+
+卡片内容（必须用中文显示）：
+- 顶部大图标：🐧
+- 主标题（大号粗体）：纯本地 Linux 环境
+- 副标题：完整 Alpine Linux 内置于 App
+- 特性列表：
+  ✦ 90%+ 常用软件完美运行
+  ✦ Python · FFmpeg · git · curl 开箱即用
+  ✦ 数据永不离开你的手机
+- 右下角品牌标识：Minis
+
+视觉细节：背景隐约可见终端代码行或绿色矩阵光点，发光强调线条，高级质感。不要出现人物照片。""",
+        "file": "/var/minis/attachments/minis_card1_linux_cn.png",
+        "aspect": "3:4",
+        "size": "2K",
+    },
+    {
+        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
+
+风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，金橙色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
+
+卡片内容（必须用中文显示）：
+- 顶部大图标：🔑
+- 主标题（大号粗体）：多 AI 自由接入
+- 副标题：带上自己的 API Key 或订阅即可
+- 以发光胶囊标签展示各 AI 提供商：
+  Claude · GPT · Gemini · Ollama
+- 特性列表：
+  ✦ 无需注册任何新账号
+  ✦ 随时切换模型
+  ✦ 一个 App 统一管理所有 AI
+- 右下角品牌标识：Minis
+
+视觉细节：背景隐约可见网络节点连线，各 AI 提供商以发光胶囊标签展示，高级深色卡片质感。""",
+        "file": "/var/minis/attachments/minis_card2_ai_cn.png",
+        "aspect": "3:4",
+        "size": "2K",
+    },
+    {
+        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
+
+风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，青绿色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
+
+卡片内容（必须用中文显示）：
+- 顶部大图标：📱
+- 主标题（大号粗体）：与手机无缝连接
+- 副标题：AI 直接调用 iPhone 原生系统能力
+- 图标网格展示功能（emoji + 中文标签）：
+  🏥 健康数据   📅 日历
+  📍 位置       📸 相册
+  🌤 天气       🔊 语音
+- 底部说明：无需云端中转，全部本地原生调用
+- 右下角品牌标识：Minis
+
+视觉细节：背景隐约可见 iPhone 轮廓，发光连线向外辐射至各功能图标，高级质感。""",
+        "file": "/var/minis/attachments/minis_card3_device_cn.png",
+        "aspect": "3:4",
+        "size": "2K",
+    },
+    {
+        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
+
+风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，紫罗兰色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
+
+卡片内容（必须用中文显示）：
+- 顶部大图标：🌐
+- 主标题（大号粗体）：内置本地浏览器
+- 副标题：AI 自主浏览网页、提取内容、完成操作
+- 特性列表：
+  ✦ 全程本地执行，无需云端中转
+  ✦ AI 像人一样操控网页
+  ✦ 提取内容、填写表单、自动导航
+- 分割线后展示第二特性：
+  ⚡ 零安装零配置 — 首次启动自动部署，即开即用
+- 右下角品牌标识：Minis
+
+视觉细节：背景隐约可见浏览器线框，光标点击波纹效果，发光紫色强调线条。""",
+        "file": "/var/minis/attachments/minis_card4_browser_cn.png",
+        "aspect": "3:4",
+        "size": "2K",
+    },
+]
+
+for i, task in enumerate(TASKS):
+    print(f"[{i+1}/{len(TASKS)}] Generating: {task['file']}")
+    try:
+        response = client.models.generate_content(
+            model="gemini-3.1-flash-image-preview",
+            contents=[task["prompt"]],
+            config=types.GenerateContentConfig(
+                response_modalities=["IMAGE"],
+                image_config=types.ImageConfig(
+                    aspect_ratio=task.get("aspect", "1:1"),
+                    image_size=task.get("size", "1K"),
+                ),
+            ),
+        )
+        saved = False
+        for part in response.candidates[0].content.parts:
+            if part.inline_data is not None:
+                part.as_image().save(task["file"])
+                print(f"  ✅ Saved: {task['file']}")
+                saved = True
+            elif hasattr(part, "text") and part.text:
+                print(f"  ℹ️  {part.text}")
+        if not saved:
+            print(f"  ❌ No image returned for task {i+1}")
+    except Exception as e:
+        print(f"  ❌ Error: {e}")
+
+print("\nAll done!")

--- a/nano-banana/scripts/batch.py
+++ b/nano-banana/scripts/batch.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Nano Banana 批量生图脚本
-用法: 编辑脚本底部的 TASKS 列表，然后运行
-      python3 batch.py
+Nano Banana — Batch Image Generation (multiple prompts → multiple images)
+Usage: Edit the TASKS list below, then run:
+       python3 batch.py
 """
 import os
 from google import genai
@@ -10,91 +10,19 @@ from google.genai import types
 
 client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
+# ✏️ Edit this list to define your batch tasks
 TASKS = [
     {
-        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
-
-风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，蓝紫色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
-
-卡片内容（必须用中文显示）：
-- 顶部大图标：🐧
-- 主标题（大号粗体）：纯本地 Linux 环境
-- 副标题：完整 Alpine Linux 内置于 App
-- 特性列表：
-  ✦ 90%+ 常用软件完美运行
-  ✦ Python · FFmpeg · git · curl 开箱即用
-  ✦ 数据永不离开你的手机
-- 右下角品牌标识：Minis
-
-视觉细节：背景隐约可见终端代码行或绿色矩阵光点，发光强调线条，高级质感。不要出现人物照片。""",
-        "file": "/var/minis/attachments/minis_card1_linux_cn.png",
-        "aspect": "3:4",
-        "size": "2K",
+        "prompt": "a futuristic city skyline at night, neon reflections on wet streets, cinematic",
+        "file": "/var/minis/attachments/batch_1.png",
+        "aspect": "16:9",
+        "size": "1K",
     },
     {
-        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
-
-风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，金橙色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
-
-卡片内容（必须用中文显示）：
-- 顶部大图标：🔑
-- 主标题（大号粗体）：多 AI 自由接入
-- 副标题：带上自己的 API Key 或订阅即可
-- 以发光胶囊标签展示各 AI 提供商：
-  Claude · GPT · Gemini · Ollama
-- 特性列表：
-  ✦ 无需注册任何新账号
-  ✦ 随时切换模型
-  ✦ 一个 App 统一管理所有 AI
-- 右下角品牌标识：Minis
-
-视觉细节：背景隐约可见网络节点连线，各 AI 提供商以发光胶囊标签展示，高级深色卡片质感。""",
-        "file": "/var/minis/attachments/minis_card2_ai_cn.png",
-        "aspect": "3:4",
-        "size": "2K",
-    },
-    {
-        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
-
-风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，青绿色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
-
-卡片内容（必须用中文显示）：
-- 顶部大图标：📱
-- 主标题（大号粗体）：与手机无缝连接
-- 副标题：AI 直接调用 iPhone 原生系统能力
-- 图标网格展示功能（emoji + 中文标签）：
-  🏥 健康数据   📅 日历
-  📍 位置       📸 相册
-  🌤 天气       🔊 语音
-- 底部说明：无需云端中转，全部本地原生调用
-- 右下角品牌标识：Minis
-
-视觉细节：背景隐约可见 iPhone 轮廓，发光连线向外辐射至各功能图标，高级质感。""",
-        "file": "/var/minis/attachments/minis_card3_device_cn.png",
-        "aspect": "3:4",
-        "size": "2K",
-    },
-    {
-        "prompt": """创建一张专业的深色主题特性卡片，用于手机应用 "Minis"。
-
-风格：现代科技 UI 卡片，深黑色背景（#0D1117），简洁无衬线中文字体，紫罗兰色渐变强调色，简约优雅。类似 Apple 产品营销或 Linear 设计美学。3:4 竖版格式。
-
-卡片内容（必须用中文显示）：
-- 顶部大图标：🌐
-- 主标题（大号粗体）：内置本地浏览器
-- 副标题：AI 自主浏览网页、提取内容、完成操作
-- 特性列表：
-  ✦ 全程本地执行，无需云端中转
-  ✦ AI 像人一样操控网页
-  ✦ 提取内容、填写表单、自动导航
-- 分割线后展示第二特性：
-  ⚡ 零安装零配置 — 首次启动自动部署，即开即用
-- 右下角品牌标识：Minis
-
-视觉细节：背景隐约可见浏览器线框，光标点击波纹效果，发光紫色强调线条。""",
-        "file": "/var/minis/attachments/minis_card4_browser_cn.png",
-        "aspect": "3:4",
-        "size": "2K",
+        "prompt": "a cozy coffee shop interior, warm lighting, wooden furniture, rainy window",
+        "file": "/var/minis/attachments/batch_2.png",
+        "aspect": "1:1",
+        "size": "1K",
     },
 ]
 

--- a/nano-banana/scripts/edit.py
+++ b/nano-banana/scripts/edit.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Nano Banana 图片编辑脚本
+用法: python3 edit.py <输入图片路径> "编辑指令" [输出路径]
+示例: python3 edit.py /var/minis/attachments/photo.jpg "给猫加一顶巫师帽" /var/minis/attachments/edited.png
+"""
+import os, sys
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+if len(sys.argv) < 3:
+    print("Usage: edit.py <input_image> <prompt> [output_path]")
+    sys.exit(1)
+
+input_path  = sys.argv[1]
+edit_prompt = sys.argv[2]
+output_path = sys.argv[3] if len(sys.argv) > 3 else "/var/minis/attachments/edited.png"
+
+ext = input_path.lower().rsplit(".", 1)[-1]
+mime_map = {"jpg": "image/jpeg", "jpeg": "image/jpeg", "png": "image/png", "webp": "image/webp"}
+mime_type = mime_map.get(ext, "image/jpeg")
+
+with open(input_path, "rb") as f:
+    image_bytes = f.read()
+
+print(f"Editing: {input_path}")
+print(f"Instruction: {edit_prompt[:60]}...")
+
+response = client.models.generate_content(
+    model="gemini-3.1-flash-image-preview",
+    contents=[
+        types.Part.from_bytes(data=image_bytes, mime_type=mime_type),
+        edit_prompt,
+    ],
+    config=types.GenerateContentConfig(
+        response_modalities=["IMAGE", "TEXT"],
+    ),
+)
+
+saved = False
+for part in response.candidates[0].content.parts:
+    if part.inline_data is not None:
+        part.as_image().save(output_path)
+        print(f"✅ Saved: {output_path}")
+        saved = True
+    elif hasattr(part, "text") and part.text:
+        print(f"ℹ️  Model: {part.text}")
+
+if not saved:
+    print("❌ No image returned.")
+    sys.exit(1)

--- a/nano-banana/scripts/edit.py
+++ b/nano-banana/scripts/edit.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Nano Banana 图片编辑脚本
-用法: python3 edit.py <输入图片路径> "编辑指令" [输出路径]
-示例: python3 edit.py /var/minis/attachments/photo.jpg "给猫加一顶巫师帽" /var/minis/attachments/edited.png
+Nano Banana — Image Editing (image + prompt → image)
+Usage:   python3 edit.py <input_image> "edit instruction" [output_path]
+Example: python3 edit.py /var/minis/attachments/photo.jpg "add a wizard hat to the cat" /var/minis/attachments/edited.png
 """
 import os, sys
 from google import genai

--- a/nano-banana/scripts/gen.py
+++ b/nano-banana/scripts/gen.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Nano Banana 文生图脚本
+用法: python3 gen.py "prompt内容" [输出路径] [宽高比] [分辨率]
+示例: python3 gen.py "一只熊猫在竹林喝茶" /var/minis/attachments/out.png 1:1 2K
+宽高比: 1:1, 4:3, 3:4, 16:9, 9:16
+分辨率: 1K, 2K
+"""
+import os, sys
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+prompt      = sys.argv[1] if len(sys.argv) > 1 else "a beautiful landscape"
+output_path = sys.argv[2] if len(sys.argv) > 2 else "/var/minis/attachments/output.png"
+aspect      = sys.argv[3] if len(sys.argv) > 3 else "1:1"
+size        = sys.argv[4] if len(sys.argv) > 4 else "1K"
+
+print(f"Generating: {prompt[:60]}...")
+print(f"Output: {output_path} | {aspect} | {size}")
+
+response = client.models.generate_content(
+    model="gemini-3.1-flash-image-preview",
+    contents=[prompt],
+    config=types.GenerateContentConfig(
+        response_modalities=["IMAGE"],
+        image_config=types.ImageConfig(
+            aspect_ratio=aspect,
+            image_size=size,
+        ),
+    ),
+)
+
+saved = False
+for part in response.candidates[0].content.parts:
+    if part.inline_data is not None:
+        part.as_image().save(output_path)
+        print(f"✅ Saved: {output_path}")
+        saved = True
+    elif hasattr(part, "text") and part.text:
+        print(f"ℹ️  Model: {part.text}")
+
+if not saved:
+    print("❌ No image returned. Try rephrasing the prompt.")
+    sys.exit(1)

--- a/nano-banana/scripts/gen.py
+++ b/nano-banana/scripts/gen.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Nano Banana 文生图脚本
-用法: python3 gen.py "prompt内容" [输出路径] [宽高比] [分辨率]
-示例: python3 gen.py "一只熊猫在竹林喝茶" /var/minis/attachments/out.png 1:1 2K
-宽高比: 1:1, 4:3, 3:4, 16:9, 9:16
-分辨率: 1K, 2K
+Nano Banana — Text to Image
+Usage:   python3 gen.py "prompt" [output_path] [aspect_ratio] [resolution]
+Example: python3 gen.py "a panda drinking tea in a bamboo forest" /var/minis/attachments/out.png 1:1 2K
+
+Aspect ratios: 1:1, 4:3, 3:4, 16:9, 9:16
+Resolutions:   1K, 2K
 """
 import os, sys
 from google import genai


### PR DESCRIPTION
## Changes

### 📄 README overhaul
Rewrote README with full contribution standards:
- Skill directory naming conventions (lowercase kebab-case)
- `SKILL.md` format spec (YAML frontmatter, description best practices)
- Bundled resource layout (`scripts/`, `references/`, `assets/`)
- Writing style guide (imperative form, explain the *why*)
- Evals schema and PR submission checklist

### 🍌 nano-banana skill
Adds the Nano Banana (Gemini image generation) skill:
- `SKILL.md` with full workflow, model selection, API gotchas, and prompt tips
- `scripts/gen.py` — text-to-image
- `scripts/edit.py` — image editing (image + prompt → image)
- `scripts/batch.py` — batch generation

All script paths use portable `<skill-path>` references per the new conventions.