### PR TITLE
Add boss-hub skill for BOSS 直聘 automation 

### DIFF
--- a/boss-hub/SKILL.md
+++ b/boss-hub/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: boss-cli
+description: >
+  使用 boss-cli 操作 BOSS 直聘 — 搜索职位、查看推荐、管理投递、沟通过 Boss、给 HR 打招呼。
+  当用户提到"BOSS 直聘"、"找工作"、"投简历"、"看职位"、"搜岗位"、"boss"、"打招呼"，
+  或任何需要操作 BOSS 直聘的场景，必须触发本技能。
+---
+
+# boss-cli
+
+> **来源**：[jackwener/boss-cli](https://github.com/jackwener/boss-cli)
+> 本技能修改：移除 `browser-cookie3` 依赖，改为从环境变量读取 Cookie。
+
+---
+
+## 文件结构
+
+```
+/var/minis/skills/boss-cli/
+├── SKILL.md
+├── pyproject.toml
+└── boss_cli/
+    ├── __init__.py
+    ├── cli.py          # Click 入口
+    ├── client.py       # API 客户端（限速、重试）
+    ├── auth.py         # 认证（环境变量 / QR 登录）
+    ├── constants.py    # API 端点、过滤器代码
+    ├── exceptions.py    # 异常类
+    └── commands/       # 子命令
+```
+
+---
+
+## 认证方式
+
+### 方法一：环境变量传入 Cookie（推荐）
+
+BOSS 直聘使用两个 Cookie：`wt2` 和 `wbg`。
+
+设置方式：
+1. 用 `browser_use` 工具打开 `https://www.zhipin.com` 并登录
+2. 用 `get_cookies` 获取 `wt2` 和 `wbg` 的值
+3. 存入 Minis 环境变量：
+   - `BOSS_COOKIE`: 完整 cookie 字符串 `"wt2=xxx;wbg=xxx"`
+   - 或 `BOSS_WT2` + `BOSS_WBG`: 分别设置
+
+```bash
+# 方式1：完整 cookie
+export BOSS_COOKIE="wt2=xxxx;wbg=xxxx"
+
+# 方式2：分开设置
+export BOSS_WT2="xxxx"
+export BOSS_WBG="xxxx"
+```
+
+### 方法二：QR 码登录
+
+```bash
+cd /var/minis/skills/boss-cli
+uv run python -m boss_cli.cli login
+```
+
+---
+
+## 快速使用
+
+### 基本命令
+
+```bash
+cd /var/minis/skills/boss-cli
+
+# 搜索职位
+uv run python -m boss_cli.cli search "Python" --city 深圳
+
+# 按薪资筛选
+uv run python -m boss_cli.cli search "golang" --salary 20-30K
+
+# 按经验筛选
+uv run python -m boss_cli.cli search "前端" --exp 3-5年
+
+# 按行业+规模筛选
+uv run python -m boss_cli.cli search "后端" --industry 互联网 --scale 1000-9999人
+
+# 查看推荐职位
+uv run python -m boss_cli.cli recommend
+
+# 按编号查看详情（3 = 上次搜索第3个结果）
+uv run python -m boss_cli.cli show 3
+
+# 查看职位详情
+uv run python -m boss_cli.cli detail <securityId>
+
+# 导出为 CSV
+uv run python -m boss_cli.cli export "Python" -n 50 -o jobs.csv
+
+# 导出为 JSON
+uv run python -m boss_cli.cli export "golang" --format json -o jobs.json
+
+# 查看已投递
+uv run python -m boss_cli.cli applied
+
+# 查看面试邀请
+uv run python -m boss_cli.cli interviews
+
+# 查看沟通过的 Boss
+uv run python -m boss_cli.cli chat
+
+# 打招呼
+uv run python -m boss_cli.cli greet <securityId>
+
+# 批量打招呼（自动 1.5s 延迟防风控）
+uv run python -m boss_cli.cli batch-greet "golang" --city 杭州 -n 5
+
+# 查看个人资料
+uv run python -m boss_cli.cli me
+
+# 查看支持的城市
+uv run python -m boss_cli.cli cities
+```
+
+### 带环境变量的完整示例
+
+```bash
+# 设置 cookie 后搜索
+export BOSS_WT2="你的wt2值"
+export BOSS_WBG="你的wbg值"
+
+cd /var/minis/skills/boss-cli
+uv run python -m boss_cli.cli search "AI" --city 上海 --salary 30-50K
+```
+
+---
+
+## 常用过滤器
+
+| 参数 | 说明 | 示例 |
+|------|------|------|
+| `--city` | 城市 | `--city 深圳` |
+| `--salary` | 薪资范围 | `--salary 20-30K` |
+| `--exp` | 工作经验 | `--exp 3-5年` |
+| `--degree` | 学历 | `--degree 本科` |
+| `--industry` | 行业 | `--industry 互联网` |
+| `--scale` | 公司规模 | `--scale 1000-9999人` |
+| `--stage` | 融资阶段 | `--stage 已上市` |
+| `--job-type` | 工作类型 | `--job-type 全职` |
+| `-p` | 页码 | `-p 2` |
+| `-n` | 数量（导出用） | `-n 50` |
+
+---
+
+## 子命令速查
+
+| 命令 | 说明 |
+|------|------|
+| `search <keyword>` | 搜索职位 |
+| `recommend` | 个性化推荐 |
+| `show <index>` | 按编号查看详情 |
+| `detail <securityId>` | 按 ID 查看详情 |
+| `export <keyword>` | 导出搜索结果 |
+| `applied` | 已投递列表 |
+| `interviews` | 面试邀请 |
+| `history` | 浏览历史 |
+| `chat` | 沟通过的 Boss |
+| `greet <securityId>` | 打招呼 |
+| `batch-greet <keyword>` | 批量打招呼 |
+| `me` | 个人资料 |
+| `login` | 扫码登录 |
+| `logout` | 清除凭证 |
+| `status` | 登录状态 |
+| `cities` | 支持的城市列表 |
+
+---
+
+## 注意事项
+
+- Cookie 有效期约 7 天，过期后需重新获取
+- 批量打招呼有 1.5s 延迟防风控
+- 写操作（打招呼、投递）风险高于读操作
+- 部分功能需要完善求职期望才可用

--- a/boss-hub/boss_cli/__init__.py
+++ b/boss-hub/boss_cli/__init__.py
@@ -1,0 +1,3 @@
+"""Boss CLI — A terminal client for Boss Zhipin (BOSS直聘)."""
+
+__version__ = "0.3.0"

--- a/boss-hub/boss_cli/auth.py
+++ b/boss-hub/boss_cli/auth.py
@@ -1,0 +1,465 @@
+"""Authentication for Boss Zhipin.
+
+Strategy:
+1. Try loading saved credential from ~/.config/boss-cli/credential.json
+2. Try extracting cookies from local browsers via browser-cookie3
+3. Fallback: QR code login in terminal
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+import httpx
+import qrcode
+
+from boss_cli.constants import (
+    BASE_URL,
+    CONFIG_DIR,
+    CREDENTIAL_FILE,
+    HEADERS,
+    QR_DISPATCHER_URL,
+    QR_RANDKEY_URL,
+    QR_SCAN_LOGIN_URL,
+    QR_SCAN_URL,
+)
+
+logger = logging.getLogger(__name__)
+
+# Credential TTL: warn and attempt refresh after 7 days
+CREDENTIAL_TTL_DAYS = 7
+_CREDENTIAL_TTL_SECONDS = CREDENTIAL_TTL_DAYS * 86400
+
+# QR poll config
+POLL_TIMEOUT_S = 240  # 4 minutes
+
+
+# ── Credential data class ───────────────────────────────────────────
+
+class Credential:
+    """Holds Boss Zhipin session cookies."""
+
+    def __init__(self, cookies: dict[str, str]):
+        self.cookies = cookies
+
+    @property
+    def is_valid(self) -> bool:
+        return bool(self.cookies)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"cookies": self.cookies, "saved_at": time.time()}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Credential:
+        return cls(cookies=data.get("cookies", {}))
+
+    def as_cookie_header(self) -> str:
+        return "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+
+
+# ── Credential persistence ──────────────────────────────────────────
+
+def save_credential(credential: Credential) -> None:
+    """Save credential to config file."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CREDENTIAL_FILE.write_text(json.dumps(credential.to_dict(), indent=2, ensure_ascii=False))
+    CREDENTIAL_FILE.chmod(0o600)
+    logger.info("Credential saved to %s", CREDENTIAL_FILE)
+
+
+def load_credential() -> Credential | None:
+    """Load credential from saved file with TTL-based auto-refresh.
+
+    If saved cookies are older than 7 days, automatically attempt to
+    refresh from the browser before falling back to stale cookies.
+    """
+    if not CREDENTIAL_FILE.exists():
+        return None
+    try:
+        data = json.loads(CREDENTIAL_FILE.read_text())
+        cred = Credential.from_dict(data)
+        if not cred.is_valid:
+            return None
+
+        # Check TTL — auto-refresh if stale
+        saved_at = data.get("saved_at", 0)
+        if saved_at and (time.time() - saved_at) > _CREDENTIAL_TTL_SECONDS:
+            logger.info(
+                "Credential older than %d days, attempting browser refresh",
+                CREDENTIAL_TTL_DAYS,
+            )
+            fresh = extract_browser_credential()
+            if fresh:
+                logger.info("Auto-refreshed credential from browser")
+                return fresh
+            logger.warning(
+                "Cookie refresh failed; using existing cookies (age: %d+ days)",
+                CREDENTIAL_TTL_DAYS,
+            )
+        return cred
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning("Failed to load saved credential: %s", e)
+    return None
+
+
+def clear_credential() -> None:
+    """Remove saved credential file."""
+    if CREDENTIAL_FILE.exists():
+        CREDENTIAL_FILE.unlink()
+        logger.info("Credential removed: %s", CREDENTIAL_FILE)
+
+
+# ── Browser cookie extraction ───────────────────────────────────────
+
+def extract_browser_credential(cookie_source: str | None = None) -> Credential | None:
+    """Extract Boss Zhipin cookies from local browsers via browser-cookie3.
+
+    Args:
+        cookie_source: Optional browser name to extract from (e.g., 'chrome', 'arc').
+                       If None, tries all supported browsers in order.
+    """
+    extract_script = '''
+import json, sys
+try:
+    import browser_cookie3 as bc3
+except ImportError:
+    print(json.dumps({"error": "not_installed"}))
+    sys.exit(0)
+
+target = sys.argv[1] if len(sys.argv) > 1 else None
+
+browsers = [
+    ("Chrome", bc3.chrome),
+    ("Firefox", bc3.firefox),
+    ("Edge", bc3.edge),
+    ("Brave", bc3.brave),
+    ("Chromium", bc3.chromium),
+    ("Opera", bc3.opera),
+    ("Vivaldi", bc3.vivaldi),
+]
+
+# Try adding optional browsers (not all browser_cookie3 versions support these)
+for name, attr in [("Arc", "arc"), ("Safari", "safari"), ("LibreWolf", "librewolf")]:
+    fn = getattr(bc3, attr, None)
+    if fn:
+        browsers.append((name, fn))
+
+if target:
+    target_lower = target.lower()
+    browsers = [(n, fn) for n, fn in browsers if n.lower() == target_lower]
+    if not browsers:
+        print(json.dumps({"error": f"unsupported_browser: {target}"}))
+        sys.exit(0)
+
+for name, loader in browsers:
+    try:
+        cj = loader(domain_name=".zhipin.com")
+        cookies = {c.name: c.value for c in cj if "zhipin.com" in (c.domain or "")}
+        if cookies:
+            print(json.dumps({"browser": name, "cookies": cookies}))
+            sys.exit(0)
+    except Exception:
+        pass
+
+print(json.dumps({"error": "no_cookies"}))
+'''
+
+    try:
+        cmd = [sys.executable, "-c", extract_script]
+        if cookie_source:
+            cmd.append(cookie_source)
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        if result.returncode != 0:
+            logger.debug("Cookie extraction subprocess failed: %s", result.stderr)
+            return None
+
+        output = result.stdout.strip()
+        if not output:
+            return None
+
+        data = json.loads(output)
+        if "error" in data:
+            if data["error"] == "not_installed":
+                logger.debug("browser-cookie3 not installed, skipping")
+            else:
+                logger.debug("No valid Boss Zhipin cookies found: %s", data["error"])
+            return None
+
+        cookies = data["cookies"]
+        browser_name = data["browser"]
+        logger.info("Found cookies in %s (%d cookies)", browser_name, len(cookies))
+        cred = Credential(cookies=cookies)
+        save_credential(cred)
+        return cred
+
+    except subprocess.TimeoutExpired:
+        logger.warning("Cookie extraction timed out (browser may be running)")
+        return None
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning("Cookie extraction parse error: %s", e)
+        return None
+
+
+# ── QR Code terminal rendering ──────────────────────────────────────
+
+def _render_qr_half_blocks(matrix: list[list[bool]]) -> str:
+    """Render QR matrix using Unicode half-block characters (▀▄█ and space).
+
+    Same approach as xiaohongshu-cli: two rows are combined into one
+    terminal line using half-block glyphs, halving the vertical space.
+    """
+    if not matrix:
+        return ""
+
+    # Add 1-module quiet zone
+    size = len(matrix)
+    padded = [[False] * (size + 2)]
+    for row in matrix:
+        padded.append([False] + list(row) + [False])
+    padded.append([False] * (size + 2))
+    matrix = padded
+    rows = len(matrix)
+
+    # Check terminal width
+    term_cols = shutil.get_terminal_size(fallback=(80, 24)).columns
+    qr_width = len(matrix[0])
+    if qr_width > term_cols:
+        logger.warning("Terminal too narrow (%d) for QR (%d)", term_cols, qr_width)
+        return ""
+
+    lines: list[str] = []
+    for y in range(0, rows, 2):
+        line = ""
+        top_row = matrix[y]
+        bottom_row = matrix[y + 1] if y + 1 < rows else [False] * len(top_row)
+        for x in range(len(top_row)):
+            top = top_row[x]
+            bottom = bottom_row[x]
+            if top and bottom:
+                line += "█"
+            elif top and not bottom:
+                line += "▀"
+            elif not top and bottom:
+                line += "▄"
+            else:
+                line += " "
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _display_qr_in_terminal(data: str) -> bool:
+    """Display *data* as a QR code in the terminal using Unicode half-blocks.
+
+    Returns True on success.
+    """
+    qr = qrcode.QRCode(error_correction=qrcode.constants.ERROR_CORRECT_L)
+    qr.add_data(data)
+    qr.make(fit=True)
+    modules = qr.get_matrix()
+
+    rendered = _render_qr_half_blocks(modules)
+    if rendered:
+        print(rendered)
+        return True
+
+    # Fallback to basic ASCII
+    qr2 = qrcode.QRCode(
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=1,
+        border=1,
+    )
+    qr2.add_data(data)
+    qr2.make(fit=True)
+    qr2.print_ascii(invert=True)
+    return True
+
+
+# ── QR Login flow ───────────────────────────────────────────────────
+
+async def _get_qr_session(client: httpx.AsyncClient) -> dict[str, str]:
+    """Step 1: Get QR session (qrId, randKey, secretKey)."""
+    resp = await client.post(QR_RANDKEY_URL)
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get("code") != 0:
+        raise RuntimeError(f"Failed to get QR session: {data.get('message', 'Unknown error')}")
+    return data["zpData"]
+
+
+async def _wait_for_scan(client: httpx.AsyncClient, qr_id: str) -> bool:
+    """Step 3: Long-poll waiting for QR scan."""
+    try:
+        resp = await client.get(QR_SCAN_URL, params={"uuid": qr_id}, timeout=35)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("scaned", False)
+    except httpx.ReadTimeout:
+        return False
+
+
+async def _wait_for_confirm(client: httpx.AsyncClient, qr_id: str) -> bool:
+    """Step 4: Long-poll waiting for login confirmation."""
+    try:
+        resp = await client.get(QR_SCAN_LOGIN_URL, params={"qrId": qr_id}, timeout=35)
+        resp.raise_for_status()
+        return resp.status_code == 200
+    except httpx.ReadTimeout:
+        return False
+
+
+async def _dispatch_login(client: httpx.AsyncClient, qr_id: str) -> Credential:
+    """Step 5: Get final login cookies via dispatcher."""
+    resp = await client.get(
+        QR_DISPATCHER_URL,
+        params={"qrId": qr_id, "pk": "header-login"},
+    )
+    resp.raise_for_status()
+
+    # Extract cookies from response
+    cookies = {}
+    for name, value in resp.cookies.items():
+        cookies[name] = value
+
+    # Also grab cookies accumulated on the client
+    for name, value in client.cookies.items():
+        cookies[name] = value
+
+    if not cookies:
+        raise RuntimeError("Login dispatcher returned no cookies")
+
+    return Credential(cookies=cookies)
+
+
+async def qr_login() -> Credential:
+    """Full QR code login flow.
+
+    1. Get QR session
+    2. Display QR code in terminal (Unicode half-blocks)
+    3. Wait for scan (long-polling)
+    4. Wait for confirm (long-polling)
+    5. Dispatch to get cookies
+    """
+    async with httpx.AsyncClient(
+        base_url=BASE_URL,
+        headers=HEADERS,
+        follow_redirects=True,
+        timeout=httpx.Timeout(30, read=40),
+    ) as client:
+        # Step 1: Get QR session
+        session = await _get_qr_session(client)
+        qr_id = session["qrId"]
+
+        # Step 2: Display QR code in terminal using Unicode half-blocks
+        print("\n📱 请使用 Boss 直聘 APP 扫描以下二维码登录:\n")
+        _display_qr_in_terminal(qr_id)
+        print("\n⏳ 扫码后请在手机上确认登录...")
+        print(f"   (QR ID: {qr_id[:20]}...)\n")
+
+        # Step 3: Wait for scan
+        max_retries = 6  # ~3 min with 30s timeout each
+        scanned = False
+        for _ in range(max_retries):
+            scanned = await _wait_for_scan(client, qr_id)
+            if scanned:
+                print("  📲 已扫码，请在手机上确认...")
+                break
+
+        if not scanned:
+            raise RuntimeError("二维码已过期，请重试 (boss login)")
+
+        # Step 4: Wait for confirm
+        confirmed = False
+        for _ in range(max_retries):
+            confirmed = await _wait_for_confirm(client, qr_id)
+            if confirmed:
+                break
+
+        if not confirmed:
+            raise RuntimeError("确认超时，请重试 (boss login)")
+
+        # Step 5: Dispatch
+        credential = await _dispatch_login(client, qr_id)
+        save_credential(credential)
+        print("\n✅ 登录成功！凭证已保存到", CREDENTIAL_FILE)
+        return credential
+
+
+# ── Environment variable credential ────────────────────────────────
+
+def load_env_credential() -> Credential | None:
+    """Load credential from environment variables.
+    
+    Supports:
+    - BOSS_COOKIE: Full cookie string "wt2=xxx;wbg=xxx"
+    - BOSS_WT2, BOSS_WBG: Individual cookie values
+    """
+    import os
+    
+    # Try full cookie string
+    cookie_str = os.environ.get("BOSS_COOKIE")
+    if cookie_str:
+        cookies = {}
+        for part in cookie_str.split(";"):
+            part = part.strip()
+            if "=" in part:
+                key, value = part.split("=", 1)
+                cookies[key] = value
+        if cookies:
+            logger.info("Loaded credential from BOSS_COOKIE env var")
+            return Credential(cookies=cookies)
+    
+    # Try individual cookies
+    wt2 = os.environ.get("BOSS_WT2")
+    wbg = os.environ.get("BOSS_WBG")
+    if wt2 or wbg:
+        cookies = {}
+        if wt2:
+            cookies["wt2"] = wt2
+        if wbg:
+            cookies["wbg"] = wbg
+        if cookies:
+            logger.info("Loaded credential from BOSS_WT2/BOSS_WBG env vars")
+            return Credential(cookies=cookies)
+    
+    return None
+
+
+# ── Unified get_credential ──────────────────────────────────────────
+
+def get_credential() -> Credential | None:
+    """Try all auth methods and return credential.
+
+    Priority:
+    1. Environment variables (BOSS_COOKIE or BOSS_WT2 + BOSS_WBG)
+    2. Saved credential file
+    3. QR code login (if no other method available)
+    """
+    # 1. Try environment variables first
+    cred = load_env_credential()
+    if cred:
+        logger.info("Loaded credential from environment variables")
+        return cred
+
+    # 2. Try saved credential file
+    cred = load_credential()
+    if cred:
+        logger.info("Loaded credential from %s", CREDENTIAL_FILE)
+        return cred
+
+    # 3. Browser extraction disabled (browser-cookie3 removed)
+    # Fall back to QR login handled by caller
+    
+    return None

--- a/boss-hub/boss_cli/cli.py
+++ b/boss-hub/boss_cli/cli.py
@@ -1,0 +1,66 @@
+"""CLI entry point for Boss CLI.
+
+Usage:
+    boss login / status / logout
+    boss search <keyword> [--city C] [--salary S] [--exp E] [--degree D]
+    boss recommend [--page N]
+    boss me / applied / interviews / chat
+    boss greet <securityId>
+    boss batch-greet <keyword> [-n N] [--city C] [--dry-run]
+    boss cities
+"""
+
+from __future__ import annotations
+
+import logging
+
+import click
+
+from . import __version__
+from .commands import auth, personal, search, social
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="boss")
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose logging (show request URLs, timing)")
+@click.pass_context
+def cli(ctx, verbose: bool) -> None:
+    """Boss CLI — 在终端使用 BOSS 直聘 🤝"""
+    ctx.ensure_object(dict)
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format="%(name)s %(message)s")
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+
+# ─── Auth commands ───────────────────────────────────────────────────
+
+cli.add_command(auth.login)
+cli.add_command(auth.logout)
+cli.add_command(auth.status)
+cli.add_command(auth.me)
+
+# ─── Search & Browse commands ────────────────────────────────────────
+
+cli.add_command(search.search)
+cli.add_command(search.recommend)
+cli.add_command(search.detail)
+cli.add_command(search.show)
+cli.add_command(search.export)
+cli.add_command(search.history)
+cli.add_command(search.cities)
+
+# ─── Personal Center commands ────────────────────────────────────────
+
+cli.add_command(personal.applied)
+cli.add_command(personal.interviews)
+
+# ─── Social commands ────────────────────────────────────────────────
+
+cli.add_command(social.chat_list)
+cli.add_command(social.greet)
+cli.add_command(social.batch_greet)
+
+
+if __name__ == "__main__":
+    cli()

