### PR TITLE
Add ytmusic-hub enhancement scripts and evals

### DIFF
--- a/ytmusic-hub/evals/evals.json
+++ b/ytmusic-hub/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "ytmusic-hub",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "帮我读取我的 YouTube Music 歌单。",
+      "expected_output": "触发 ytmusic-hub，先检查依赖与认证状态；若未认证则指导用户用 browser_use 打开 music.youtube.com、获取 cookies、生成认证文件，再列出歌单。",
+      "files": [],
+      "assertions": [
+        {"type": "contains", "text": "YouTube Music"},
+        {"type": "contains", "text": "get_cookies"},
+        {"type": "contains", "text": "setup_auth.py"},
+        {"type": "contains", "text": "歌单"}
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "把周杰伦的一首歌加进我的 YT Music 歌单。",
+      "expected_output": "触发 ytmusic-hub，先确认登录态和目标歌单，再执行搜索歌曲与 add_playlist_items 的流程。",
+      "files": [],
+      "assertions": [
+        {"type": "contains", "text": "yt.search"},
+        {"type": "contains", "text": "add_playlist_items"},
+        {"type": "contains", "text": "确认"},
+        {"type": "contains", "text": "歌单"}
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "导出我的某个 YouTube Music 歌单成 Markdown。",
+      "expected_output": "触发 ytmusic-hub，读取指定歌单详情，并用 Markdown 列表格式导出歌曲标题与艺人。",
+      "files": [],
+      "assertions": [
+        {"type": "contains", "text": "Markdown"},
+        {"type": "contains", "text": "get_playlist"},
+        {"type": "contains", "text": "title"},
+        {"type": "contains", "text": "artists"}
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "我的 YT Music 登录失效了，帮我重新认证。",
+      "expected_output": "触发 ytmusic-hub，重新执行 browser_use + get_cookies + setup_auth.py + test_auth.py 的认证与验证闭环，并明确检查 SAPISID。",
+      "files": [],
+      "assertions": [
+        {"type": "contains", "text": "music.youtube.com"},
+        {"type": "contains", "text": "get_cookies"},
+        {"type": "contains", "text": "SAPISID"},
+        {"type": "contains", "text": "test_auth.py"}
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "根据我的点赞歌曲推荐一些类似风格的歌，然后创建一个新的 YouTube Music 歌单。",
+      "expected_output": "触发 ytmusic-hub，先读取点赞歌曲，分析高频艺人或风格线索，再搜索候选歌曲、去重、创建新歌单并输出结果表。",
+      "files": [],
+      "assertions": [
+        {"type": "contains", "text": "get_liked_songs"},
+        {"type": "contains", "text": "recommend_from_likes.py"},
+        {"type": "contains", "text": "创建"},
+        {"type": "contains", "text": "歌单"}
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "这是个新号，按周杰伦风格给我做一个新歌单。",
+      "expected_output": "触发 ytmusic-hub，识别这是冷启动场景，不依赖空的 liked songs，而是按指定歌手风格做种子推荐并创建新歌单。",
+      "files": [],
+      "assertions": [
+        {"type": "contains", "text": "新号"},
+        {"type": "contains", "text": "周杰伦"},
+        {"type": "contains", "text": "冷启动"},
+        {"type": "contains", "text": "创建"}
+      ]
+    }
+  ]
+}

--- a/ytmusic-hub/scripts/export_playlist.py
+++ b/ytmusic-hub/scripts/export_playlist.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "/var/minis/skills/ytmusic-hub/scripts")
+from ytmusic_client import get_client
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("用法：python3 export_playlist.py <playlistId> [输出文件路径]", file=sys.stderr)
+        return 1
+
+    playlist_id = argv[1]
+    output = Path(argv[2]) if len(argv) >= 3 else None
+
+    yt = get_client()
+    playlist = yt.get_playlist(playlist_id, limit=500)
+
+    lines = [f"# {playlist.get('title', '未命名歌单')}", ""]
+    desc = playlist.get("description")
+    if desc:
+        lines.append(f"> {desc}")
+        lines.append("")
+
+    for idx, track in enumerate(playlist.get("tracks", []), 1):
+        artists = ", ".join(a.get("name", "未知艺人") for a in track.get("artists", []))
+        lines.append(f"{idx}. **{track.get('title', '未知曲目')}** — {artists}")
+
+    text = "\n".join(lines)
+    if output:
+        output.write_text(text, encoding="utf-8")
+        print(f"✅ 已导出到：{output}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/ytmusic-hub/scripts/list_playlists.py
+++ b/ytmusic-hub/scripts/list_playlists.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, "/var/minis/skills/ytmusic-hub/scripts")
+from ytmusic_client import get_client
+
+
+def main() -> int:
+    yt = get_client()
+    playlists = yt.get_library_playlists(limit=100)
+    if not playlists:
+        print("未读取到任何歌单。")
+        return 0
+    for idx, pl in enumerate(playlists, 1):
+        print(f"{idx}. {pl.get('title', '未命名歌单')}\t{pl.get('playlistId', 'NO_ID')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ytmusic-hub/scripts/recommend_from_likes.py
+++ b/ytmusic-hub/scripts/recommend_from_likes.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, "/var/minis/skills/ytmusic-hub/scripts")
+from ytmusic_client import get_client
+
+
+DEFAULT_TITLE = "为你推荐・近期相似风格"
+DEFAULT_DESC = "基于你的 Liked Music 收藏风格生成的推荐歌单。由 Minis AI 辅助整理。"
+
+
+def artist_names(track: dict) -> list[str]:
+    return [a.get("name", "").strip() for a in track.get("artists", []) if a.get("name")]
+
+
+def collect_profile(tracks: list[dict]) -> dict:
+    artist_counter = Counter()
+    liked_ids = set()
+    samples = []
+    for t in tracks:
+        vid = t.get("videoId")
+        if vid:
+            liked_ids.add(vid)
+        names = artist_names(t)
+        artist_counter.update(names)
+        if len(samples) < 12:
+            samples.append({
+                "title": t.get("title", "未知曲目"),
+                "artists": names,
+            })
+    top_artists = [name for name, _ in artist_counter.most_common(8)]
+    return {
+        "liked_ids": liked_ids,
+        "top_artists": top_artists,
+        "artist_counter": artist_counter,
+        "samples": samples,
+    }
+
+
+def build_queries(profile: dict) -> list[str]:
+    top = profile["top_artists"]
+    queries = []
+    if top:
+        for name in top[:5]:
+            queries.append(name)
+            queries.append(f"{name} similar")
+            queries.append(f"{name} 推荐")
+    queries += [
+        "华语 indie",
+        "华语 流行 抒情",
+        "mandopop 2024",
+        "indie pop 2024",
+        "j-pop 2024",
+    ]
+    # 去重保序
+    seen = set()
+    deduped = []
+    for q in queries:
+        if q not in seen:
+            seen.add(q)
+            deduped.append(q)
+    return deduped
+
+
+def search_candidates(yt, queries: list[str], liked_ids: set[str], limit_per_query: int = 5) -> list[dict]:
+    picked = []
+    seen_vids = set(liked_ids)
+    artist_seen = Counter()
+
+    for q in queries:
+        try:
+            results = yt.search(q, filter="songs")
+        except Exception:
+            continue
+        for item in results[:limit_per_query]:
+            vid = item.get("videoId")
+            if not vid or vid in seen_vids:
+                continue
+            names = artist_names(item)
+            main_artist = names[0] if names else "未知艺人"
+            if artist_seen[main_artist] >= 2:
+                continue
+            seen_vids.add(vid)
+            artist_seen[main_artist] += 1
+            picked.append({
+                "videoId": vid,
+                "title": item.get("title", "未知曲目"),
+                "artists": names,
+                "source_query": q,
+            })
+            if len(picked) >= 20:
+                return picked
+    return picked
+
+
+def format_report(title: str, profile: dict, songs: list[dict], playlist_id: str) -> str:
+    lines = [
+        f"# 🎧 已创建歌单：{title}",
+        "",
+        f"- Playlist ID: `{playlist_id}`",
+        f"- 你的高频艺人：{', '.join(profile['top_artists'][:6]) or '未识别'}",
+        "",
+        "## 风格样本",
+    ]
+    for s in profile["samples"][:8]:
+        lines.append(f"- {s['title']} — {', '.join(s['artists']) or '未知艺人'}")
+    lines += ["", "## 推荐结果", "", "| # | 歌曲 | 歌手 | 搜索来源 |", "|---|---|---|---|"]
+    for idx, song in enumerate(songs, 1):
+        lines.append(
+            f"| {idx} | {song['title']} | {', '.join(song['artists']) or '未知艺人'} | {song['source_query']} |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="根据点赞歌曲生成相似风格推荐歌单")
+    parser.add_argument("--title", default=DEFAULT_TITLE)
+    parser.add_argument("--desc", default=DEFAULT_DESC)
+    parser.add_argument("--liked-limit", type=int, default=100)
+    parser.add_argument("--max-songs", type=int, default=14)
+    parser.add_argument("--report", default="/var/minis/workspace/ytmusic_recommend_report.md")
+    args = parser.parse_args(argv[1:])
+
+    yt = get_client()
+    liked = yt.get_liked_songs(limit=args.liked_limit)
+    tracks = liked.get("tracks", [])
+    if not tracks:
+        print("未读取到点赞歌曲，无法生成推荐。", file=sys.stderr)
+        return 1
+
+    profile = collect_profile(tracks)
+    queries = build_queries(profile)
+    random.shuffle(queries)
+    candidates = search_candidates(yt, queries, profile["liked_ids"])[: args.max_songs]
+    if not candidates:
+        print("未搜索到可用推荐歌曲。", file=sys.stderr)
+        return 2
+
+    playlist_id = yt.create_playlist(args.title, args.desc, privacy_status="PRIVATE")
+    yt.add_playlist_items(playlist_id, [c["videoId"] for c in candidates])
+
+    report = format_report(args.title, profile, candidates, playlist_id)
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report, encoding="utf-8")
+
+    print(f"✅ 已创建歌单：{args.title}")
+    print(f"Playlist ID: {playlist_id}")
+    print(f"推荐歌曲数：{len(candidates)}")
+    print(f"报告文件：{report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/ytmusic-hub/scripts/recommend_from_seed_jay.py
+++ b/ytmusic-hub/scripts/recommend_from_seed_jay.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, '/var/minis/skills/ytmusic-hub/scripts')
+from ytmusic_client import get_client
+
+SEED = '周杰伦'
+TITLE = '为你推荐・周杰伦向'
+DESC = '基于周杰伦风格做的冷启动推荐歌单，由 Minis AI 生成。'
+REPORT = Path('/var/minis/workspace/ytmusic_jay_playlist_report.md')
+
+QUERIES = [
+    '周杰伦',
+    'Jay Chou',
+    'mandopop 周杰伦 similar',
+    '华语流行 周杰伦风格',
+    '周杰伦 similar songs',
+    '华语经典流行',
+    '华语抒情流行',
+]
+
+
+def artist_names(track: dict) -> list[str]:
+    return [a.get('name', '').strip() for a in track.get('artists', []) if a.get('name')]
+
+
+def main() -> int:
+    yt = get_client()
+    picked = []
+    seen = set()
+    artist_count = {}
+
+    for q in QUERIES:
+        results = yt.search(q, filter='songs')
+        for item in results[:8]:
+            vid = item.get('videoId')
+            if not vid or vid in seen:
+                continue
+            artists = artist_names(item)
+            if not artists:
+                continue
+            main_artist = artists[0]
+            if artist_count.get(main_artist, 0) >= 2:
+                continue
+            seen.add(vid)
+            artist_count[main_artist] = artist_count.get(main_artist, 0) + 1
+            picked.append({
+                'title': item.get('title', '未知曲目'),
+                'videoId': vid,
+                'artists': artists,
+                'query': q,
+            })
+            if len(picked) >= 14:
+                break
+        if len(picked) >= 14:
+            break
+
+    if not picked:
+        print('未搜到可用歌曲。', file=sys.stderr)
+        return 1
+
+    playlist_id = yt.create_playlist(TITLE, DESC, privacy_status='PRIVATE')
+    yt.add_playlist_items(playlist_id, [x['videoId'] for x in picked])
+
+    lines = [f'# 🎧 已创建歌单：{TITLE}', '', f'- Playlist ID: `{playlist_id}`', f'- 种子风格：{SEED}', '', '| # | 歌曲 | 歌手 | 来源搜索词 |', '|---|---|---|---|']
+    for i, x in enumerate(picked, 1):
+        lines.append(f"| {i} | {x['title']} | {', '.join(x['artists'])} | {x['query']} |")
+    REPORT.write_text('\n'.join(lines), encoding='utf-8')
+
+    print(f'✅ 已创建歌单：{TITLE}')
+    print(f'Playlist ID: {playlist_id}')
+    print(f'歌曲数：{len(picked)}')
+    print(f'报告：{REPORT}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/ytmusic-hub/scripts/recommend_from_seed_jay_v2.py
+++ b/ytmusic-hub/scripts/recommend_from_seed_jay_v2.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, '/var/minis/skills/ytmusic-hub/scripts')
+from ytmusic_client import get_client
+
+TITLE = '为你推荐・周杰伦向 v2'
+DESC = '更偏周杰伦系华语流行、R&B、青春感与夜色感的冷启动推荐歌单，由 Minis AI 生成。'
+REPORT = Path('/var/minis/workspace/ytmusic_jay_v2_report.md')
+
+QUERIES = [
+    '周杰伦 songs',
+    'Jay Chou songs',
+    '方大同 陶喆 林俊杰 王力宏 songs',
+    '华语 R&B',
+    'mandopop r&b',
+    '2000年代 华语流行',
+    '青春 校园 华语流行',
+]
+
+BLOCK_ARTISTS = {
+    'Leo Ku', '古巨基', '王琪', 'en', '大头针 Official', 'CHANYEOL', 'Punch', '邹沛沛', 'Pank'
+}
+PREFER_ARTISTS = {
+    '周杰倫', '周杰伦', '陶喆', '方大同', '林俊傑', '林俊杰', '王力宏', '五月天', '蘇打綠', '苏打绿', '梁静茹', '孫燕姿', '孙燕姿', '潘瑋柏', '潘玮柏'
+}
+BLOCK_KEYWORDS = ['串烧', '情歌王', 'dj', '慢摇', 'remix']
+
+
+def artist_names(track: dict) -> list[str]:
+    return [a.get('name', '').strip() for a in track.get('artists', []) if a.get('name')]
+
+
+def score_song(title: str, artists: list[str], query: str) -> int:
+    score = 0
+    if any(a in PREFER_ARTISTS for a in artists):
+        score += 5
+    if '周杰' in ''.join(artists) or 'Jay Chou' in ''.join(artists):
+        score += 6
+    if 'r&b' in query.lower() or 'mandopop' in query.lower():
+        score += 2
+    if '2000' in query:
+        score += 2
+    if '青春' in query or '校园' in query:
+        score += 1
+    if any(k.lower() in title.lower() for k in BLOCK_KEYWORDS):
+        score -= 10
+    return score
+
+
+def allowed(title: str, artists: list[str]) -> bool:
+    if any(a in BLOCK_ARTISTS for a in artists):
+        return False
+    low = title.lower()
+    if any(k in low for k in [x.lower() for x in BLOCK_KEYWORDS]):
+        return False
+    return True
+
+
+def main() -> int:
+    yt = get_client()
+    candidates = []
+    seen = set()
+
+    for q in QUERIES:
+        results = yt.search(q, filter='songs')
+        for item in results[:12]:
+            vid = item.get('videoId')
+            if not vid or vid in seen:
+                continue
+            artists = artist_names(item)
+            title = item.get('title', '未知曲目')
+            if not artists or not allowed(title, artists):
+                continue
+            seen.add(vid)
+            candidates.append({
+                'title': title,
+                'videoId': vid,
+                'artists': artists,
+                'query': q,
+                'score': score_song(title, artists, q),
+            })
+
+    candidates.sort(key=lambda x: (-x['score'], x['title']))
+
+    picked = []
+    artist_cap = {}
+    for item in candidates:
+        main_artist = item['artists'][0]
+        cap = 3 if ('周杰' in main_artist or main_artist in {'陶喆', '方大同', '林俊傑', '林俊杰', '王力宏'}) else 1
+        if artist_cap.get(main_artist, 0) >= cap:
+            continue
+        picked.append(item)
+        artist_cap[main_artist] = artist_cap.get(main_artist, 0) + 1
+        if len(picked) >= 14:
+            break
+
+    if not picked:
+        print('未筛出合适歌曲。', file=sys.stderr)
+        return 1
+
+    playlist_id = yt.create_playlist(TITLE, DESC, privacy_status='PRIVATE')
+    yt.add_playlist_items(playlist_id, [x['videoId'] for x in picked])
+
+    lines = [
+        f'# 🎧 已创建歌单：{TITLE}',
+        '',
+        f'- Playlist ID: `{playlist_id}`',
+        '- 风格锚点：周杰伦系、华语 R&B、2000 年代华语流行、青春感与夜色感',
+        '',
+        '| # | 歌曲 | 歌手 | 分数 | 来源搜索词 |',
+        '|---|---|---|---:|---|',
+    ]
+    for i, x in enumerate(picked, 1):
+        lines.append(f"| {i} | {x['title']} | {', '.join(x['artists'])} | {x['score']} | {x['query']} |")
+    REPORT.write_text('\n'.join(lines), encoding='utf-8')
+
+    print(f'✅ 已创建歌单：{TITLE}')
+    print(f'Playlist ID: {playlist_id}')
+    print(f'歌曲数：{len(picked)}')
+    print(f'报告：{REPORT}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/ytmusic-hub/scripts/search_and_add.py
+++ b/ytmusic-hub/scripts/search_and_add.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, "/var/minis/skills/ytmusic-hub/scripts")
+from ytmusic_client import get_client
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("用法：python3 search_and_add.py <搜索词> <playlistId>", file=sys.stderr)
+        return 1
+
+    query = argv[1]
+    playlist_id = argv[2]
+
+    yt = get_client()
+    songs = yt.search(query, filter="songs")
+    if not songs:
+        print("未找到匹配歌曲。", file=sys.stderr)
+        return 2
+
+    song = songs[0]
+    yt.add_playlist_items(playlist_id, [song["videoId"]])
+    artists = ", ".join(a.get("name", "未知艺人") for a in song.get("artists", []))
+    print(f"✅ 已加入歌单：{song.get('title', '未知曲目')} — {artists}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/ytmusic-hub/scripts/test_auth.py
+++ b/ytmusic-hub/scripts/test_auth.py
@@ -1,0 +1,29 @@
+"""
+test_auth.py
+验证当前 ytmusic 认证文件是否可用。
+"""
+
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, "/var/minis/skills/ytmusic-hub/scripts")
+
+from ytmusic_client import get_client
+
+
+def main() -> int:
+    try:
+        yt = get_client()
+        playlists = yt.get_library_playlists(limit=5)
+        print(f"✅ 认证验证成功：已读取到 {len(playlists)} 个歌单（最多显示前 5 个）。")
+        for idx, pl in enumerate(playlists[:5], 1):
+            print(f"{idx}. {pl.get('title', '未命名歌单')} [{pl.get('playlistId', 'NO_ID')}]")
+        return 0
+    except Exception as exc:
+        print(f"❌ 认证验证失败：{exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 中文说明

基于上游已合入的 `ytmusic-hub` 英文版主体，本 PR 只补充增强内容，不覆盖上游主体实现。

### 本 PR 增加的内容
- `evals/evals.json`
- `scripts/test_auth.py`
- `scripts/list_playlists.py`
- `scripts/export_playlist.py`
- `scripts/search_and_add.py`
- `scripts/recommend_from_likes.py`
- `scripts/recommend_from_seed_jay.py`
- `scripts/recommend_from_seed_jay_v2.py`

### 主要增强点
- 增加认证验证闭环（`test_auth.py`）
- 补齐读取歌单 / 导出歌单 / 搜索加歌等 helper scripts
- 增加根据点赞歌曲生成推荐歌单的工作流脚本
- 增加新账号冷启动：按指定歌手风格生成推荐歌单（周杰伦示例）
- 补充 evals，方便后续回归测试

### 说明
- 该 PR 以 `origin/main` 当前已存在的 `ytmusic-hub` 为基础
- 不重复覆盖上游已有的 `SKILL.md`、`setup_auth.py`、`ytmusic_client.py`
- 重点是把这次实测验证过的增强脚本与测试补充进去

---

## English Summary

This PR adds enhancement scripts and evals on top of the upstream `ytmusic-hub` already present in `origin/main`, without overriding the upstream core files.

### Added in this PR
- `evals/evals.json`
- `scripts/test_auth.py`
- `scripts/list_playlists.py`
- `scripts/export_playlist.py`
- `scripts/search_and_add.py`
- `scripts/recommend_from_likes.py`
- `scripts/recommend_from_seed_jay.py`
- `scripts/recommend_from_seed_jay_v2.py`

### Highlights
- Add auth validation workflow via `test_auth.py`
- Add helper scripts for playlist listing/export/search-and-add
- Add recommendation workflow from liked songs
- Add cold-start recommendation workflow for new accounts using a seed artist
- Add eval coverage for regression testing
