### PR TITLE
feat: add memos-api skill

### DIFF
--- a/memos-api/SKILL.md
+++ b/memos-api/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: memos-api
+description: |
+  Handles Memos API usage: crafting curl/python requests with Authorization Bearer tokens, paginating with pageSize/pageToken, using filter (AIP-160 syntax), updateMask updates, and mapping common endpoints (memo CRUD, attachments, activities, auth, identity providers). Trigger when user asks to call/inspect/troubleshoot Memos API, generate sample requests, or batch download memos. Warn to avoid printing tokens.
+compatibility: Requires curl and/or python3. Use env vars for tokens.
+---
+
+# Memos API Skill
+
+## When to use
+- User wants to call Memos API, build curl/python examples, or debug responses
+- Needs memo CRUD, attachments, activities, auth/identity providers, or list/filter/pagination
+- Needs batch download scripts or reference docs for endpoints
+
+## How to use
+1) Require base URL and bearer token (env var recommended). Do **not** print secret values.
+2) For list endpoints: support `pageSize`, `pageToken`, and `filter` (AIP-160) if available.
+3) For updates: use `updateMask=field1,field2` when partial updates are supported.
+4) Return ready-to-run curl examples; optionally include python `requests` snippet.
+5) If user needs full endpoint details, load reference file `references/memos-api-reference.md`.
+
+## Quick curl templates
+- List memos (example):
+  ```sh
+  curl -s -H "Authorization: Bearer $MEMOS_TOKEN" \
+       "$MEMOS_BASE/api/v1/memos?pageSize=20"
+  ```
+- Create memo:
+  ```sh
+  curl -s -X POST -H "Content-Type: application/json" \
+       -H "Authorization: Bearer $MEMOS_TOKEN" \
+       "$MEMOS_BASE/api/v1/memos" \
+       -d '{"content":"hello"}'
+  ```
+- Update memo (partial):
+  ```sh
+  curl -s -X PATCH -H "Content-Type: application/json" \
+       -H "Authorization: Bearer $MEMOS_TOKEN" \
+       "$MEMOS_BASE/api/v1/memos/$MEMO_ID?updateMask=content" \
+       -d '{"content":"updated"}'
+  ```
+- List attachments:
+  ```sh
+  curl -s -H "Authorization: Bearer $MEMOS_TOKEN" \
+       "$MEMOS_BASE/api/v1/attachments?pageSize=20"
+  ```
+
+## Bundled references
+- `references/memos-api-reference.md` — full scraped API reference (all services/endpoints).
+
+## Notes
+- Keep responses concise; link to reference when detailed schemas are needed.
+- Use placeholders/env vars (`$MEMOS_BASE`, `$MEMOS_TOKEN`, `$MEMO_ID`) and avoid leaking secrets.
+- Prefer `curl -s` and JSON bodies; add headers only as required.

