### PR TITLE
fix(tg-hub): move default data dir to ~/.tg-hub for session persistence

### DIFF
--- a/tg-hub/SKILL.md
+++ b/tg-hub/SKILL.md
@@ -26,14 +26,14 @@ description: >
 ```
 Telegram MTProto（telethon）
     ↓  sync / refresh（增量）
-本地 SQLite  /var/minis/workspace/tg-hub/messages.db
+本地 SQLite  ~/.tg-hub/messages.db
     ↓  search / today / recent / filter（离线）
 结构化数据
 ```
 
 - **读操作**（search/today/recent）：查本地 SQLite，**不联网**，毫秒级响应
 - **写操作**（sync/refresh）：连接 Telegram 拉取新消息，增量写入 SQLite
-- Session 文件：`/var/minis/workspace/tg-hub/tg_hub.session`
+- Session 文件：`~/.tg-hub/tg_hub.session`
 
 ---
 
@@ -185,7 +185,7 @@ print(f"本地共 {stats['total']} 条消息，{len(stats['chats'])} 个群")
 | `TG_API_ID` | `2040`（Telegram Desktop） | 自定义 API ID |
 | `TG_API_HASH` | 内置 | 自定义 API Hash |
 | `TG_SESSION_NAME` | `tg_hub` | Session 文件名 |
-| `TG_DATA_DIR` | `/var/minis/workspace/tg-hub` | 数据目录 |
+| `TG_DATA_DIR` | `~/.tg-hub` | 数据目录 |
 | `TG_DB_PATH` | `{TG_DATA_DIR}/messages.db` | SQLite 路径 |
 
 ---

--- a/tg-hub/scripts/config.py
+++ b/tg-hub/scripts/config.py
@@ -18,8 +18,8 @@ from pathlib import Path
 _DEFAULT_API_ID   = 2040
 _DEFAULT_API_HASH = "b18441a1ff607e10a989891a5462e627"
 
-# 默认数据目录
-_DEFAULT_DATA_DIR = Path("/var/minis/workspace/tg-hub")
+# 默认数据目录：存放在 home 目录下，跨 session 复用
+_DEFAULT_DATA_DIR = Path.home() / ".tg-hub"
 
 
 def get_api_id() -> int:


### PR DESCRIPTION
## 问题

原默认数据目录为 `/var/minis/workspace/tg-hub/`，该路径属于 Minis 临时工作区，
切换 session 后可能被清理，导致 session 文件丢失、需要重新登录。

## 修改

将默认数据目录改为 `~/.tg-hub/`：

- Session 文件：`~/.tg-hub/tg_hub.session`
- 消息数据库：`~/.tg-hub/messages.db`

`~` 是 iSH 的持久化 home 目录，跨 Minis session 保留，登录一次永久有效。

## 变更文件

- `tg-hub/scripts/config.py`：修改 `_DEFAULT_DATA_DIR`
- `tg-hub/SKILL.md`：更新路径说明