### PR TITLE
feat(tg-hub): sync upstream anti-ban hardening

### DIFF
--- a/tg-hub/SKILL.md
+++ b/tg-hub/SKILL.md
@@ -26,14 +26,14 @@ description: >
 ```
 Telegram MTProto（telethon）
     ↓  sync / refresh（增量）
-本地 SQLite  /var/minis/workspace/tg-hub/messages.db
+本地 SQLite  ~/.tg-hub/messages.db
     ↓  search / today / recent / filter（离线）
 结构化数据
 ```
 
 - **读操作**（search/today/recent）：查本地 SQLite，**不联网**，毫秒级响应
 - **写操作**（sync/refresh）：连接 Telegram 拉取新消息，增量写入 SQLite
-- Session 文件：`/var/minis/workspace/tg-hub/tg_hub.session`
+- Session 文件：`~/.tg-hub/tg_hub.session`
 
 ---
 
@@ -185,7 +185,7 @@ print(f"本地共 {stats['total']} 条消息，{len(stats['chats'])} 个群")
 | `TG_API_ID` | `2040`（Telegram Desktop） | 自定义 API ID |
 | `TG_API_HASH` | 内置 | 自定义 API Hash |
 | `TG_SESSION_NAME` | `tg_hub` | Session 文件名 |
-| `TG_DATA_DIR` | `/var/minis/workspace/tg-hub` | 数据目录 |
+| `TG_DATA_DIR` | `~/.tg-hub` | 数据目录 |
 | `TG_DB_PATH` | `{TG_DATA_DIR}/messages.db` | SQLite 路径 |
 
 ---

--- a/tg-hub/SKILL.md
+++ b/tg-hub/SKILL.md
@@ -57,22 +57,25 @@ Telegram MTProto（telethon）
 
 tg-hub 使用 **MTProto 协议**（非 Bot API），需要用你的 Telegram 账号登录。
 
+> **建议**：优先使用你自己的 `TG_API_ID` / `TG_API_HASH`。
+> 我已按上游 tg-cli 的反风控实现同步：使用 Telegram Desktop 5.x 指纹，并在继续使用默认 `api_id=2040` 时给出 warning。公共 APP ID 仅作兜底，长期仍建议使用自有凭证。
+
 ```
 1. 打开 Terminal
-2. cd /var/minis/skills/tg-hub
-3. uv run python -c "
+2. （推荐）先设置自己的 TG_API_ID / TG_API_HASH
+3. cd /var/minis/skills/tg-hub
+4. uv run python -c "
    import sys; sys.path.insert(0,'.')
    from scripts.client import TGClient
    me = TGClient().login()
    print('登录成功：', me)
    "
-4. 按提示输入手机号（+86XXXXXXXXXX 格式）
-5. 输入 Telegram App 收到的验证码
-6. 登录成功后 session 自动保存，后续免登录
+5. 按提示输入手机号（+86XXXXXXXXXX 格式）
+6. 输入 Telegram App 收到的验证码
+7. 登录成功后 session 自动保存，后续免登录
 ```
 