--- a/memos-api/references/memos-api-reference.md
+++ b/memos-api/references/memos-api-reference.md
@@ -1,0 +1,120 @@
+# Memos API Reference (Condensed)
+
+Source: https://usememos.com/docs/api
+
+## Conventions
+- Base URL: `https://<your-memos-instance>/api/v1`
+- Auth: `Authorization: Bearer <ACCESS_TOKEN>` (use env vars; don't print tokens)
+- Pagination: `pageSize`, `pageToken`
+- Filtering: `filter` (AIP-160 syntax, e.g., `memo.content:"foo"`)
+- Partial update: `updateMask=field1,field2`
+- Default content type: `application/json`
+
+## Common Shell Vars
+```sh
+MEMOS_BASE=https://demo.usememos.com
+AUTH_HEADER="Authorization: Bearer $MEMOS_TOKEN"
+```
+
+## Core Endpoints (cheatsheet)
+
+### Memos
+- List: `GET /memos?pageSize=20&pageToken=...&filter=...`
+- Get: `GET /memos/{memo}`
+- Create: `POST /memos` body `{content, visibility, resourceName, ...}`
+- Update (partial): `PATCH /memos/{memo}?updateMask=content,visibility` body `{...}`
+- Delete: `DELETE /memos/{memo}`
+
+### Attachments
+- List: `GET /attachments?pageSize=20`
+- Get: `GET /attachments/{attachment}`
+- Create: `POST /attachments` body `{filename,type,content?,externalLink?,memo?}`
+- Update: `PATCH /attachments/{attachment}?updateMask=...`
+- Delete: `DELETE /attachments/{attachment}`
+
+### Activities
+- List: `GET /activities?pageSize=50`
+- Get: `GET /activities/{activity}`
+
+### Auth / Users
+- Me: `GET /auth/me`
+- Sign in: `POST /auth/signin` (returns accessToken and sets refresh cookie)
+- Refresh: `POST /auth/refresh`
+- Sign out: `POST /auth/signout`
+
+### Identity Providers
+- List: `GET /identity-providers`
+- Create: `POST /identity-providers`
+- Get: `GET /identity-providers/{idp}`
+- Update: `PATCH /identity-providers/{idp}?updateMask=...`
+- Delete: `DELETE /identity-providers/{idp}`
+
+### Resources (files linked to memos)
+- List: `GET /resources?pageSize=...`
+- Create: `POST /resources`
+- Get: `GET /resources/{resource}`
+- Update: `PATCH /resources/{resource}?updateMask=...`
+- Delete: `DELETE /resources/{resource}`
+
+### Tags
+- List: `GET /tags`
+- Create: `POST /tags`
+- Update: `PATCH /tags/{tag}?updateMask=...`
+- Delete: `DELETE /tags/{tag}`
+
+## Curl Examples
+
+List memos with filter and pagination:
+```sh
+curl -s -H "$AUTH_HEADER" \
+  "$MEMOS_BASE/api/v1/memos?pageSize=20&filter=visibility=PUBLIC"
+```
+
+Create memo:
+```sh
+curl -s -X POST -H "Content-Type: application/json" -H "$AUTH_HEADER" \
+  "$MEMOS_BASE/api/v1/memos" \
+  -d '{"content":"hello world","visibility":"PUBLIC"}'
+```
+
+Update memo content (partial):
+```sh
+curl -s -X PATCH -H "Content-Type: application/json" -H "$AUTH_HEADER" \
+  "$MEMOS_BASE/api/v1/memos/$MEMO_ID?updateMask=content" \
+  -d '{"content":"updated text"}'
+```
+
+List attachments:
+```sh
+curl -s -H "$AUTH_HEADER" "$MEMOS_BASE/api/v1/attachments?pageSize=20"
+```
+
+Upload attachment metadata (server handles content/externalLink):
+```sh
+curl -s -X POST -H "Content-Type: application/json" -H "$AUTH_HEADER" \
+  "$MEMOS_BASE/api/v1/attachments" \
+  -d '{"filename":"a.png","type":"image/png","memo":"memos/123"}'
+```
+
+Sign in (username/password example):
+```sh
+curl -s -X POST -H "Content-Type: application/json" \
+  "$MEMOS_BASE/api/v1/auth/signin" \
+  -d '{"username":"user","password":"pass"}'
+```
+
+Refresh token:
+```sh
+curl -s -X POST "$MEMOS_BASE/api/v1/auth/refresh"
+```
+
+## Error Handling Tips
+- 401/403: check token validity and scope; ensure `Authorization: Bearer ...` header present.
+- 400: check request body fields and `updateMask` fields match payload.
+- Pagination: always propagate `nextPageToken` until empty.
+- Filters: follow AIP-160; quote strings, use `field op value`, e.g., `create_time>"2024-01-01T00:00:00Z"`.
+
+## Safety
+- Never echo tokens; use env vars (`$MEMOS_TOKEN`).
+- Prefer `curl -s` to keep output clean; add `-i` only for debugging.
+- For scripts, externalize base URL and token via environment.


### PR DESCRIPTION
## Summary
- Add memos-api skill (curl/python templates, pagination/filter/updateMask guidance).
- Include condensed API reference cheatsheet under references/.

## Checklist
- [x] Skill dir uses kebab-case
- [x] SKILL.md has name + description, <500 lines
- [x] Reference docs in references/
- [x] No secrets committed