--- a/boss-hub/boss_cli/client.py
+++ b/boss-hub/boss_cli/client.py
@@ -1,0 +1,338 @@
+"""API client for Boss Zhipin with rate limiting, retry, and anti-detection."""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Any
+
+import httpx
+
+from .constants import (
+    BASE_URL,
+    CITY_CODES,
+    DELIVER_LIST_URL,
+    FRIEND_ADD_URL,
+    FRIEND_LIST_URL,
+    GEEK_GET_JOB_URL,
+    HEADERS,
+    INTERVIEW_DATA_URL,
+    JOB_CARD_URL,
+    JOB_DETAIL_URL,
+    JOB_HISTORY_URL,
+    JOB_RECOMMEND_URL,
+    JOB_SEARCH_URL,
+    RESUME_BASEINFO_URL,
+    RESUME_EXPECT_URL,
+    RESUME_STATUS_URL,
+    USER_INFO_URL,
+)
+from .exceptions import BossApiError, ParamError, RateLimitError, SessionExpiredError
+
+logger = logging.getLogger(__name__)
+
+
+class BossClient:
+    """Boss Zhipin API client with Gaussian jitter, exponential backoff, and session-stable identity.
+
+    Anti-detection strategy:
+    - Gaussian jitter delay between requests (~1s mean, σ=0.3)
+    - 5% chance of a random long pause (2-5s) to mimic reading behavior
+    - Exponential backoff on HTTP 429/5xx (up to 3 retries)
+    - Response cookies merged back into session jar
+    - Request counter for monitoring
+    """
+
+    def __init__(
+        self,
+        credential: object | None = None,
+        timeout: float = 30.0,
+        request_delay: float = 1.0,
+        max_retries: int = 3,
+    ):
+        self.credential = credential
+        self._timeout = timeout
+        self._request_delay = request_delay
+        self._base_request_delay = request_delay
+        self._max_retries = max_retries
+        self._last_request_time = 0.0
+        self._request_count = 0
+        self._rate_limit_count = 0
+        self._http: httpx.Client | None = None
+
+    def _build_client(self) -> httpx.Client:
+        cookies = {}
+        if self.credential:
+            cookies = self.credential.cookies
+        return httpx.Client(
+            base_url=BASE_URL,
+            headers=dict(HEADERS),
+            cookies=cookies,
+            follow_redirects=True,
+            timeout=httpx.Timeout(self._timeout),
+        )
+
+    @property
+    def client(self) -> httpx.Client:
+        if not self._http:
+            raise RuntimeError("Client not initialized. Use 'with BossClient() as client:'")
+        return self._http
+
+    def __enter__(self) -> BossClient:
+        self._http = self._build_client()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        if self._http:
+            self._http.close()
+            self._http = None
+
+    # ── Rate limiting ───────────────────────────────────────────────
+
+    def _rate_limit_delay(self) -> None:
+        """Enforce minimum delay with Gaussian jitter to mimic human browsing."""
+        if self._request_delay <= 0:
+            return
+        elapsed = time.time() - self._last_request_time
+        if elapsed < self._request_delay:
+            # Gaussian jitter: mean=0.3, σ=0.15, clamped to [0, ∞)
+            jitter = max(0, random.gauss(0.3, 0.15))
+            # 5% chance of a long pause to mimic reading
+            if random.random() < 0.05:
+                jitter += random.uniform(2.0, 5.0)
+            sleep_time = self._request_delay - elapsed + jitter
+            logger.debug("Rate-limit delay: %.2fs", sleep_time)
+            time.sleep(sleep_time)
+
+    def _mark_request(self) -> None:
+        self._last_request_time = time.time()
+        self._request_count += 1
+
+    @property
+    def request_stats(self) -> dict[str, int | float]:
+        """Return current request statistics."""
+        return {
+            "request_count": self._request_count,
+            "last_request_time": self._last_request_time,
+        }
+
+    # ── Response handling ───────────────────────────────────────────
+
+    def _merge_response_cookies(self, resp: httpx.Response) -> None:
+        """Persist response Set-Cookie headers back into the session jar."""
+        for name, value in resp.cookies.items():
+            if value:
+                self.client.cookies.set(name, value)
+
+    def _handle_response(self, data: dict[str, Any], action: str) -> dict[str, Any]:
+        """Validate API response and return zpData, raise typed exceptions."""
+        code = data.get("code", -1)
+
+        if code == 0:
+            return data.get("zpData", {})
+
+        message = data.get("message", "Unknown error")
+
+        if code == 37:
+            raise SessionExpiredError()
+        if code in (17, 19):
+            raise ParamError(message, code=code)
+        if code == 9:
+            # Rate limited — auto-cooldown with exponential backoff
+            self._rate_limit_count += 1
+            cooldown = min(60, 10 * (2 ** (self._rate_limit_count - 1)))
+            self._request_delay = max(self._request_delay, self._base_request_delay * 2)
+            logger.warning(
+                "Rate limited (count=%d), cooling down %.0fs, delay raised to %.1fs",
+                self._rate_limit_count, cooldown, self._request_delay,
+            )
+            time.sleep(cooldown)
+            raise RateLimitError()
+
+        raise BossApiError(f"{action}: {message} (code={code})", code=code, response=data)
+
+    # ── Request with retry ──────────────────────────────────────────
+
+    def _request(self, method: str, url: str, **kwargs) -> dict[str, Any]:
+        """Execute HTTP request with rate-limit delay, retry, and cookie merge."""
+        self._rate_limit_delay()
+        last_exc: Exception | None = None
+
+        for attempt in range(self._max_retries):
+            t0 = time.time()
+            try:
+                resp = self.client.request(method, url, **kwargs)
+                elapsed = time.time() - t0
+                self._merge_response_cookies(resp)
+                self._mark_request()
+
+                logger.info(
+                    "[#%d] %s %s → %d (%.2fs)",
+                    self._request_count, method, url[:60], resp.status_code, elapsed,
+                )
+
+                # Retry on server errors
+                if resp.status_code in (429, 500, 502, 503, 504):
+                    wait = (2 ** attempt) + random.uniform(0, 1)
+                    logger.warning(
+                        "HTTP %d from %s, retrying in %.1fs (attempt %d/%d)",
+                        resp.status_code, url[:80], wait, attempt + 1, self._max_retries,
+                    )
+                    time.sleep(wait)
+                    continue
+
+                resp.raise_for_status()
+
+                # Check for HTML responses (redirect to login page)
+                text = resp.text
+                if text.startswith("<"):
+                    raise BossApiError(f"Received HTML instead of JSON from {url} (possible auth redirect)")
+
+                return resp.json()
+
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                elapsed = time.time() - t0
+                last_exc = exc
+                wait = (2 ** attempt) + random.uniform(0, 1)
+                logger.warning(
+                    "[#%d] %s %s → Network error: %s (%.2fs), retrying in %.1fs (attempt %d/%d)",
+                    self._request_count + 1, method, url[:60], exc, elapsed, wait,
+                    attempt + 1, self._max_retries,
+                )
+                time.sleep(wait)
+
+        if last_exc:
+            raise BossApiError(f"Request failed after {self._max_retries} retries: {last_exc}") from last_exc
+        raise BossApiError(f"Request failed after {self._max_retries} retries")
+
+    def _get(self, url: str, params: dict[str, Any] | None = None, action: str = "") -> dict[str, Any]:
+        """GET request with response validation and rate-limit retry."""
+        data = self._request("GET", url, params=params)
+        try:
+            result = self._handle_response(data, action)
+            # Reset rate-limit counter on success
+            self._rate_limit_count = 0
+            return result
+        except RateLimitError:
+            # Auto-retry once after cooldown (cooldown already happened in _handle_response)
+            logger.info("Retrying after rate-limit cooldown...")
+            data = self._request("GET", url, params=params)
+            result = self._handle_response(data, action)
+            self._rate_limit_count = 0
+            return result
+
+    # ── Job Search & Browse ─────────────────────────────────────────
+
+    def search_jobs(
+        self,
+        query: str,
+        city: str = "101010100",
+        page: int = 1,
+        page_size: int = 15,
+        experience: str | None = None,
+        degree: str | None = None,
+        salary: str | None = None,
+        industry: str | None = None,
+        scale: str | None = None,
+        stage: str | None = None,
+        job_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Search jobs."""
+        params: dict[str, Any] = {
+            "query": query,
+            "city": city,
+            "page": page,
+            "pageSize": page_size,
+        }
+        if experience:
+            params["experience"] = experience
+        if degree:
+            params["degree"] = degree
+        if salary:
+            params["salary"] = salary
+        if industry:
+            params["industry"] = industry
+        if scale:
+            params["scale"] = scale
+        if stage:
+            params["stage"] = stage
+        if job_type:
+            params["jobType"] = job_type
+        return self._get(JOB_SEARCH_URL, params=params, action="搜索职位")
+
+    def get_recommend_jobs(self, page: int = 1) -> dict[str, Any]:
+        """Get personalized job recommendations."""
+        return self._get(JOB_RECOMMEND_URL, params={"page": page}, action="推荐职位")
+
+    def get_job_card(self, security_id: str, lid: str) -> dict[str, Any]:
+        """Get job card info (hover preview)."""
+        return self._get(JOB_CARD_URL, params={"securityId": security_id, "lid": lid}, action="职位卡片")
+
+    def get_job_detail(self, security_id: str, lid: str = "") -> dict[str, Any]:
+        """Get detailed information for a specific job."""
+        params: dict[str, str] = {"securityId": security_id}
+        if lid:
+            params["lid"] = lid
+        return self._get(JOB_DETAIL_URL, params=params, action="职位详情")
+
+    # ── Personal Center ─────────────────────────────────────────────
+
+    def get_user_info(self) -> dict[str, Any]:
+        """Get current user info (userId, name, avatar, etc.)."""
+        return self._get(USER_INFO_URL, action="用户信息")
+
+    def get_resume_baseinfo(self) -> dict[str, Any]:
+        """Get resume basic info (full profile: name, age, degree, etc.)."""
+        return self._get(RESUME_BASEINFO_URL, action="简历基本信息")
+
+    def get_resume_expect(self) -> dict[str, Any]:
+        """Get job expectations (desired position, salary, city)."""
+        return self._get(RESUME_EXPECT_URL, action="求职期望")
+
+    def get_resume_status(self) -> dict[str, Any]:
+        """Get resume status."""
+        return self._get(RESUME_STATUS_URL, action="简历状态")
+
+    def get_deliver_list(self, page: int = 1) -> dict[str, Any]:
+        """Get list of jobs applied to (已投递)."""
+        return self._get(DELIVER_LIST_URL, params={"page": page}, action="已投递列表")
+
+    def get_interview_data(self) -> dict[str, Any]:
+        """Get interview data (面试)."""
+        return self._get(INTERVIEW_DATA_URL, action="面试数据")
+
+    def get_job_history(self, page: int = 1) -> dict[str, Any]:
+        """Get job browsing history."""
+        return self._get(JOB_HISTORY_URL, params={"page": page}, action="浏览历史")
+
+    # ── Social / Chat ───────────────────────────────────────────────
+
+    def get_friend_list(self) -> dict[str, Any]:
+        """Get geek friend list (沟通过的 Boss)."""
+        return self._get(FRIEND_LIST_URL, action="好友列表")
+
+    def add_friend(self, security_id: str, lid: str = "") -> dict[str, Any]:
+        """Send greeting to a Boss (打招呼 / 投递简历)."""
+        params: dict[str, str] = {"securityId": security_id}
+        if lid:
+            params["lid"] = lid
+        return self._get(FRIEND_ADD_URL, params=params, action="打招呼")
+
+    def get_geek_job(self, security_id: str) -> dict[str, Any]:
+        """Get interacted job info."""
+        return self._get(GEEK_GET_JOB_URL, params={"securityId": security_id}, action="互动职位")
+
+
+# ── City resolution ─────────────────────────────────────────────────
+
+def resolve_city(name: str) -> str:
+    """Resolve city name to code, passthrough if already a code."""
+    if name.isdigit() and len(name) >= 6:
+        return name
+    return CITY_CODES.get(name, CITY_CODES["全国"])
+
+
+def list_cities() -> dict[str, str]:
+    """Return all supported city name -> code mappings."""
+    return dict(CITY_CODES)

--- a/boss-hub/boss_cli/commands/_common.py
+++ b/boss-hub/boss_cli/commands/_common.py
@@ -1,0 +1,148 @@
+"""Common helpers for Boss CLI commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import click
+from rich.console import Console
+
+from ..auth import Credential, get_credential
+from ..client import BossClient
+from ..exceptions import BossApiError, SessionExpiredError, error_code_for_exception
+
+T = TypeVar("T")
+
+# Rich output → stderr (so structured JSON/YAML stays clean on stdout)
+console = Console(stderr=True)
+error_console = Console(stderr=True)
+
+# ── Schema envelope version ─────────────────────────────────────────
+SCHEMA_VERSION = "1"
+
+
+def require_auth() -> Credential:
+    """Get credential or exit with error."""
+    cred = get_credential()
+    if not cred:
+        console.print("[yellow]⚠️  未登录[/yellow]，使用 [bold]boss login[/bold] 扫码登录")
+        sys.exit(1)
+    return cred
+
+
+def get_client(credential: Credential | None = None) -> BossClient:
+    """Create a BossClient with optional credential."""
+    return BossClient(credential)
+
+
+def run_client_action(credential: Credential, action: Callable[[BossClient], T]) -> T:
+    """Run an authenticated client action with auto-retry on session expiry.
+
+    If SessionExpiredError is raised, tries once more with a fresh browser
+    credential before giving up.
+    """
+    try:
+        with get_client(credential) as client:
+            return action(client)
+    except SessionExpiredError:
+        # Try refreshing from browser
+        from ..auth import extract_browser_credential
+        fresh = extract_browser_credential()
+        if fresh:
+            with get_client(fresh) as client:
+                return action(client)
+        raise
+
+
+def _wrap_envelope(data: Any, *, ok: bool = True, error: dict | None = None) -> dict:
+    """Wrap data in the standard output envelope."""
+    envelope: dict[str, Any] = {
+        "ok": ok,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if ok:
+        envelope["data"] = data
+    else:
+        envelope["data"] = None
+        envelope["error"] = error or {}
+    return envelope
+
+
+def _output_structured(data: Any, *, as_json: bool, as_yaml: bool) -> None:
+    """Output data wrapped in envelope as JSON or YAML."""
+    envelope = _wrap_envelope(data)
+    if as_json:
+        click.echo(json.dumps(envelope, indent=2, ensure_ascii=False))
+    elif as_yaml or not sys.stdout.isatty():
+        try:
+            import yaml
+            click.echo(yaml.dump(envelope, allow_unicode=True, default_flow_style=False))
+        except ImportError:
+            click.echo(json.dumps(envelope, indent=2, ensure_ascii=False))
+
+
+def handle_command(
+    credential: Credential,
+    *,
+    action: Callable[[BossClient], T],
+    render: Callable[[T], None] | None = None,
+    as_json: bool = False,
+    as_yaml: bool = False,
+) -> T | None:
+    """Run a client action with structured output support.
+
+    - If --json is set, print JSON envelope to stdout
+    - If --yaml is set, print YAML envelope to stdout
+    - If non-TTY and neither flag, auto YAML envelope
+    - Otherwise, call render() for rich output
+    """
+    try:
+        data = run_client_action(credential, action)
+
+        if as_json or as_yaml or not sys.stdout.isatty():
+            _output_structured(data, as_json=as_json, as_yaml=as_yaml)
+            return data
+
+        if render:
+            render(data)
+        return data
+
+    except BossApiError as exc:
+        _print_error(exc, as_json=as_json, as_yaml=as_yaml)
+        return None
+
+
+def handle_errors(fn: Callable[[], T]) -> T | None:
+    """Run arbitrary command logic and catch BossApiError."""
+    try:
+        return fn()
+    except BossApiError as exc:
+        _print_error(exc)
+        return None
+
+
+def _print_error(exc: BossApiError, *, as_json: bool = False, as_yaml: bool = False) -> None:
+    """Print formatted error message, with envelope if structured output."""
+    code = error_code_for_exception(exc)
+    if as_json or as_yaml or not sys.stdout.isatty():
+        envelope = _wrap_envelope(None, ok=False, error={"code": code, "message": str(exc)})
+        if as_json:
+            click.echo(json.dumps(envelope, indent=2, ensure_ascii=False))
+        else:
+            try:
+                import yaml
+                click.echo(yaml.dump(envelope, allow_unicode=True, default_flow_style=False))
+            except ImportError:
+                click.echo(json.dumps(envelope, indent=2, ensure_ascii=False))
+    else:
+        console.print(f"[red]❌ [{code}] {exc}[/red]")
+
+
+def structured_output_options(command: Callable) -> Callable:
+    """Add --json/--yaml options to a Click command."""
+    command = click.option("--yaml", "as_yaml", is_flag=True, help="以 YAML 格式输出")(command)
+    command = click.option("--json", "as_json", is_flag=True, help="以 JSON 格式输出")(command)
+    return command

--- a/boss-hub/boss_cli/commands/auth.py
+++ b/boss-hub/boss_cli/commands/auth.py
@@ -1,0 +1,122 @@
+"""Authentication commands: login, logout, status, me."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import click
+from rich.panel import Panel
+
+from ._common import (
+    console,
+    handle_command,
+    require_auth,
+    structured_output_options,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("--qrcode", is_flag=True, help="使用二维码扫码登录")
+@click.option("--cookie-source", default=None, help="指定浏览器 (chrome/firefox/edge/brave/arc/safari等)")
+def login(qrcode: bool, cookie_source: str | None) -> None:
+    """扫码登录 Boss 直聘 APP"""
+    if qrcode:
+        from ..auth import qr_login
+        import asyncio
+        try:
+            asyncio.run(qr_login())
+        except RuntimeError as e:
+            console.print(f"[red]❌ {e}[/red]")
+            raise SystemExit(1) from None
+    else:
+        from ..auth import extract_browser_credential
+        # Try browser cookies first
+        cred = extract_browser_credential(cookie_source=cookie_source)
+        if cred:
+            console.print(f"[green]✅ 登录成功！[/green] ({len(cred.cookies)} cookies)")
+        else:
+            # Fallback to QR login
+            console.print("[yellow]未找到浏览器 Cookie，尝试二维码登录...[/yellow]")
+            from ..auth import qr_login
+            import asyncio
+            try:
+                asyncio.run(qr_login())
+            except RuntimeError as e:
+                console.print(f"[red]❌ {e}[/red]")
+                raise SystemExit(1) from None
+
+
+@click.command()
+def logout() -> None:
+    """清除已保存的登录凭证"""
+    from ..auth import clear_credential
+    clear_credential()
+    console.print("[green]✅ 已退出登录[/green]")
+
+
+@click.command()
+@structured_output_options
+def status(as_json: bool, as_yaml: bool) -> None:
+    """查看当前登录状态"""
+    from ..auth import get_credential
+    cred = get_credential()
+    if cred:
+        cookie_names = sorted(cred.cookies.keys())
+        data = {
+            "authenticated": True,
+            "cookie_count": len(cred.cookies),
+            "cookies": cookie_names,
+        }
+        if as_json:
+            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+        elif as_yaml:
+            try:
+                import yaml
+                click.echo(yaml.dump(data, allow_unicode=True))
+            except ImportError:
+                click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+        else:
+            n = len(cred.cookies)
+            keys = ", ".join(cookie_names[:5])
+            extra = f" (+{n - 5} more)" if n > 5 else ""
+            console.print(f"[green]✅ 已登录[/green] ({n} cookies)")
+            console.print(f"  [dim]{keys}{extra}[/dim]")
+    else:
+        if as_json:
+            click.echo(json.dumps({"authenticated": False}))
+        else:
+            console.print("[yellow]⚠️  未登录[/yellow]，使用 [bold]boss login[/bold] 扫码登录")
+
+
+@click.command()
+@structured_output_options
+def me(as_json: bool, as_yaml: bool) -> None:
+    """查看个人资料和求职期望"""
+    cred = require_auth()
+
+    def _render(info: dict) -> None:
+        name = info.get("name", info.get("nickName", "-"))
+        age = info.get("age", "-")
+        degree = info.get("degreeCategory", "-")
+        account = info.get("account", "-")
+        gender = "男" if info.get("gender") == 1 else "女" if info.get("gender") == 2 else "-"
+
+        panel = Panel(
+            f"[bold]{name}[/bold]  {gender}  {age}\n"
+            f"学历: {degree}\n"
+            f"账号: {account}",
+            title="👤 个人资料",
+            border_style="cyan",
+        )
+        console.print(panel)
+
+    handle_command(
+        cred,
+        action=lambda c: c.get_resume_baseinfo(),
+        render=_render,
+        as_json=as_json,
+        as_yaml=as_yaml,
+    )

--- a/boss-hub/boss_cli/commands/personal.py
+++ b/boss-hub/boss_cli/commands/personal.py
@@ -1,0 +1,97 @@
+"""Personal center commands: applied, interviews."""
+
+from __future__ import annotations
+
+import logging
+
+import click
+from rich.table import Table
+
+from ._common import (
+    console,
+    handle_command,
+    require_auth,
+    structured_output_options,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("-p", "--page", default=1, type=int, help="页码 (默认: 1)")
+@structured_output_options
+def applied(page: int, as_json: bool, as_yaml: bool) -> None:
+    """查看已投递的职位"""
+    cred = require_auth()
+
+    def _render(data: dict) -> None:
+        card_list = data.get("cardList", [])
+        total = data.get("totalCount", 0)
+
+        if not card_list:
+            console.print("[yellow]暂无投递记录[/yellow]")
+            return
+
+        table = Table(title=f"📮 已投递 ({total} 个)", show_lines=True)
+        table.add_column("#", style="dim", width=3)
+        table.add_column("职位", style="bold cyan", max_width=25)
+        table.add_column("公司", style="green", max_width=20)
+        table.add_column("薪资", style="yellow", max_width=12)
+        table.add_column("状态", max_width=10)
+        table.add_column("时间", style="dim", max_width=15)
+
+        for i, card in enumerate(card_list, 1):
+            job_info = card.get("jobInfo", card)
+            brand_info = card.get("brandInfo", card)
+            status_info = card.get("deliverStatusDesc", card.get("statusDesc", "-"))
+
+            table.add_row(
+                str(i),
+                job_info.get("jobName", card.get("jobName", "-")),
+                brand_info.get("brandName", card.get("brandName", "-")),
+                job_info.get("salaryDesc", card.get("salaryDesc", "-")),
+                str(status_info),
+                card.get("updateTimeDesc", card.get("createTimeDesc", "-")),
+            )
+
+        console.print(table)
+        if page * 15 < total:
+            console.print(f"\n  [dim]▸ 更多: boss applied -p {page + 1}[/dim]")
+
+    handle_command(cred, action=lambda c: c.get_deliver_list(page=page), render=_render, as_json=as_json, as_yaml=as_yaml)
+
+
+@click.command()
+@structured_output_options
+def interviews(as_json: bool, as_yaml: bool) -> None:
+    """查看面试邀请"""
+    cred = require_auth()
+
+    def _render(data: dict) -> None:
+        interview_list = data.get("interviewList", [])
+
+        if not interview_list:
+            console.print("[yellow]暂无面试邀请[/yellow]")
+            return
+
+        table = Table(title=f"📋 面试邀请 ({len(interview_list)} 个)", show_lines=True)
+        table.add_column("#", style="dim", width=3)
+        table.add_column("职位", style="bold cyan", max_width=25)
+        table.add_column("公司", style="green", max_width=20)
+        table.add_column("时间", style="yellow", max_width=20)
+        table.add_column("地点", style="blue", max_width=25)
+        table.add_column("状态", max_width=10)
+
+        for i, interview in enumerate(interview_list, 1):
+            table.add_row(
+                str(i),
+                interview.get("jobName", "-"),
+                interview.get("brandName", "-"),
+                interview.get("interviewTime", "-"),
+                interview.get("address", "-"),
+                interview.get("statusDesc", "-"),
+            )
+
+        console.print(table)
+
+    handle_command(cred, action=lambda c: c.get_interview_data(), render=_render, as_json=as_json, as_yaml=as_yaml)

--- a/boss-hub/boss_cli/commands/search.py
+++ b/boss-hub/boss_cli/commands/search.py
@@ -1,0 +1,396 @@
+"""Search and browse commands: search, recommend, cities, detail, show, export, history."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+
+import click
+from rich.panel import Panel
+from rich.table import Table
+
+from ..client import BossClient, list_cities, resolve_city
+from ..constants import DEGREE_CODES, EXP_CODES, INDUSTRY_CODES, JOB_TYPE_CODES, SALARY_CODES, SCALE_CODES, STAGE_CODES
+from ..exceptions import BossApiError
+from ..index_cache import get_index_info, get_job_by_index, save_index
+from ._common import (
+    console,
+    handle_command,
+    require_auth,
+    run_client_action,
+    structured_output_options,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Helper: render job table ────────────────────────────────────────
+
+def _render_job_table(
+    job_list: list[dict], title: str, page: int = 1, hint_next: str = "",
+) -> None:
+    """Render a list of jobs as a rich table and save to index cache."""
+    if not job_list:
+        console.print("[yellow]没有找到匹配的职位[/yellow]")
+        return
+
+    # Save to index cache for `boss show` navigation
+    save_index(job_list, source=title[:30])
+
+    table = Table(title=f"{title} — {len(job_list)} 个结果", show_lines=True)
+    table.add_column("#", style="dim", width=3)
+    table.add_column("职位", style="bold cyan", max_width=30)
+    table.add_column("公司", style="green", max_width=20)
+    table.add_column("薪资", style="yellow", max_width=12)
+    table.add_column("经验", max_width=10)
+    table.add_column("学历", max_width=8)
+    table.add_column("地区", style="blue", max_width=15)
+    table.add_column("技能", style="dim", max_width=20)
+
+    for i, job in enumerate(job_list, 1):
+        skills = job.get("skills", [])
+        skill_str = ", ".join(skills[:3]) if skills else "-"
+        area = job.get("areaDistrict", "")
+        biz = job.get("businessDistrict", "")
+        location = f"{area} {biz}".strip() if area else job.get("cityName", "-")
+
+        table.add_row(
+            str(i),
+            job.get("jobName", "-"),
+            job.get("brandName", "-"),
+            job.get("salaryDesc", "-"),
+            job.get("jobExperience", "-"),
+            job.get("jobDegree", "-"),
+            location,
+            skill_str,
+        )
+
+    console.print(table)
+    console.print("  [dim]💡 使用 boss show <编号> 查看职位详情[/dim]")
+
+    if hint_next:
+        console.print(f"  [dim]▸ {hint_next}[/dim]")
+
+
+# ── search ──────────────────────────────────────────────────────────
+
+@click.command()
+@click.argument("keyword")
+@click.option("-c", "--city", default="全国", help="城市名称或代码 (默认: 全国)")
+@click.option("-p", "--page", default=1, type=int, help="页码 (默认: 1)")
+@click.option("--salary", type=click.Choice(list(SALARY_CODES.keys())), help="薪资筛选")
+@click.option("--exp", type=click.Choice(list(EXP_CODES.keys())), help="工作经验筛选")
+@click.option("--degree", type=click.Choice(list(DEGREE_CODES.keys())), help="学历筛选")
+@click.option("--industry", type=click.Choice(list(INDUSTRY_CODES.keys())), help="行业筛选 (如: 互联网, 金融)")
+@click.option("--scale", type=click.Choice(list(SCALE_CODES.keys())), help="公司规模筛选 (如: 1000-9999人)")
+@click.option("--stage", type=click.Choice(list(STAGE_CODES.keys())), help="融资阶段筛选 (如: A轮, 已上市)")
+@click.option("--job-type", type=click.Choice(list(JOB_TYPE_CODES.keys())), help="职位类型 (全职/兼职/实习)")
+@structured_output_options
+def search(
+    keyword: str, city: str, page: int,
+    salary: str | None, exp: str | None, degree: str | None,
+    industry: str | None, scale: str | None, stage: str | None, job_type: str | None,
+    as_json: bool, as_yaml: bool,
+) -> None:
+    """搜索职位 (例: boss search Python --city 北京 --industry 互联网)"""
+    cred = require_auth()
+
+    city_code = resolve_city(city)
+    salary_code = SALARY_CODES.get(salary) if salary else None
+    exp_code = EXP_CODES.get(exp) if exp else None
+    degree_code = DEGREE_CODES.get(degree) if degree else None
+    industry_code = INDUSTRY_CODES.get(industry) if industry else None
+    scale_code = SCALE_CODES.get(scale) if scale else None
+    stage_code = STAGE_CODES.get(stage) if stage else None
+    job_type_code = JOB_TYPE_CODES.get(job_type) if job_type else None
+
+    def _action(c: BossClient) -> dict:
+        return c.search_jobs(
+            query=keyword, city=city_code, page=page,
+            experience=exp_code, degree=degree_code, salary=salary_code,
+            industry=industry_code, scale=scale_code, stage=stage_code,
+            job_type=job_type_code,
+        )
+
+    def _render(data: dict) -> None:
+        job_list = data.get("jobList", [])
+        # Always save index cache for `boss show` navigation
+        if job_list:
+            save_index(job_list, source=f"search:{keyword}")
+
+        filters = [city]
+        for f in (salary, exp, degree, industry, scale, stage, job_type):
+            if f:
+                filters.append(f)
+        filter_str = " · ".join(filters)
+
+        _render_job_table(
+            job_list,
+            title=f"🔍 搜索: {keyword} ({filter_str})",
+            page=page,
+            hint_next=f"更多结果: boss search \"{keyword}\" --city {city} -p {page + 1}" if data.get("hasMore") else "",
+        )
+
+    handle_command(cred, action=_action, render=_render, as_json=as_json, as_yaml=as_yaml)
+
+
+# ── recommend ───────────────────────────────────────────────────────
+
+@click.command()
+@click.option("-p", "--page", default=1, type=int, help="页码 (默认: 1)")
+@structured_output_options
+def recommend(page: int, as_json: bool, as_yaml: bool) -> None:
+    """查看推荐职位 (基于求职期望)"""
+    cred = require_auth()
+
+    def _action(c):
+        return c.get_recommend_jobs(page=page)
+
+    def _render(data: dict) -> None:
+        job_list = data.get("jobList", [])
+        _render_job_table(
+            job_list,
+            title=f"⭐ 推荐职位 (第 {page} 页)",
+            page=page,
+            hint_next=f"更多推荐: boss recommend -p {page + 1}" if data.get("hasMore") else "",
+        )
+
+    handle_command(cred, action=_action, render=_render, as_json=as_json, as_yaml=as_yaml)
+
+
+# ── detail ──────────────────────────────────────────────────────────
+
+@click.command()
+@click.argument("security_id")
+@structured_output_options
+def detail(security_id: str, as_json: bool, as_yaml: bool) -> None:
+    """查看职位详情 (需要 securityId 或使用 boss show)"""
+    cred = require_auth()
+
+    def _action(c: BossClient) -> dict:
+        return c.get_job_detail(security_id=security_id)
+
+    handle_command(cred, action=_action, render=_render_detail, as_json=as_json, as_yaml=as_yaml)
+
+
+# ── show (short-index) ──────────────────────────────────────────────
+
+@click.command()
+@click.argument("index", type=int)
+@structured_output_options
+def show(index: int, as_json: bool, as_yaml: bool) -> None:
+    """按搜索结果编号查看职位详情 (例: boss show 3)
+
+    使用 search 或 recommend 命令后，可用编号快速查看详情。
+    """
+    job = get_job_by_index(index)
+    if not job:
+        info = get_index_info()
+        if not info.get("exists"):
+            console.print("[yellow]暂无缓存的搜索结果，请先运行 boss search 或 boss recommend[/yellow]")
+        else:
+            console.print(f"[yellow]编号 {index} 超出范围 (共 {info.get('count', 0)} 个结果)[/yellow]")
+        return
+
+    security_id = job.get("securityId", "")
+    if not security_id:
+        console.print("[red]❌ 该职位缺少 securityId[/red]")
+        return
+
+    # Show brief info from cache first
+    console.print(
+        f"  [dim]#{index}[/dim] [cyan]{job.get('jobName', '-')}[/cyan] @ "
+        f"[green]{job.get('brandName', '-')}[/green]  "
+        f"[yellow]{job.get('salaryDesc', '-')}[/yellow]"
+    )
+    console.print()
+
+    # Fetch full detail
+    cred = require_auth()
+
+    def _action(c: BossClient) -> dict:
+        return c.get_job_detail(security_id=security_id)
+
+    handle_command(cred, action=_action, render=_render_detail, as_json=as_json, as_yaml=as_yaml)
+
+
+def _render_detail(data: dict) -> None:
+    """Render job detail panel (shared by detail and show commands)."""
+    job = data.get("jobInfo", data)
+    boss = data.get("bossInfo", {})
+    brand = data.get("brandComInfo", {})
+
+    title = job.get("jobName", "-")
+    salary = job.get("salaryDesc", "-")
+    exp = job.get("experienceName", job.get("jobExperience", "-"))
+    degree = job.get("degreeName", job.get("jobDegree", "-"))
+    city = job.get("locationName", job.get("cityName", "-"))
+
+    company = brand.get("brandName", job.get("brandName", "-"))
+    industry = brand.get("industryName", "-")
+    scale = brand.get("scaleName", "-")
+    stage = brand.get("stageName", "-")
+
+    boss_name = boss.get("name", "-")
+    boss_title = boss.get("title", "-")
+
+    skills = job.get("skills", [])
+    skill_str = ", ".join(skills) if skills else "-"
+
+    desc = job.get("postDescription", job.get("jobDesc", ""))
+    if not desc:
+        desc = data.get("jobDesc", "-")
+
+    panel_text = (
+        f"[bold cyan]{title}[/bold cyan]  [yellow]{salary}[/yellow]\n"
+        f"经验: {exp} · 学历: {degree} · 地区: {city}\n"
+        f"技能: {skill_str}\n"
+        f"\n"
+        f"[bold green]公司:[/bold green] {company}\n"
+        f"行业: {industry} · 规模: {scale} · 阶段: {stage}\n"
+        f"\n"
+        f"[bold magenta]招聘者:[/bold magenta] {boss_name} ({boss_title})\n"
+    )
+
+    if desc:
+        if len(desc) > 500:
+            desc = desc[:500] + "..."
+        panel_text += f"\n[bold]职位描述:[/bold]\n{desc}"
+
+    panel = Panel(panel_text, title="📋 职位详情", border_style="cyan")
+    console.print(panel)
+
+
+# ── export ──────────────────────────────────────────────────────────
+
+@click.command()
+@click.argument("keyword")
+@click.option("-c", "--city", default="全国", help="城市名称或代码")
+@click.option("-n", "--count", default=30, type=int, help="导出数量 (默认: 30)")
+@click.option("--salary", type=click.Choice(list(SALARY_CODES.keys())), help="薪资筛选")
+@click.option("--exp", type=click.Choice(list(EXP_CODES.keys())), help="工作经验筛选")
+@click.option("--degree", type=click.Choice(list(DEGREE_CODES.keys())), help="学历筛选")
+@click.option("--industry", type=click.Choice(list(INDUSTRY_CODES.keys())), help="行业筛选")
+@click.option("--scale", type=click.Choice(list(SCALE_CODES.keys())), help="公司规模筛选")
+@click.option("--stage", type=click.Choice(list(STAGE_CODES.keys())), help="融资阶段筛选")
+@click.option("--job-type", type=click.Choice(list(JOB_TYPE_CODES.keys())), help="职位类型")
+@click.option("-o", "--output", "output_file", default=None, help="输出文件路径 (默认: stdout)")
+@click.option("--format", "fmt", type=click.Choice(["csv", "json"]), default="csv", help="输出格式")
+def export(
+    keyword: str, city: str, count: int,
+    salary: str | None, exp: str | None, degree: str | None,
+    industry: str | None, scale: str | None, stage: str | None, job_type: str | None,
+    output_file: str | None, fmt: str,
+) -> None:
+    """导出搜索结果为 CSV 或 JSON
+
+    例: boss export "golang" --city 杭州 -n 50 -o jobs.csv
+    """
+    cred = require_auth()
+
+    city_code = resolve_city(city)
+    salary_code = SALARY_CODES.get(salary) if salary else None
+    exp_code = EXP_CODES.get(exp) if exp else None
+    degree_code = DEGREE_CODES.get(degree) if degree else None
+    industry_code = INDUSTRY_CODES.get(industry) if industry else None
+    scale_code = SCALE_CODES.get(scale) if scale else None
+    stage_code = STAGE_CODES.get(stage) if stage else None
+    job_type_code = JOB_TYPE_CODES.get(job_type) if job_type else None
+
+    all_jobs: list[dict] = []
+    pages_needed = (count + 14) // 15  # 15 per page
+
+    try:
+        def _collect(c: BossClient) -> list[dict]:
+            nonlocal all_jobs
+            for pg in range(1, pages_needed + 1):
+                data = c.search_jobs(
+                    query=keyword, city=city_code, page=pg,
+                    experience=exp_code, degree=degree_code, salary=salary_code,
+                    industry=industry_code, scale=scale_code, stage=stage_code,
+                    job_type=job_type_code,
+                )
+                job_list = data.get("jobList", [])
+                all_jobs.extend(job_list)
+                console.print(f"  [dim]📦 第 {pg} 页: {len(job_list)} 个职位 (累计: {len(all_jobs)})[/dim]")
+
+                if not data.get("hasMore", False) or len(all_jobs) >= count:
+                    break
+            return all_jobs[:count]
+
+        all_jobs = run_client_action(cred, _collect)
+
+        if fmt == "json":
+            output_text = json.dumps(all_jobs, indent=2, ensure_ascii=False)
+        else:
+            # CSV
+            buf = io.StringIO()
+            fieldnames = ["职位", "公司", "薪资", "经验", "学历", "城市", "地区", "技能", "securityId"]
+            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for job in all_jobs:
+                writer.writerow({
+                    "职位": job.get("jobName", ""),
+                    "公司": job.get("brandName", ""),
+                    "薪资": job.get("salaryDesc", ""),
+                    "经验": job.get("jobExperience", ""),
+                    "学历": job.get("jobDegree", ""),
+                    "城市": job.get("cityName", ""),
+                    "地区": job.get("areaDistrict", ""),
+                    "技能": ", ".join(job.get("skills", [])),
+                    "securityId": job.get("securityId", ""),
+                })
+            output_text = buf.getvalue()
+
+        if output_file:
+            with open(output_file, "w", encoding="utf-8-sig" if fmt == "csv" else "utf-8") as f:
+                f.write(output_text)
+            console.print(f"\n[green]✅ 已导出 {len(all_jobs)} 个职位到 {output_file}[/green]")
+        else:
+            click.echo(output_text)
+
+    except BossApiError as exc:
+        console.print(f"[red]❌ 导出失败: {exc}[/red]")
+
+
+# ── history ─────────────────────────────────────────────────────────
+
+@click.command()
+@click.option("-p", "--page", default=1, type=int, help="页码 (默认: 1)")
+@structured_output_options
+def history(page: int, as_json: bool, as_yaml: bool) -> None:
+    """查看浏览历史"""
+    cred = require_auth()
+
+    def _action(c: BossClient) -> dict:
+        return c.get_job_history(page=page)
+
+    def _render(data: dict) -> None:
+        job_list = data.get("jobList", [])
+        _render_job_table(
+            job_list,
+            title=f"📜 浏览历史 (第 {page} 页)",
+            page=page,
+            hint_next=f"更多: boss history -p {page + 1}" if data.get("hasMore") else "",
+        )
+
+    handle_command(cred, action=_action, render=_render, as_json=as_json, as_yaml=as_yaml)
+
+
+# ── cities ──────────────────────────────────────────────────────────
+
+@click.command()
+def cities() -> None:
+    """列出支持的城市代码"""
+    codes = list_cities()
+    table = Table(title="🏙️ 支持的城市", show_lines=False)
+    table.add_column("城市", style="cyan", width=10)
+    table.add_column("代码", style="dim", width=12)
+
+    for name, code in codes.items():
+        table.add_row(name, code)
+
+    console.print(table)
+    console.print(f"\n  [dim]共 {len(codes)} 个城市。使用: boss search \"Python\" --city 杭州[/dim]")

--- a/boss-hub/boss_cli/commands/social.py
+++ b/boss-hub/boss_cli/commands/social.py
@@ -1,0 +1,162 @@
+"""Social commands: chat, greet, batch-greet."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+import click
+from rich.table import Table
+
+from ..client import BossClient, resolve_city
+from ..constants import DEGREE_CODES, EXP_CODES, SALARY_CODES
+from ..exceptions import BossApiError
+from ._common import (
+    console,
+    handle_command,
+    require_auth,
+    structured_output_options,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("chat")
+@structured_output_options
+def chat_list(as_json: bool, as_yaml: bool) -> None:
+    """查看沟通过的 Boss 列表"""
+    cred = require_auth()
+
+    def _render(data: dict) -> None:
+        friend_list = data.get("result", data.get("friendList", []))
+
+        if not friend_list:
+            console.print("[yellow]暂无沟通记录[/yellow]")
+            return
+
+        table = Table(title=f"💬 沟通列表 ({len(friend_list)} 个)", show_lines=True)
+        table.add_column("#", style="dim", width=3)
+        table.add_column("Boss", style="bold cyan", max_width=15)
+        table.add_column("公司", style="green", max_width=20)
+        table.add_column("职位", max_width=25)
+        table.add_column("最近消息", style="dim", max_width=30)
+
+        for i, friend in enumerate(friend_list, 1):
+            table.add_row(
+                str(i),
+                friend.get("name", friend.get("bossName", "-")),
+                friend.get("brandName", "-"),
+                friend.get("jobName", "-"),
+                friend.get("lastMsg", friend.get("lastText", "-")),
+            )
+
+        console.print(table)
+
+    handle_command(cred, action=lambda c: c.get_friend_list(), render=_render, as_json=as_json, as_yaml=as_yaml)
+
+
+@click.command()
+@click.argument("security_id")
+@click.option("--lid", default="", help="Lid parameter from search results")
+@structured_output_options
+def greet(security_id: str, lid: str, as_json: bool, as_yaml: bool) -> None:
+    """向 Boss 打招呼 / 投递简历 (需要 securityId)"""
+    cred = require_auth()
+
+    def _action(c):
+        return c.add_friend(security_id=security_id, lid=lid)
+
+    def _render(data: dict) -> None:
+        console.print("[green]✅ 打招呼成功！[/green]")
+        if data:
+            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+
+    handle_command(cred, action=_action, render=_render, as_json=as_json, as_yaml=as_yaml)
+
+
+@click.command("batch-greet")
+@click.argument("keyword")
+@click.option("-c", "--city", default="全国", help="城市名称或代码")
+@click.option("-n", "--count", default=5, type=int, help="打招呼数量 (默认: 5)")
+@click.option("--salary", type=click.Choice(list(SALARY_CODES.keys())), help="薪资筛选")
+@click.option("--exp", type=click.Choice(list(EXP_CODES.keys())), help="工作经验筛选")
+@click.option("--degree", type=click.Choice(list(DEGREE_CODES.keys())), help="学历筛选")
+@click.option("--dry-run", is_flag=True, help="仅预览，不实际发送")
+@click.option("-y", "--yes", is_flag=True, help="跳过确认提示")
+def batch_greet(keyword: str, city: str, count: int, salary: str | None, exp: str | None, degree: str | None, dry_run: bool, yes: bool) -> None:
+    """批量向搜索结果中的 Boss 打招呼
+
+    例: boss batch-greet "golang" --city 杭州 -n 10 --salary 20-30K
+    """
+    cred = require_auth()
+
+    city_code = resolve_city(city)
+    salary_code = SALARY_CODES.get(salary) if salary else None
+    exp_code = EXP_CODES.get(exp) if exp else None
+    degree_code = DEGREE_CODES.get(degree) if degree else None
+
+    try:
+        with BossClient(cred) as client:
+            # Search for jobs
+            data = client.search_jobs(
+                query=keyword, city=city_code,
+                experience=exp_code, degree=degree_code, salary=salary_code,
+            )
+
+            job_list = data.get("jobList", [])
+            if not job_list:
+                console.print("[yellow]没有找到匹配的职位[/yellow]")
+                return
+
+            targets = job_list[:count]
+
+            # Preview table
+            table = Table(title=f"🎯 将向以下 {len(targets)} 个职位打招呼", show_lines=True)
+            table.add_column("#", style="dim", width=3)
+            table.add_column("职位", style="bold cyan", max_width=25)
+            table.add_column("公司", style="green", max_width=20)
+            table.add_column("薪资", style="yellow", max_width=12)
+
+            for i, job in enumerate(targets, 1):
+                table.add_row(str(i), job.get("jobName", "-"), job.get("brandName", "-"), job.get("salaryDesc", "-"))
+
+            console.print(table)
+
+            if dry_run:
+                console.print("\n  [dim]📋 预览模式，未实际发送[/dim]")
+                return
+
+            if not yes:
+                confirm = click.confirm(f"\n确定向 {len(targets)} 个职位打招呼吗?")
+                if not confirm:
+                    console.print("[dim]已取消[/dim]")
+                    return
+
+            # Send greetings with rate limiting
+            success = 0
+            for i, job in enumerate(targets, 1):
+                security_id = job.get("securityId", "")
+                lid = job.get("lid", "")
+                job_name = job.get("jobName", "?")
+                brand = job.get("brandName", "?")
+
+                if not security_id:
+                    console.print(f"  [{i}] [yellow]跳过 {job_name} (无 securityId)[/yellow]")
+                    continue
+
+                try:
+                    client.add_friend(security_id=security_id, lid=lid)
+                    console.print(f"  [{i}] [green]✅ {job_name} @ {brand}[/green]")
+                    success += 1
+                except BossApiError as e:
+                    console.print(f"  [{i}] [red]❌ {job_name}: {e}[/red]")
+
+                # Explicit rate-limit delay between greetings to avoid detection
+                if i < len(targets):
+                    time.sleep(1.5)
+
+            console.print(f"\n[bold]完成: {success}/{len(targets)} 个打招呼成功[/bold]")
+
+    except BossApiError as exc:
+        console.print(f"[red]❌ 搜索失败: {exc}[/red]")

--- a/boss-hub/boss_cli/constants.py
+++ b/boss-hub/boss_cli/constants.py
@@ -1,0 +1,205 @@
+"""Constants for Boss CLI — API endpoints, headers, and config paths."""
+
+from pathlib import Path
+
+# ── Config ──────────────────────────────────────────────────────────
+CONFIG_DIR = Path.home() / ".config" / "boss-cli"
+CREDENTIAL_FILE = CONFIG_DIR / "credential.json"
+
+# ── Base URL ────────────────────────────────────────────────────────
+BASE_URL = "https://www.zhipin.com"
+
+# ── QR Login API ────────────────────────────────────────────────────
+QR_RANDKEY_URL = "/wapi/zppassport/captcha/randkey"
+QR_CODE_URL = "/wapi/zpweixin/qrcode/getqrcode"
+QR_SCAN_URL = "/wapi/zppassport/qrcode/scan"
+QR_SCAN_LOGIN_URL = "/wapi/zppassport/qrcode/scanLogin"
+QR_DISPATCHER_URL = "/wapi/zppassport/qrcode/dispatcher"
+
+# ── Job API ─────────────────────────────────────────────────────────
+JOB_SEARCH_URL = "/wapi/zpgeek/search/joblist.json"
+JOB_RECOMMEND_URL = "/wapi/zpgeek/pc/recommend/job/list.json"
+JOB_CARD_URL = "/wapi/zpgeek/job/card.json"
+JOB_DETAIL_URL = "/wapi/zpgeek/job/detail.json"
+JOB_HISTORY_URL = "/wapi/zpgeek/history/joblist.json"
+
+# ── Personal Center API ─────────────────────────────────────────────
+USER_INFO_URL = "/wapi/zpuser/wap/getUserInfo.json"
+RESUME_BASEINFO_URL = "/wapi/zpgeek/resume/baseinfo/query.json"
+RESUME_EXPECT_URL = "/wapi/zpgeek/resume/expect/query.json"
+RESUME_STATUS_URL = "/wapi/zpgeek/resume/status.json"
+DELIVER_LIST_URL = "/wapi/zprelation/resume/geekDeliverList"
+INTERVIEW_DATA_URL = "/wapi/zpinterview/geek/interview/data.json"
+
+# ── Social / Chat API ──────────────────────────────────────────────
+FRIEND_LIST_URL = "/wapi/zprelation/friend/getGeekFriendList.json"
+FRIEND_ADD_URL = "/wapi/zpgeek/friend/add.json"
+GEEK_GET_JOB_URL = "/wapi/zprelation/interaction/geekGetJob"
+
+# ── Request Headers (Chrome 145, macOS) ─────────────────────────────
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/145.0.0.0 Safari/537.36"
+    ),
+    "sec-ch-ua": '"Chromium";v="145", "Not(A:Brand";v="99", "Google Chrome";v="145"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-origin",
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    "DNT": "1",
+    "Priority": "u=1, i",
+    "Referer": f"{BASE_URL}/",
+}
+
+# ── Cookie keys required for authenticated sessions ─────────────────
+REQUIRED_COOKIES = {"wt2", "wbg"}
+
+# ── City codes ──────────────────────────────────────────────────────
+CITY_CODES: dict[str, str] = {
+    "全国": "100010000",
+    # 一线
+    "北京": "101010100",
+    "上海": "101020100",
+    "广州": "101280100",
+    "深圳": "101280600",
+    # 新一线
+    "杭州": "101210100",
+    "成都": "101270100",
+    "南京": "101190100",
+    "武汉": "101200100",
+    "西安": "101110100",
+    "苏州": "101190400",
+    "长沙": "101250100",
+    "天津": "101030100",
+    "重庆": "101040100",
+    "郑州": "101180100",
+    "东莞": "101281600",
+    "佛山": "101280800",
+    "合肥": "101220100",
+    "青岛": "101120200",
+    "宁波": "101210400",
+    "沈阳": "101070100",
+    "昆明": "101290100",
+    # 二线
+    "大连": "101070200",
+    "厦门": "101230200",
+    "珠海": "101280700",
+    "无锡": "101190200",
+    "福州": "101230100",
+    "济南": "101120100",
+    "哈尔滨": "101050100",
+    "长春": "101060100",
+    "南昌": "101240100",
+    "贵阳": "101260100",
+    "南宁": "101300100",
+    "石家庄": "101090100",
+    "太原": "101100100",
+    "兰州": "101160100",
+    "海口": "101310100",
+    "常州": "101191100",
+    "温州": "101210700",
+    "嘉兴": "101210300",
+    "徐州": "101190800",
+    # 特别行政区
+    "香港": "101320100",
+}
+
+# ── Salary filter codes ─────────────────────────────────────────────
+SALARY_CODES: dict[str, str] = {
+    "3K以下": "401",
+    "3-5K": "402",
+    "5-10K": "403",
+    "10-15K": "404",
+    "15-20K": "405",
+    "20-30K": "406",
+    "30-50K": "407",
+    "50K以上": "408",
+}
+
+# ── Experience filter codes ─────────────────────────────────────────
+EXP_CODES: dict[str, str] = {
+    "不限": "0",
+    "在校/应届": "108",
+    "1年以内": "101",
+    "1-3年": "102",
+    "3-5年": "103",
+    "5-10年": "104",
+    "10年以上": "105",
+}
+
+# ── Degree filter codes ─────────────────────────────────────────────
+DEGREE_CODES: dict[str, str] = {
+    "不限": "0",
+    "初中及以下": "209",
+    "中专/中技": "208",
+    "高中": "206",
+    "大专": "202",
+    "本科": "203",
+    "硕士": "204",
+    "博士": "205",
+}
+
+# ── Industry filter codes ──────────────────────────────────────────
+INDUSTRY_CODES: dict[str, str] = {
+    "不限": "0",
+    "互联网": "100020",
+    "电子商务": "100021",
+    "游戏": "100024",
+    "软件/信息服务": "100032",
+    "人工智能": "100901",
+    "大数据": "100902",
+    "云计算": "100903",
+    "区块链": "100904",
+    "物联网": "100905",
+    "金融": "100101",
+    "银行": "100102",
+    "保险": "100103",
+    "证券/基金": "100104",
+    "教育培训": "100200",
+    "医疗健康": "100300",
+    "房地产": "100400",
+    "汽车": "100500",
+    "物流/运输": "100600",
+    "广告/传媒": "100700",
+    "消费品": "100800",
+    "制造业": "101000",
+    "能源/环保": "101100",
+    "政府/非营利": "101200",
+    "农业": "101300",
+}
+
+# ── Company scale filter codes ─────────────────────────────────────
+SCALE_CODES: dict[str, str] = {
+    "不限": "0",
+    "0-20人": "301",
+    "20-99人": "302",
+    "100-499人": "303",
+    "500-999人": "304",
+    "1000-9999人": "305",
+    "10000人以上": "306",
+}
+
+# ── Company stage (funding) filter codes ───────────────────────────
+STAGE_CODES: dict[str, str] = {
+    "不限": "0",
+    "未融资": "801",
+    "天使轮": "802",
+    "A轮": "803",
+    "B轮": "804",
+    "C轮": "805",
+    "D轮及以上": "806",
+    "已上市": "807",
+    "不需要融资": "808",
+}
+
+# ── Job type filter codes ──────────────────────────────────────────
+JOB_TYPE_CODES: dict[str, str] = {
+    "全职": "1901",
+    "兼职": "1903",
+    "实习": "1903",
+}

--- a/boss-hub/boss_cli/exceptions.py
+++ b/boss-hub/boss_cli/exceptions.py
@@ -1,0 +1,57 @@
+"""Custom exceptions for Boss CLI API client."""
+
+from __future__ import annotations
+
+
+
+class BossApiError(Exception):
+    """Base exception for Boss Zhipin API errors."""
+
+    def __init__(self, message: str, code: int | str | None = None, response: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.response = response
+
+
+class SessionExpiredError(BossApiError):
+    """Raised when __zp_stoken__ has expired (code=37)."""
+
+    def __init__(self):
+        super().__init__(
+            "环境异常 (__zp_stoken__ 已过期)。请重新登录: boss logout && boss login",
+            code=37,
+        )
+
+
+class AuthRequiredError(BossApiError):
+    """Raised when user is not logged in."""
+
+    def __init__(self):
+        super().__init__("未登录，请先使用 boss login 扫码登录")
+
+
+class ParamError(BossApiError):
+    """Raised when API reports missing or invalid parameters."""
+
+    def __init__(self, message: str, code: int | None = None):
+        super().__init__(f"参数错误: {message}", code=code)
+
+
+class RateLimitError(BossApiError):
+    """Raised when too many requests are made."""
+
+    def __init__(self):
+        super().__init__("请求过于频繁，请稍后再试")
+
+
+def error_code_for_exception(exc: Exception) -> str:
+    """Map domain exceptions to stable error code strings."""
+    if isinstance(exc, (AuthRequiredError, SessionExpiredError)):
+        return "not_authenticated"
+    if isinstance(exc, RateLimitError):
+        return "rate_limited"
+    if isinstance(exc, ParamError):
+        return "invalid_params"
+    if isinstance(exc, BossApiError):
+        return "api_error"
+    return "unknown_error"

--- a/boss-hub/boss_cli/index_cache.py
+++ b/boss-hub/boss_cli/index_cache.py
@@ -1,0 +1,100 @@
+"""Search result index cache for short-index navigation.
+
+Stores the last search/recommend result set so that users can quickly
+access a job by its 1-based index number (e.g., `boss show 3`).
+
+Cache file: ~/.config/boss-cli/index_cache.json
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from .constants import CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+INDEX_CACHE_FILE = CONFIG_DIR / "index_cache.json"
+
+
+def save_index(jobs: list[dict[str, Any]], source: str = "search") -> None:
+    """Persist an ordered list of jobs for short-index navigation.
+
+    Each entry stores the minimum metadata needed for `show` and `detail`:
+    securityId, jobName, brandName, salaryDesc, lid.
+    """
+    if not jobs:
+        return
+
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    entries = []
+    for job in jobs:
+        entry = {
+            "securityId": job.get("securityId", ""),
+            "jobName": job.get("jobName", ""),
+            "brandName": job.get("brandName", ""),
+            "salaryDesc": job.get("salaryDesc", ""),
+            "cityName": job.get("cityName", ""),
+            "areaDistrict": job.get("areaDistrict", ""),
+            "jobExperience": job.get("jobExperience", ""),
+            "jobDegree": job.get("jobDegree", ""),
+            "skills": job.get("skills", []),
+            "lid": job.get("lid", ""),
+        }
+        if entry["securityId"]:
+            entries.append(entry)
+
+    payload = {
+        "source": source,
+        "saved_at": time.time(),
+        "count": len(entries),
+        "items": entries,
+    }
+
+    INDEX_CACHE_FILE.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    INDEX_CACHE_FILE.chmod(0o600)
+    logger.debug("Saved index cache with %d entries from %s", len(entries), source)
+
+
+def get_job_by_index(index: int) -> dict[str, Any] | None:
+    """Resolve a 1-based short index to a cached job reference.
+
+    Returns the job entry dict or None if index is out of range.
+    """
+    if index <= 0:
+        return None
+
+    if not INDEX_CACHE_FILE.exists():
+        return None
+
+    try:
+        data = json.loads(INDEX_CACHE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    items = data.get("items", [])
+    if index > len(items):
+        return None
+
+    return items[index - 1]
+
+
+def get_index_info() -> dict[str, Any]:
+    """Get metadata about the current index cache."""
+    if not INDEX_CACHE_FILE.exists():
+        return {"exists": False, "count": 0}
+
+    try:
+        data = json.loads(INDEX_CACHE_FILE.read_text())
+        return {
+            "exists": True,
+            "source": data.get("source", "unknown"),
+            "count": data.get("count", 0),
+            "saved_at": data.get("saved_at", 0),
+        }
+    except (OSError, json.JSONDecodeError):
+        return {"exists": False, "count": 0}

--- a/boss-hub/pyproject.toml
+++ b/boss-hub/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "boss-hub"
+version = "0.1.0"
+description = "BOSS 直聘 CLI — 搜索职位、推荐、投递、打招呼"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+dependencies = [
+    "click>=8.0",
+    "rich>=13.0",
+    "httpx>=0.27",
+    "qrcode>=7.0",
+]
+
+[project.scripts]
+boss = "boss_cli.cli:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["boss_cli"]


### PR DESCRIPTION
## 中文说明
新增 `boss-hub` 技能，用于在 Minis 中通过 Python + UV 操作 BOSS 直聘。

本 PR 主要内容：
- 支持搜索职位、推荐职位、查看已投递、查看面试邀请、查看沟通过 Boss
- 支持单个 / 批量打招呼
- 环境变量认证：`BOSS_COOKIE` 或 `BOSS_WT2` + `BOSS_WBG`
- 移除 `browser-cookie3` 依赖，更适合 Minis 环境
- 保留原项目的限速、重试、反风控能力

## English Summary
This PR adds a new `boss-hub` skill for BOSS Zhipin automation in Minis.

It supports job search, recommendations, applied jobs, interviews, chat list, and greetings.
Authentication is handled via environment variables instead of browser cookie extraction, which makes it fit better in Minis.