-> **注意**：使用内置的 Telegram Desktop 公共凭证（`api_id=2040`），无需自己申请 API。
-> 如需使用自己的凭证，设置环境变量 `TG_API_ID` 和 `TG_API_HASH`。
+> 如暂时没有自己的凭证，可先用内置公共凭证登录；如遇登录/拉取异常，优先切换为自己的 APP ID。
 
 [打开 Terminal 登录](minis://open_terminal?init_command=cd%20%2Fvar%2Fminis%2Fskills%2Ftg-hub%20%26%26%20uv%20run%20python%20-c%20%22import%20sys%3B%20sys.path.insert(0%2C'.')%3B%20from%20scripts.client%20import%20TGClient%3B%20TGClient().login()%22)
 
@@ -110,7 +113,8 @@ n = client.sync("群名或用户名", limit=1000)
 print(f"新增 {n} 条消息")
 
 # 快速刷新所有群（每群最多 500 条新消息）
-result = client.refresh()
+# 默认带轻微节流；也可以限制本轮只刷前 30 个 chat
+result = client.refresh(delay=1.0, max_chats=30)
 for name, count in result.items():
     if count > 0:
         print(f"  {name}: +{count}")
@@ -159,8 +163,8 @@ print(f"本地共 {stats['total']} 条消息，{len(stats['chats'])} 个群")
 |------|------|
 | `list_chats(chat_type=None)` | 列出所有对话（实时） |
 | `sync(chat, limit=5000)` | 同步单个群到本地 SQLite |
-| `sync_all(limit_per_chat=5000)` | 同步所有群 |
-| `refresh(limit_per_chat=500)` | 快速增量刷新（推荐日常使用） |
+| `sync_all(limit_per_chat=5000, delay=1.0, max_chats=None)` | 同步所有群（带节流/数量限制） |
+| `refresh(limit_per_chat=500, delay=1.0, max_chats=None)` | 快速增量刷新（推荐日常使用） |
 
 ### 查询（本地，不联网）
 
@@ -182,17 +186,35 @@ print(f"本地共 {stats['total']} 条消息，{len(stats['chats'])} 个群")
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `TG_API_ID` | `2040`（Telegram Desktop） | 自定义 API ID |
-| `TG_API_HASH` | 内置 | 自定义 API Hash |
+| `TG_API_ID` | `2040`（仅兜底） | **推荐改为你自己的** API ID |
+| `TG_API_HASH` | 内置（仅兜底） | **推荐改为你自己的** API Hash |
 | `TG_SESSION_NAME` | `tg_hub` | Session 文件名 |
 | `TG_DATA_DIR` | `~/.tg-hub` | 数据目录 |
 | `TG_DB_PATH` | `{TG_DATA_DIR}/messages.db` | SQLite 路径 |
+| `TG_DEVICE_MODEL` | `Desktop` | Telethon 客户端设备型号 |
+| `TG_SYSTEM_VERSION` | `macOS 15.3` | Telethon 客户端系统版本 |
+| `TG_APP_VERSION` | `5.12.1` | Telethon 客户端版本 |
+| `TG_LANG_CODE` | `en` | 客户端语言代码 |
+| `TG_SYSTEM_LANG_CODE` | `en-US` | 系统语言代码 |
+
+---
+
+## 账号安全建议
+
+1. **优先使用自己的 API 凭证**：前往 `https://my.telegram.org` 创建应用后设置 `TG_API_ID` / `TG_API_HASH`。
+2. **控制同步频率**：避免高频反复执行 `refresh()`。
+3. **使用 `delay` 和 `max_chats`**：建议日常增量刷新时限制每轮同步数量，并保留 chat 之间的间隔。
+4. **首次全量同步不要太激进**：tg-hub 已对首次同步 chat 自动限制更低的抓取量。
+5. **优先读操作**：搜索/统计等本地查询不联网，风险远低于频繁同步。
 
 ---
 
 ## 注意事项
 
 - 首次登录必须在交互式 terminal 中完成（需要输入验证码）
+- **强烈建议优先使用自己的 `TG_API_ID` / `TG_API_HASH`**，避免公共 APP ID 被滥用带来的风控问题
+- tg-hub 已对齐上游 tg-cli 的 Telegram Desktop 5.x 客户端指纹，并保留环境变量覆盖能力，用于降低异常指纹风险
+- 若仍使用默认 `api_id=2040`，连接时会打印 warning，提醒改用自己的 `TG_API_ID` / `TG_API_HASH`
 - Session 文件保存在 `/var/minis/workspace/tg-hub/tg_hub.session`，妥善保管
 - `sync_all` 首次运行时间较长（取决于群数量和历史消息量）
 - 建议用 `refresh()` 做日常增量更新，用 `sync(chat, limit=10000)` 做首次全量同步

--- a/tg-hub/scripts/client.py
+++ b/tg-hub/scripts/client.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import re
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Callable
@@ -23,12 +24,25 @@ from datetime import datetime, timezone
 from typing import Any
 
 from telethon import TelegramClient
+from telethon.errors import FloodWaitError
 from telethon.tl.types import Channel, Chat, User
 
-from .config import get_api_hash, get_api_id, get_session_path
+from .config import (
+    get_api_hash,
+    get_api_id,
+    get_app_version,
+    get_device_model,
+    get_lang_code,
+    get_session_path,
+    get_system_lang_code,
+    get_system_version,
+    is_default_api_id,
+)
 from .db import MessageDB
 
 log = logging.getLogger(__name__)
+
+_FIRST_SYNC_LIMIT = 500
 
 
 # ─── 内部工具 ─────────────────────────────────────────────────────────────────
@@ -47,10 +61,36 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+_default_api_warned = False
+
+
 @asynccontextmanager
 async def _connect() -> AsyncGenerator[TelegramClient, None]:
     """异步上下文管理器：连接 Telegram，退出时自动断开。"""
-    c = TelegramClient(get_session_path(), get_api_id(), get_api_hash())
+    global _default_api_warned
+
+    api_id = get_api_id()
+    api_hash = get_api_hash()
+
+    if not _default_api_warned and is_default_api_id():
+        _default_api_warned = True
+        log.warning(
+            "Using default Telegram Desktop API credentials (api_id=2040). "
+            "This increases the risk of account restrictions. "
+            "Get your own at https://my.telegram.org and set TG_API_ID / TG_API_HASH."
+        )
+
+    c = TelegramClient(
+        get_session_path(),
+        api_id,
+        api_hash,
+        device_model=get_device_model(),
+        system_version=get_system_version(),
+        app_version=get_app_version(),
+        lang_code=get_lang_code(),
+        system_lang_code=get_system_lang_code(),
+        flood_sleep_threshold=120,
+    )
     await c.start()
     try:
         yield c
@@ -99,11 +139,13 @@ async def _fetch_history(
     db: MessageDB | None = None,
     on_progress: Callable[[int], None] | None = None,
     min_id: int = 0,
+    batch_delay: float = 0.5,
 ) -> int:
     """拉取历史消息存入 SQLite，返回新增条数。"""
     owns_db = db is None
     if db is None:
         db = MessageDB()
+    inserted = 0
     try:
         entity = await client.get_entity(chat)
         chat_name = (
@@ -114,20 +156,26 @@ async def _fetch_history(
         chat_id = entity.id
 
         sender_cache: dict[int, str] = {}
-        try:
-            async for user in client.iter_participants(entity):
-                sender_cache[user.id] = _get_sender_name(user) or str(user.id)
-        except Exception:
-            pass
-
         batch: list[dict] = []
-        inserted = 0
         BATCH = 200
 
         async for msg in client.iter_messages(entity, limit=limit, min_id=min_id):
             if msg.text is None and msg.message is None:
                 continue
-            sender_name = sender_cache.get(msg.sender_id) if msg.sender_id else None
+
+            sender_name = None
+            if msg.sender_id:
+                if msg.sender_id in sender_cache:
+                    sender_name = sender_cache[msg.sender_id]
+                else:
+                    try:
+                        sender = await msg.get_sender()
+                        sender_name = _get_sender_name(sender)
+                    except Exception:
+                        sender_name = None
+                    if sender_name:
+                        sender_cache[msg.sender_id] = sender_name
+
             content = msg.text or msg.message or ""
             ts = msg.date
             if ts and ts.tzinfo is None:
@@ -142,9 +190,16 @@ async def _fetch_history(
                 batch.clear()
                 if on_progress:
                     on_progress(inserted)
+                if batch_delay > 0:
+                    jitter = batch_delay * random.uniform(-0.3, 0.3)
+                    await asyncio.sleep(batch_delay + jitter)
 
         if batch:
             inserted += db.insert_batch(batch)
+        return inserted
+    except FloodWaitError as e:
+        log.warning("Telegram rate limit hit, waiting %ss...", e.seconds)
+        await asyncio.sleep(e.seconds + random.uniform(1, 3))
         return inserted
     finally:
         if owns_db:
@@ -156,6 +211,8 @@ async def _sync_all(
     db: MessageDB,
     limit_per_chat: int = 5000,
     on_chat_done: Callable[[str, int], None] | None = None,
+    delay: float = 1.0,
+    max_chats: int | None = None,
 ) -> dict[str, int]:
     results: dict[str, int] = {}
     stored = {c["chat_id"]: c for c in db.get_chats()}
@@ -164,20 +221,40 @@ async def _sync_all(
         entity = dialog.entity
         dialog_cache[entity.id] = (entity, dialog.name)
 
-    for chat_id, (entity, dialog_name) in dialog_cache.items():
+    items = list(dialog_cache.items())
+    if max_chats is not None:
+        items = items[:max_chats]
+    total = len(items)
+
+    for idx, (chat_id, (entity, dialog_name)) in enumerate(items):
         chat_info = stored.get(chat_id, {})
         chat_name = chat_info.get("chat_name") or dialog_name or str(chat_id)
         last_id = db.get_last_msg_id(chat_id) or 0
+        effective_limit = limit_per_chat
+        if last_id == 0 and limit_per_chat > _FIRST_SYNC_LIMIT:
+            effective_limit = _FIRST_SYNC_LIMIT
         try:
             count = await _fetch_history(
-                client, entity, limit=limit_per_chat, db=db, min_id=last_id,
+                client,
+                entity,
+                limit=effective_limit,
+                db=db,
+                min_id=last_id,
             )
             results[chat_name] = count
             if on_chat_done:
                 on_chat_done(chat_name, count)
+        except FloodWaitError as e:
+            log.warning("%s rate limited, waiting %ss...", chat_name, e.seconds)
+            await asyncio.sleep(e.seconds + random.uniform(1, 3))
+            results[chat_name] = 0
         except Exception as e:
             log.warning("同步 %s 失败: %s", chat_name, e)
             results[chat_name] = 0
+
+        if delay > 0 and idx < total - 1:
+            jitter = delay * random.uniform(-0.2, 0.2)
+            await asyncio.sleep(delay + jitter)
     return results
 
 
@@ -188,6 +265,7 @@ class TGClient:
     tg-hub 核心客户端，提供同步接口。
 
     首次使用需要交互式登录（手机号 + 验证码），之后 session 自动复用。
+    建议优先使用你自己的 Telegram APP ID / APP HASH，降低公共凭证被滥用带来的风控风险。
 
     用法：
         client = TGClient()
@@ -256,9 +334,20 @@ class TGClient:
                     return await _fetch_history(c, chat, limit=limit, db=db, on_progress=_progress)
         return _run(_do())
 
-    def sync_all(self, limit_per_chat: int = 5000) -> dict[str, int]:
+    def sync_all(
+        self,
+        limit_per_chat: int = 5000,
+        *,
+        delay: float = 1.0,
+        max_chats: int | None = None,
+    ) -> dict[str, int]:
         """
         同步所有对话到本地 SQLite（增量）。
+
+        Args:
+            limit_per_chat: 每个 chat 最多同步多少条
+            delay: chat 之间的等待秒数（带随机抖动）
+            max_chats: 本轮最多同步多少个 chat
 
         Returns:
             {chat_name: new_count, ...}
@@ -270,12 +359,25 @@ class TGClient:
         async def _do():
             async with _connect() as c:
                 with MessageDB() as db:
-                    return await _sync_all(c, db, limit_per_chat=limit_per_chat, on_chat_done=_on_done)
+                    return await _sync_all(
+                        c,
+                        db,
+                        limit_per_chat=limit_per_chat,
+                        on_chat_done=_on_done,
+                        delay=delay,
+                        max_chats=max_chats,
+                    )
         return _run(_do())
 
-    def refresh(self, limit_per_chat: int = 500) -> dict[str, int]:
+    def refresh(
+        self,
+        limit_per_chat: int = 500,
+        *,
+        delay: float = 1.0,
+        max_chats: int | None = None,
+    ) -> dict[str, int]:
         """快速增量刷新所有对话（每个群最多 500 条新消息）。"""
-        return self.sync_all(limit_per_chat=limit_per_chat)
+        return self.sync_all(limit_per_chat=limit_per_chat, delay=delay, max_chats=max_chats)
 
     # ── 本地查询（不联网）──────────────────────────────────────────────────
 

--- a/tg-hub/scripts/config.py
+++ b/tg-hub/scripts/config.py
@@ -18,8 +18,8 @@ from pathlib import Path
 _DEFAULT_API_ID   = 2040
 _DEFAULT_API_HASH = "b18441a1ff607e10a989891a5462e627"
 
-# 默认数据目录
-_DEFAULT_DATA_DIR = Path("/var/minis/workspace/tg-hub")
+# 默认数据目录：存放在 home 目录下，跨 session 复用
+_DEFAULT_DATA_DIR = Path.home() / ".tg-hub"
 
 
 def get_api_id() -> int:

--- a/tg-hub/scripts/config.py
+++ b/tg-hub/scripts/config.py
@@ -14,12 +14,24 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-# Telegram Desktop 内置公共凭证（无需自己申请）
+# Telegram Desktop 内置公共凭证（仅作兜底，不推荐长期使用）
 _DEFAULT_API_ID   = 2040
 _DEFAULT_API_HASH = "b18441a1ff607e10a989891a5462e627"
 
+# 上游 tg-cli 采用的 Telegram Desktop 5.x 指纹
+_DEFAULT_DEVICE_MODEL = "Desktop"
+_DEFAULT_SYSTEM_VERSION = "macOS 15.3"
+_DEFAULT_APP_VERSION = "5.12.1"
+_DEFAULT_LANG_CODE = "en"
+_DEFAULT_SYSTEM_LANG_CODE = "en-US"
+
 # 默认数据目录：存放在 home 目录下，跨 session 复用
 _DEFAULT_DATA_DIR = Path.home() / ".tg-hub"
+
+
+def is_default_api_id() -> bool:
+    """Return True if the user has NOT set a custom TG_API_ID."""
+    return not os.environ.get("TG_API_ID", "")
 
 
 def get_api_id() -> int:
@@ -28,7 +40,28 @@ def get_api_id() -> int:
 
 
 def get_api_hash() -> str:
-    return os.environ.get("TG_API_HASH", _DEFAULT_API_HASH)
+    val = os.environ.get("TG_API_HASH", "")
+    return val if val else _DEFAULT_API_HASH
+
+
+def get_device_model() -> str:
+    return os.environ.get("TG_DEVICE_MODEL", _DEFAULT_DEVICE_MODEL)
+
+
+def get_system_version() -> str:
+    return os.environ.get("TG_SYSTEM_VERSION", _DEFAULT_SYSTEM_VERSION)
+
+
+def get_app_version() -> str:
+    return os.environ.get("TG_APP_VERSION", _DEFAULT_APP_VERSION)
+
+
+def get_lang_code() -> str:
+    return os.environ.get("TG_LANG_CODE", _DEFAULT_LANG_CODE)
+
+
+def get_system_lang_code() -> str:
+    return os.environ.get("TG_SYSTEM_LANG_CODE", _DEFAULT_SYSTEM_LANG_CODE)
 
 
 def get_data_dir() -> Path:


### PR DESCRIPTION
## Summary
- sync tg-hub with upstream tg-cli anti-ban hardening changes
- warn when using default Telegram Desktop API credentials (api_id=2040)
- align Telethon fingerprint with upstream Telegram Desktop 5.x defaults
- add delay/max_chats throttling for sync_all and refresh
- add first-sync limit and FloodWaitError handling
- replace iter_participants prefetch with lazy sender resolution
- update tg-hub SKILL.md accordingly

## Files changed
- tg-hub/scripts/config.py
- tg-hub/scripts/client.py
- tg-hub/SKILL.md

## Validation
- python syntax check passed
- verified with uv run against a real Telegram session
- successfully exported the first 10 messages from the Open Minis group
