### PR TITLE
docs: fix Minis link to OpenMinis GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MinisSkills
 
-A community collection of skills for [Minis](https://minis.ai) — reusable instruction sets that extend Claude's capabilities with specialized workflows, domain knowledge, and bundled resources.
+A community collection of skills for [Minis](https://github.com/OpenMinis) — reusable instruction sets that extend Claude's capabilities with specialized workflows, domain knowledge, and bundled resources.
 
 ---
 


### PR DESCRIPTION
Fixes the Minis link in README from `https://minis.ai` to the correct `https://github.com/OpenMinis` organization URL.