### PR TITLE
fix: update license copyright owner to OpenMinis

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 ArcanePivot
+Copyright (c) 2026 OpenMinis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the Apache 2.0 license copyright owner from the placeholder `[yyyy] [name of copyright owner]` to `2025 OpenMinis`.