### PR TITLE
feat(weibo-hub): add Weibo skill with httpx-only dependency

### DIFF
--- a/weibo-hub/SKILL.md
+++ b/weibo-hub/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: weibo-hub
+description: >
+  使用 Python + UV 读写微博（Weibo）数据的技能，仅依赖 httpx，通过 browser_use get_cookies
+  自动获取 Cookie 完成认证，无需手动复制。支持热搜榜、热门 Feed、关注 Feed、关键词搜索、
+  微博详情/评论/转发、用户资料/微博/关注/粉丝列表等。
+  当用户提到"微博"、"weibo"、"weibo-hub"、"微博热搜"、"抓取微博"、"搜索微博"、
+  "微博评论"、"微博用户"，或任何需要以编程方式读写微博数据的场景，必须触发本技能。
+---
+
+# weibo-hub
+
+> **改造来源**：[jackwener/weibo-cli](https://github.com/jackwener/weibo-cli)（Apache-2.0）
+>
+> 本技能在原仓库基础上做了以下精简：
+> - **移除** `click` / `rich` / `browser-cookie3` / `qrcode` / `pyyaml` 依赖
+> - **仅保留** `httpx` 一个第三方依赖
+> - **移除** CLI 层，所有功能封装为同步 Python API
+> - **认证改为** `browser_use get_cookies` 提取 → 调用 `setup_credential()` 保存
+> - 数据目录改为 `/var/minis/workspace/weibo-hub/`
+
+---
+
+## 文件结构
+
+```
+/var/minis/skills/weibo-hub/
+├── SKILL.md
+├── pyproject.toml          # 仅 httpx
+└── scripts/
+    ├── __init__.py
+    ├── constants.py        # API 端点、Headers、路径常量
+    ├── exceptions.py       # WeiboError 异常体系
+    ├── auth.py             # Credential 持久化（无 browser-cookie3）
+    └── client.py           # WeiboClient 核心类（全部 API）
+```
+
+---
+
+## 认证流程（每次使用前检查）
+
+weibo-hub 使用 **浏览器 Cookie 认证**，通过 `browser_use get_cookies` 从 weibo.com 提取，
+无需 `browser-cookie3`，无需 QR 扫码。
+
+### Step 1：用 browser_use 提取 Cookie
+
+```python
+# 在 agent 中调用：
+browser_use(action="navigate", url="https://weibo.com")
+# 确保已登录后：
+browser_use(action="get_cookies", url="https://weibo.com")
+# 将返回的 offload env 文件路径记录下来
+```
+
+### Step 2：从 env 文件读取并保存凭证
+
+```python
+import sys, os, subprocess, json
+
+# 加载 Cookie 环境变量（路径来自 get_cookies 返回的 offload 文件）
+env_file = "/var/minis/offloads/env_cookies_xxx.sh"   # 替换为实际路径
+result = subprocess.run(
+    f". {env_file} && python3 -c \"import os,json; print(json.dumps(dict(os.environ)))\"",
+    shell=True, capture_output=True, text=True
+)
+env = json.loads(result.stdout)
+
+# 解析出 Cookie 字典（COOKIE_ 前缀变量）
+cookies = {
+    k[len("COOKIE_"):]: v
+    for k, v in env.items()
+    if k.startswith("COOKIE_")
+}
+
+# 保存凭证
+sys.path.insert(0, "/var/minis/skills/weibo-hub")
+from scripts.client import WeiboClient
+WeiboClient.setup_credential(cookies)
+```
+
+> **关键 Cookie**：`SUB`、`SUBP`（必须），其余越多越好。
+> 凭证保存到 `/var/minis/workspace/weibo-hub/credential.json`，有效期 7 天，到期自动提示。
+
+---
+
+## 环境准备
+
+```bash
+cd /var/minis/skills/weibo-hub
+uv sync
+```
+
+---
+
+## 快速使用
+
+```python
+import sys
+sys.path.insert(0, "/var/minis/skills/weibo-hub")
+from scripts.client import WeiboClient
+
+with WeiboClient() as client:
+
+    # ── 热搜 / 趋势（无需登录）──────────────────────────────
+    topics = client.hot_search()          # 热搜榜（~52 条）
+    for t in topics[:10]:
+        print(f"#{t.get('realtime_hot_show_label','')} {t.get('word','')}")
+
+    band = client.hot_band()              # 完整热搜榜
+    trends = client.trending()            # 实时搜索推荐词
+
+    # ── Feed（热门无需登录，关注需登录）─────────────────────
+    hot = client.hot_feed(count=10)       # 热门时间线
+    home = client.home_feed(count=20)     # 关注者时间线
+
+    # ── 搜索（移动端 API）────────────────────────────────────
+    results = client.search("人工智能", page=1)
+    for w in results[:5]:
+        print(w.get("text", "")[:80])
+
+    # ── 微博详情 / 评论 / 转发（需要登录）──────────────────
+    wb = client.detail("Qw06Kd98p")
+    cmt = client.comments("微博ID", count=20)
+    rep = client.reposts("微博ID", count=10)
+
+    # ── 用户（需要登录）─────────────────────────────────────
+    me = client.me()                      # 当前登录用户
+    user = client.profile("1699432410")   # 指定用户资料
+    weibos = client.user_weibos("1699432410", page=1)
+    following = client.following("1699432410", page=1)
+    followers = client.followers("1699432410", page=1)
+```
+
+---
+
+## API 速查
+
+### 无需登录（公开接口）
+
+| 方法 | 说明 |
+|------|------|
+| `hot_search()` | 热搜榜 sidebar（~52 条） |
+| `hot_band()` | 完整热搜榜 |
+| `trending()` | 实时搜索推荐词 |
+| `hot_feed(count, max_id)` | 热门时间线 |
+| `search(keyword, page)` | 关键词搜索微博 |
+
+### 需要登录（Cookie 认证）
+
+| 方法 | 说明 |
+|------|------|
+| `me()` | 当前登录用户信息 |
+| `home_feed(count, max_id)` | 关注者时间线 |
+| `detail(mblogid)` | 单条微博详情 |
+| `comments(weibo_id, count, max_id)` | 微博评论列表 |
+| `reposts(weibo_id, page, count)` | 微博转发列表 |
+| `profile(uid)` | 用户资料 |
+| `user_weibos(uid, page, count)` | 用户微博列表 |
+| `following(uid, page)` | 用户关注列表 |
+| `followers(uid, page)` | 用户粉丝列表 |
+
+### 认证
+
+| 方法 | 说明 |
+|------|------|
+| `WeiboClient.setup_credential(cookies)` | 保存 Cookie 凭证（静态方法） |
+
+---
+
+## 反风控说明
+
+与上游 weibo-cli 保持一致：
+- **Gaussian 抖动**：每次请求间隔 = `request_delay + gauss(0.3, 0.15)`，约 1s
+- **5% 长停顿**：随机触发 2–5s 额外延迟，模拟阅读行为
+- **指数退避**：HTTP 429/5xx 最多重试 3 次，等待时间 2^n 秒
+- **Chrome 145 UA**：桌面端 User-Agent，与浏览器指纹一致
+
+---
+
+## 注意事项
+
+- 首次使用必须先调用 `WeiboClient.setup_credential(cookies)` 保存凭证
+- 凭证文件：`/var/minis/workspace/weibo-hub/credential.json`，权限 0600
+- 必要 Cookie：`SUB` + `SUBP`，缺失时 `setup_credential()` 会抛出 `ValueError`
+- Cookie 7 天后自动提示过期，需重新提取
+- 热搜/热门 Feed/搜索无需登录，profile/detail/home_feed 等需要有效 Cookie
+- `search()` 使用移动端 API（`m.weibo.cn`），结果格式略有不同

--- a/weibo-hub/pyproject.toml
+++ b/weibo-hub/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "weibo-hub"
+version = "0.1.0"
+description = "Lightweight Weibo skill for Minis — httpx only, no CLI layer"
+requires-python = ">=3.10"
+dependencies = [
+    "httpx>=0.27",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scripts"]

--- a/weibo-hub/scripts/__init__.py
+++ b/weibo-hub/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""weibo-hub scripts package."""

--- a/weibo-hub/scripts/auth.py
+++ b/weibo-hub/scripts/auth.py
@@ -1,0 +1,97 @@
+"""Credential management for weibo-hub.
+
+Auth strategy (no browser-cookie3, no QR code):
+  1. Load saved credential from /var/minis/workspace/weibo-hub/credential.json
+  2. If missing/expired, agent calls setup_credential(cookies_dict) with cookies
+     obtained via browser_use get_cookies on weibo.com.
+  3. Credential persisted with 7-day TTL; auto-warns when stale.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from .constants import CREDENTIAL_FILE, CREDENTIAL_TTL_DAYS, DATA_DIR, REQUIRED_COOKIES
+from .exceptions import AuthRequiredError
+
+
+# ── Credential ────────────────────────────────────────────────────────
+
+class Credential:
+    """Holds Weibo session cookies."""
+
+    def __init__(self, cookies: dict[str, str]):
+        self.cookies = cookies
+
+    @property
+    def is_valid(self) -> bool:
+        return bool(self.cookies) and bool(REQUIRED_COOKIES & set(self.cookies))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"cookies": self.cookies, "saved_at": time.time()}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Credential":
+        return cls(cookies=data.get("cookies", {}))
+
+    def as_cookie_header(self) -> str:
+        return "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+
+
+# ── Persistence ───────────────────────────────────────────────────────
+
+def save_credential(credential: Credential) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    CREDENTIAL_FILE.write_text(json.dumps(credential.to_dict(), indent=2, ensure_ascii=False))
+    CREDENTIAL_FILE.chmod(0o600)
+
+
+def load_credential() -> Credential | None:
+    """Load credential from disk; warn if older than TTL."""
+    if not CREDENTIAL_FILE.exists():
+        return None
+    try:
+        data = json.loads(CREDENTIAL_FILE.read_text())
+        cred = Credential.from_dict(data)
+        if not cred.is_valid:
+            return None
+        saved_at = data.get("saved_at", 0)
+        age_days = (time.time() - saved_at) / 86400
+        if age_days > CREDENTIAL_TTL_DAYS:
+            print(
+                f"[weibo-hub] ⚠️  凭证已存储 {age_days:.0f} 天（TTL={CREDENTIAL_TTL_DAYS}天），"
+                "建议重新调用 setup_credential() 刷新"
+            )
+        return cred
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def clear_credential() -> None:
+    if CREDENTIAL_FILE.exists():
+        CREDENTIAL_FILE.unlink()
+
+
+def setup_credential(cookies: dict[str, str]) -> Credential:
+    """Create and persist a Credential from a cookies dict.
+
+    Typically called by the agent after browser_use get_cookies on weibo.com:
+
+        cookies = {"SUB": "...", "SUBP": "...", ...}
+        cred = setup_credential(cookies)
+
+    Returns the saved Credential.
+    """
+    cred = Credential(cookies=cookies)
+    if not cred.is_valid:
+        missing = REQUIRED_COOKIES - set(cookies)
+        raise ValueError(
+            f"Cookie 不完整，缺少必要字段: {missing}。"
+            "请在浏览器中登录 weibo.com 后重新提取。"
+        )
+    save_credential(cred)
+    print(f"[weibo-hub] ✅ 凭证已保存（{len(cookies)} 个 Cookie），有效期 {CREDENTIAL_TTL_DAYS} 天")
+    return cred

--- a/weibo-hub/scripts/client.py
+++ b/weibo-hub/scripts/client.py
@@ -1,0 +1,335 @@
+"""WeiboClient — core API client for weibo-hub.
+
+Only dependency: httpx.
+Anti-detection: Gaussian jitter + 5% long pause + exponential backoff (same as upstream).
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Any
+
+import httpx
+
+from .auth import Credential, load_credential, setup_credential
+from .constants import (
+    BASE_URL,
+    BUILD_COMMENTS_URL,
+    FEED_GROUPS_URL,
+    FRIENDS_TIMELINE_URL,
+    FRIENDS_URL,
+    GET_CONFIG_URL,
+    HEADERS,
+    HOT_BAND_URL,
+    HOT_SEARCH_URL,
+    HOT_TIMELINE_URL,
+    MOBILE_BASE_URL,
+    MOBILE_HEADERS,
+    MOBILE_SEARCH_URL,
+    MY_MBLOG_URL,
+    PROFILE_INFO_URL,
+    REPOST_TIMELINE_URL,
+    SEARCH_BAND_URL,
+    STATUSES_SHOW_URL,
+)
+from .exceptions import AuthRequiredError, SessionExpiredError, WeiboError
+
+logger = logging.getLogger(__name__)
+
+_SESSION_EXPIRED_KEYWORDS = ("请先登录", "请登录后使用", "请登录", "用户未登录")
+
+
+class WeiboClient:
+    """Weibo API client — httpx only, no CLI layer.
+
+    Usage (context manager):
+        with WeiboClient() as client:
+            topics = client.hot_search()
+
+    Usage (manual):
+        client = WeiboClient()
+        client.open()
+        topics = client.hot_search()
+        client.close()
+
+    Auth:
+        # First time: get cookies via browser_use get_cookies on weibo.com, then:
+        WeiboClient.setup_credential({"SUB": "...", "SUBP": "...", ...})
+        # Subsequent calls: credential auto-loaded from disk.
+    """
+
+    # ── Static auth helper (delegate to auth module) ──────────────────
+    @staticmethod
+    def setup_credential(cookies: dict[str, str]) -> Credential:
+        """Persist cookies obtained from browser_use get_cookies."""
+        return setup_credential(cookies)
+
+    # ── Init ──────────────────────────────────────────────────────────
+
+    def __init__(
+        self,
+        credential: Credential | None = None,
+        *,
+        timeout: float = 30.0,
+        request_delay: float = 1.0,
+        max_retries: int = 3,
+    ):
+        self._credential = credential or load_credential()
+        self._timeout = timeout
+        self._request_delay = request_delay
+        self._max_retries = max_retries
+        self._last_request_time: float = 0.0
+        self._http: httpx.Client | None = None
+
+    # ── Lifecycle ─────────────────────────────────────────────────────
+
+    def _build_client(self) -> httpx.Client:
+        cookies = self._credential.cookies if self._credential else {}
+        return httpx.Client(
+            base_url=BASE_URL,
+            headers=dict(HEADERS),
+            cookies=cookies,
+            follow_redirects=True,
+            timeout=httpx.Timeout(self._timeout),
+        )
+
+    def open(self) -> "WeiboClient":
+        self._http = self._build_client()
+        return self
+
+    def close(self) -> None:
+        if self._http:
+            self._http.close()
+            self._http = None
+
+    def __enter__(self) -> "WeiboClient":
+        return self.open()
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    @property
+    def _client(self) -> httpx.Client:
+        if not self._http:
+            raise RuntimeError("Client not open. Use 'with WeiboClient() as c:' or call c.open() first.")
+        return self._http
+
+    # ── Rate limiting ─────────────────────────────────────────────────
+
+    def _rate_limit(self) -> None:
+        if self._request_delay <= 0:
+            return
+        elapsed = time.time() - self._last_request_time
+        if elapsed < self._request_delay:
+            jitter = max(0.0, random.gauss(0.3, 0.15))
+            if random.random() < 0.05:
+                jitter += random.uniform(2.0, 5.0)
+            time.sleep(self._request_delay - elapsed + jitter)
+        self._last_request_time = time.time()
+
+    # ── Response handling ─────────────────────────────────────────────
+
+    def _check(self, data: dict[str, Any], action: str, *, unwrap: bool = True) -> dict[str, Any]:
+        ok = data.get("ok")
+        if ok == -100:
+            raise SessionExpiredError()
+        msg = str(data.get("msg", data.get("message", "")))
+        if ok == 0:
+            if any(kw in msg for kw in _SESSION_EXPIRED_KEYWORDS):
+                raise SessionExpiredError()
+            raise WeiboError(f"{action}: {msg}", code=ok)
+        if ok:
+            return data.get("data", data) if unwrap else data
+        raise WeiboError(f"{action}: unexpected ok={ok} msg={msg}", code=ok)
+
+    # ── Low-level request ─────────────────────────────────────────────
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        client: httpx.Client | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self._rate_limit()
+        http = client or self._client
+        last_exc: Exception | None = None
+
+        for attempt in range(self._max_retries):
+            try:
+                resp = http.request(method, url, **kwargs)
+                if client is None:
+                    # Merge response cookies back into main session
+                    for k, v in resp.cookies.items():
+                        if v:
+                            self._client.cookies.set(k, v)
+
+                if resp.status_code in (429, 500, 502, 503, 504):
+                    wait = 2 ** attempt + random.uniform(0, 1)
+                    logger.warning("HTTP %d — retry %d/%d in %.1fs", resp.status_code, attempt + 1, self._max_retries, wait)
+                    time.sleep(wait)
+                    continue
+
+                resp.raise_for_status()
+                if resp.text.startswith("<"):
+                    raise WeiboError(f"Got HTML instead of JSON from {url} — session may have expired")
+                return resp.json()
+
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                last_exc = exc
+                time.sleep(2 ** attempt + random.uniform(0, 1))
+
+        raise WeiboError(f"Request failed after {self._max_retries} retries: {last_exc}")
+
+    def _get(self, url: str, params: dict | None = None, action: str = "", *, unwrap: bool = True) -> dict[str, Any]:
+        data = self._request("GET", url, params=params)
+        return self._check(data, action, unwrap=unwrap)
+
+    # ── Public API ────────────────────────────────────────────────────
+    # Hot / Trending
+
+    def hot_search(self) -> list[dict]:
+        """热搜榜（sidebar，~52 条，无需登录）。"""
+        data = self._get(HOT_SEARCH_URL, action="热搜")
+        return data.get("realtime", [])
+
+    def hot_band(self) -> list[dict]:
+        """完整热搜榜（无需登录）。"""
+        data = self._get(HOT_BAND_URL, action="热搜榜")
+        return data.get("band_list", [])
+
+    def trending(self) -> list[dict]:
+        """实时搜索推荐词（无需登录）。"""
+        data = self._get(SEARCH_BAND_URL, action="搜索推荐")
+        return data.get("bands", [])
+
+    # Feed
+
+    def hot_feed(self, count: int = 10, max_id: str = "0") -> list[dict]:
+        """热门时间线（无需登录）。"""
+        data = self._get(
+            HOT_TIMELINE_URL,
+            params={
+                "since_id": "0", "refresh": "0",
+                "group_id": "102803", "containerid": "102803",
+                "extparam": "discover|new_feed",
+                "max_id": max_id, "count": str(count),
+            },
+            action="热门Feed",
+            unwrap=False,
+        )
+        return data.get("data", {}).get("statuses", [])
+
+    def home_feed(self, count: int = 20, max_id: str = "0") -> list[dict]:
+        """关注者时间线（需要登录）。"""
+        data = self._get(
+            FRIENDS_TIMELINE_URL,
+            params={"count": str(count), "max_id": max_id},
+            action="关注Feed",
+            unwrap=False,
+        )
+        return data.get("statuses", [])
+
+    # Search
+
+    def search(self, keyword: str, page: int = 1) -> list[dict]:
+        """按关键词搜索微博（使用移动端 API）。"""
+        params = {
+            "containerid": f"100103type=1&q={keyword}",
+            "page_type": "searchall",
+            "page": str(page),
+        }
+        with httpx.Client(
+            base_url=MOBILE_BASE_URL,
+            headers=dict(MOBILE_HEADERS),
+            cookies=self._credential.cookies if self._credential else {},
+            follow_redirects=True,
+            timeout=httpx.Timeout(self._timeout),
+        ) as mob:
+            raw = self._request("GET", MOBILE_SEARCH_URL, client=mob, params=params)
+        # Extract card list
+        cards = raw.get("data", {}).get("cards", [])
+        results = []
+        for card in cards:
+            if card.get("card_type") == 9:
+                mblog = card.get("mblog")
+                if mblog:
+                    results.append(mblog)
+        return results
+
+    # Weibo detail / comments / reposts
+
+    def detail(self, mblogid: str) -> dict:
+        """单条微博详情（需要登录）。"""
+        return self._get(STATUSES_SHOW_URL, params={"id": mblogid}, action="微博详情", unwrap=False)
+
+    def comments(self, weibo_id: str, count: int = 20, max_id: int = 0) -> list[dict]:
+        """微博评论列表。"""
+        params: dict[str, Any] = {
+            "id": weibo_id, "is_show_bulletin": "2",
+            "count": str(count), "flow": "0",
+        }
+        if max_id:
+            params["max_id"] = str(max_id)
+        data = self._get(BUILD_COMMENTS_URL, params=params, action="评论")
+        return data.get("data", [])
+
+    def reposts(self, weibo_id: str, page: int = 1, count: int = 10) -> list[dict]:
+        """微博转发列表。"""
+        data = self._get(
+            REPOST_TIMELINE_URL,
+            params={"id": weibo_id, "page": str(page), "count": str(count)},
+            action="转发",
+            unwrap=False,
+        )
+        return data.get("statuses", [])
+
+    # User
+
+    def profile(self, uid: str) -> dict:
+        """用户资料（需要登录）。"""
+        return self._get(PROFILE_INFO_URL, params={"uid": uid}, action="用户资料")
+
+    def user_weibos(self, uid: str, page: int = 1, count: int = 20) -> list[dict]:
+        """用户微博列表（需要登录）。"""
+        data = self._get(MY_MBLOG_URL, params={"uid": uid, "page": str(page)}, action="用户微博")
+        return data.get("list", [])
+
+    def following(self, uid: str, page: int = 1) -> list[dict]:
+        """用户关注列表（需要登录）。"""
+        data = self._get(FRIENDS_URL, params={"uid": uid, "page": str(page)}, action="关注列表", unwrap=False)
+        return data.get("users", [])
+
+    def followers(self, uid: str, page: int = 1) -> list[dict]:
+        """用户粉丝列表（需要登录）。"""
+        data = self._get(
+            FRIENDS_URL,
+            params={"uid": uid, "page": str(page), "relate": "fans"},
+            action="粉丝列表",
+            unwrap=False,
+        )
+        return data.get("users", [])
+
+    # Me
+
+    def me(self) -> dict:
+        """当前登录用户信息（需要登录）。
+        
+        先通过移动端 /api/config 拿 uid，再调 profile() 返回完整用户资料。
+        """
+        cookies = self._credential.cookies if self._credential else {}
+        with httpx.Client(
+            base_url=MOBILE_BASE_URL,
+            headers=dict(MOBILE_HEADERS),
+            cookies=cookies,
+            follow_redirects=True,
+            timeout=httpx.Timeout(self._timeout),
+        ) as mob:
+            raw = self._request("GET", "/api/config", client=mob)
+        uid = str(raw.get("data", {}).get("uid", ""))
+        if not uid:
+            raise AuthRequiredError()
+        return self.profile(uid)

--- a/weibo-hub/scripts/constants.py
+++ b/weibo-hub/scripts/constants.py
@@ -1,0 +1,65 @@
+"""Constants for weibo-hub — API endpoints, headers, config paths."""
+
+from pathlib import Path
+
+# ── Config ───────────────────────────────────────────────────────────
+DATA_DIR = Path("/var/minis/workspace/weibo-hub")
+CREDENTIAL_FILE = DATA_DIR / "credential.json"
+CREDENTIAL_TTL_DAYS = 7
+
+# ── Base URLs ────────────────────────────────────────────────────────
+BASE_URL = "https://weibo.com"
+MOBILE_BASE_URL = "https://m.weibo.cn"
+
+# ── API Endpoints ────────────────────────────────────────────────────
+# Public (no auth required)
+HOT_SEARCH_URL = "/ajax/side/hotSearch"
+HOT_BAND_URL = "/ajax/statuses/hot_band"
+SEARCH_BAND_URL = "/ajax/side/searchBand"
+HOT_TIMELINE_URL = "/ajax/feed/hottimeline"
+FEED_GROUPS_URL = "/ajax/feed/allGroups"
+
+# Auth required
+FRIENDS_TIMELINE_URL = "/ajax/feed/friendstimeline"
+PROFILE_INFO_URL = "/ajax/profile/info"
+MY_MBLOG_URL = "/ajax/statuses/mymblog"
+STATUSES_SHOW_URL = "/ajax/statuses/show"
+BUILD_COMMENTS_URL = "/ajax/statuses/buildComments"
+REPOST_TIMELINE_URL = "/ajax/statuses/repostTimeline"
+FRIENDS_URL = "/ajax/friendships/friends"
+GET_CONFIG_URL = "/ajax/config/get_config"
+
+# Mobile search
+MOBILE_SEARCH_URL = "/api/container/getIndex"
+
+# ── Request Headers (Chrome 145, macOS) ──────────────────────────────
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/145.0.0.0 Safari/537.36"
+    ),
+    "sec-ch-ua": '"Not:A-Brand";v="99", "Google Chrome";v="145", "Chromium";v="145"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-origin",
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    "Referer": f"{BASE_URL}/",
+}
+
+MOBILE_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 "
+        "Mobile/15E148 Safari/604.1"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Referer": f"{MOBILE_BASE_URL}/",
+    "X-Requested-With": "XMLHttpRequest",
+}
+
+# ── Response codes ────────────────────────────────────────────────────
+REQUIRED_COOKIES = {"SUB", "SUBP"}

--- a/weibo-hub/scripts/exceptions.py
+++ b/weibo-hub/scripts/exceptions.py
@@ -1,0 +1,32 @@
+"""Custom exceptions for weibo-hub."""
+
+from __future__ import annotations
+
+
+class WeiboError(Exception):
+    """Base exception for all Weibo API errors."""
+
+    def __init__(self, message: str, code: int | str | None = None):
+        super().__init__(message)
+        self.code = code
+
+
+class SessionExpiredError(WeiboError):
+    """Session cookies have expired — re-run auth."""
+
+    def __init__(self):
+        super().__init__("会话已过期，请重新认证（调用 WeiboClient.setup_credential()）", code="session_expired")
+
+
+class AuthRequiredError(WeiboError):
+    """No credential found."""
+
+    def __init__(self):
+        super().__init__("未找到凭证，请先调用 WeiboClient.setup_credential()", code="not_authenticated")
+
+
+class RateLimitError(WeiboError):
+    """Too many requests."""
+
+    def __init__(self):
+        super().__init__("请求过于频繁，请稍后再试", code="rate_limited")

--- a/weibo-hub/uv.lock
+++ b/weibo-hub/uv.lock
@@ -1,0 +1,104 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "weibo-hub"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "httpx", specifier = ">=0.27" }]


### PR DESCRIPTION
## weibo-hub

Lightweight Weibo skill adapted from [jackwener/weibo-cli](https://github.com/jackwener/weibo-cli) (Apache-2.0).

### What's changed from upstream

| | upstream weibo-cli | weibo-hub |
|---|---|---|
| `click` | ✅ | ❌ removed |
| `rich` | ✅ | ❌ removed |
| `browser-cookie3` | ✅ | ❌ removed |
| `qrcode` | ✅ | ❌ removed |
| `pyyaml` | ✅ | ❌ removed |
| `httpx` | ✅ | ✅ **only dependency** |

### Auth

Replaces `browser-cookie3` with `browser_use get_cookies` — extracts Weibo cookies from Minis built-in browser, no desktop browser access needed.

```python
WeiboClient.setup_credential({"SUB": "...", "SUBP": "..."})
```

### API

```python
with WeiboClient() as client:
    client.hot_search()       # 热搜榜（no auth）
    client.hot_band()         # 完整热搜榜（no auth）
    client.trending()         # 搜索推荐词（no auth）
    client.hot_feed(count=10) # 热门 Feed（no auth）
    client.search("AI")       # 关键词搜索（no auth）
    client.me()               # 当前用户
    client.home_feed()        # 关注 Feed
    client.detail(mblogid)    # 微博详情
    client.comments(id)       # 评论
    client.reposts(id)        # 转发
    client.profile(uid)       # 用户资料
    client.user_weibos(uid)   # 用户微博列表
    client.following(uid)     # 关注列表
    client.followers(uid)     # 粉丝列表
```

### Anti-detection

Inherits upstream strategy: Gaussian jitter (~1s) + 5% long pause + exponential backoff on 429/5xx.