### PR TITLE
feat: add github-sync-helper (git basics + GitHub API ops)

### DIFF
--- a/github-sync-helper/SKILL.md
+++ b/github-sync-helper/SKILL.md
@@ -12,6 +12,7 @@ compatibility: >
 
 1) 清晰的命令速查（解释 + 何时用）
 2) 可执行的一键脚本（避免重复手工步骤）
+3) 常用输出尽量“带编号”，方便你直接回复编号选择（例如：仓库列表）
 
 ## 安全与约束（必须遵守）
 
@@ -106,13 +107,52 @@ sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh commit --message "res
 sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh push-main
 ```
 
-### 2）删除除 main 外的所有分支（本地+远程）
+### 4）仅替换仓库目标文件内容（保留原路径/文件名），然后提交并推送
+
+适用场景：用户要求“只内容替换”“只替换里面的 worker”“保留仓库原文件名/路径”，本意是：**只覆盖目标文件内容，不新增上传源文件名，不改仓库中的目标路径**。
+
+推荐执行顺序：
+
+```bash
+# 1. 拉取/刷新仓库
+repo_dir=/var/minis/workspace/<repo>
+if [ -d "$repo_dir/.git" ]; then
+  cd "$repo_dir" && git fetch --all --prune && git reset --hard origin/main
+else
+  gh repo clone <owner/repo> "$repo_dir"
+fi
+
+# 2. 仅内容覆盖：用源文件内容覆盖仓库目标文件
+cp <source_file> "$repo_dir/<target_path>"
+
+# 3. 如未配置 Git 身份，优先复用 GitHub 登录名，并使用 GitHub noreply 邮箱
+cd "$repo_dir"
+git config user.name '<GitHub显示名>'
+git config user.email '<login>@users.noreply.github.com'
+
+# 4. 提交并直推 main（仅在用户明确要求提交/推送时执行）
+git add <target_path>
+git commit -m 'replace <target_path> content'
+git push origin main
+```
+
+执行要点：
+- 用户说“只内容替换”时，统一理解为：**保留仓库中的原文件路径与文件名，仅覆盖内容**。
+- 不要把源文件名直接放进仓库；目标仍应是仓库里原本那个文件（例如 `worker.js`）。
+- 若目标路径已知，直接覆盖该路径；若未知，先在仓库中定位目标文件再替换。
+- 提交前若报 `Author identity unknown`，可在当前仓库写入：
+  - `git config user.name '<GitHub显示名>'`
+  - `git config user.email '<login>@users.noreply.github.com'`
+- 默认先 `git fetch` + `git reset --hard origin/main`，避免在旧工作树上误提交。
+- 若用户已经明确要求“提交”“推送”，可直接继续执行，无需重复确认。
+
+### 5）删除除 main 外的所有分支（本地+远程）
 
 ```bash
 sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh delete-branches --keep main
 ```
 
-### 3）不建分支，fork:main → upstream:main 直接开 PR
+### 6）不建分支，fork:main → upstream:main 直接开 PR
 
 ```bash
 sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh pr \
@@ -123,7 +163,11 @@ sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh pr \
   --body "..."
 ```
 
-## 故障排查
+- **仓库列表输出必须使用 Markdown 表格**，并包含 `编号` 列，便于用户直接回复编号选择。
+- 字段建议：`编号 | 仓库(owner/repo) | 可见性 | Fork | 默认分支 | 最近更新 | URL`
+- 交互建议：表格后提示“回复编号即可继续（clone/pull/提交推送/只内容替换等）”。
+
+> 备注：若用户需要更多字段（description、language、stars），再加 `--json ...` 扩展。
 
 | 序号 | 现象 | 处理 |
 |---:|---|---|

--- a/github-sync-helper/SKILL.md
+++ b/github-sync-helper/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-sync-helper
 description: >
-  通用 GitHub 基础操作 + 同步/PR 自动化技能（Minis 环境）。当用户提到“GitHub 怎么用、clone、init、remote、branch、commit、push、pull、fetch、merge、rebase、tag、release、stash、submodule、fork、PR、同步到上游(upstream)、删除分支、清空目录后恢复、直推 main、一键同步”等任意 Git/GitHub 基础操作与工作流时，必须触发本技能。
+  通用 GitHub 基础操作 + GitHub 平台对象（Issues/Labels/Milestones/Releases/Actions）自动化技能（Minis 环境）。当用户提到“GitHub 怎么用、clone、init、remote、branch、commit、push、pull、fetch、merge、rebase、tag、release、issues、actions、labels、milestone、保护分支、fork、PR、同步到上游(upstream)、删除分支、清空目录后恢复、直推 main、一键同步”等任意 Git/GitHub 基础操作与工作流时，必须触发本技能。
 compatibility: >
   Requires git, python3. Uses env GITHUB_TOKEN for GitHub API + HTTPS push (non-interactive via GIT_ASKPASS).
 ---
@@ -45,15 +45,32 @@ compatibility: >
 |11| 暂存栈 | stash | 临时收起未提交改动 | `git stash` | `stash` |
 |12| 标签 | tag | 给提交打版本号 | `git tag` | `tag` |
 |13| 子模块 | submodule | 管理子仓库依赖 | `git submodule` | `submodule` |
-|14| GitHub 协作 | fork/PR | fork 后在自己仓库改，提交 PR 到上游 |（网页 + API） | `pr` |
+|15| GitHub 平台 | issues/labels/milestones/releases/actions | 通过 GitHub API 管理平台对象 |（API） | `gh-issues-list` 等（见下方） |
 
 > 注：脚本的定位是“把常用基础操作变成可复用命令”。遇到复杂 rebase/冲突，仍建议用交互式终端处理。
+
+## GitHub 平台操作（API）
+
+> 统一要求：需要 env `GITHUB_TOKEN`。
+
+| 序号 | command | 作用 |
+|---:|---|---|
+| 1 | `gh-issues-list --repo <owner/repo> [--state open|closed|all]` | 列出 Issues |
+| 2 | `gh-issue-create --repo <owner/repo> --title <t> [--body <b>]` | 创建 Issue |
+| 3 | `gh-issue-close --repo <owner/repo> --number <n>` | 关闭 Issue |
+| 4 | `gh-labels-list --repo <owner/repo>` | 列出 labels |
+| 5 | `gh-label-create --repo <owner/repo> --name <n> [--color <rrggbb>] [--description <d>]` | 创建 label |
+| 6 | `gh-milestones-list --repo <owner/repo> [--state open|closed|all]` | 列出 milestones |
+| 7 | `gh-milestone-create --repo <owner/repo> --title <t> [--description <d>] [--due <YYYY-MM-DD>]` | 创建 milestone |
+| 8 | `gh-releases-list --repo <owner/repo>` | 列出 releases |
+| 9 | `gh-release-create --repo <owner/repo> --tag <vX.Y.Z> --name <n> [--body <b>] [--draft true|false] [--prerelease true|false]` | 创建 release |
+|10| `gh-actions-list --repo <owner/repo>` | 列出 workflows |
+|11| `gh-actions-dispatch --repo <owner/repo> --workflow <id_or_file> [--ref <branch>] [--inputs <json>]` | 手动触发 workflow_dispatch |
 
 ## 脚本命令清单（gh_sync.sh）
 
 | 序号 | command | 作用 |
 |---:|---|---|
-| 1 | `init` | 在当前目录初始化 git 仓库 |
 | 2 | `clone --url <url> [--dir <path>]` | clone 仓库到指定目录 |
 | 3 | `remotes` | 显示当前 remotes |
 | 4 | `add-remote --name <n> --url <url>` | 添加远端 |
@@ -76,6 +93,7 @@ compatibility: >
 |21| `empty-dir --dir <path>` | 清空仓库内某目录但保留目录（用 .gitkeep） |
 |22| `restore-dir --src <path> --dst <path>` | 用本机目录覆盖恢复到仓库目录（会先删除 dst 内容） |
 |23| `pr --upstream <owner/repo> --head <owner:branch> --base <branch> --title <t> --body <b>` | 通过 GitHub API 创建 PR |
+|24| `gh-issues-list ...` 等 | GitHub 平台对象操作（issues/labels/milestones/releases/actions） |
 
 ## 典型工作流（示例）
 

--- a/github-sync-helper/SKILL.md
+++ b/github-sync-helper/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: github-sync-helper
+description: >
+  通用 GitHub 基础操作 + 同步/PR 自动化技能（Minis 环境）。当用户提到“GitHub 怎么用、clone、init、remote、branch、commit、push、pull、fetch、merge、rebase、tag、release、stash、submodule、fork、PR、同步到上游(upstream)、删除分支、清空目录后恢复、直推 main、一键同步”等任意 Git/GitHub 基础操作与工作流时，必须触发本技能。
+compatibility: >
+  Requires git, python3. Uses env GITHUB_TOKEN for GitHub API + HTTPS push (non-interactive via GIT_ASKPASS).
+---
+
+## 目标
+
+把 GitHub/Git 的“基础操作”与常见协作流程固化为：
+
+1) 清晰的命令速查（解释 + 何时用）
+2) 可执行的一键脚本（避免重复手工步骤）
+
+## 安全与约束（必须遵守）
+
+| 序号 | 规则 | 原因 |
+|---:|---|---|
+| 1 | **不要输出 Token**：任何命令都不得把 `$GITHUB_TOKEN` echo/print 到 stdout | 防止泄露 |
+| 2 | **危险操作二次确认**：删分支、清空目录、强制覆盖、强推、直推 main | 可逆性差 |
+| 3 | 默认用“分支 + PR”协作；只有用户明确要求才“直推 main” | 降低对主分支破坏 |
+| 4 | push/pull 前先 `git status` | 防止误提交/误覆盖 |
+
+## 运行方式
+
+- **脚本入口**：`sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh <command> [options]`
+
+> 脚本在“当前 git 仓库目录”下运行（必须在仓库内）。
+
+## Git/GitHub 基础操作速查（解释 + 对应脚本）
+
+| 序号 | 类别 | 操作 | 一句话解释 | 常用命令 | 脚本支持 |
+|---:|---|---|---|---|---|
+| 1 | 初始化 | init | 把当前目录变成 git 仓库 | `git init` | `init` |
+| 2 | 获取代码 | clone | 从远端下载仓库到本地 | `git clone <url>` | `clone` |
+| 3 | 远端 | remote | 管理 origin/upstream 等远端 | `git remote -v/add/set-url/remove` | `remotes/add-remote/add-upstream/set-remote-url/remove-remote` |
+| 4 | 分支 | branch | 查看/创建/删除分支 | `git branch -a/-d/-D` | `branches/create-branch/delete-branches` |
+| 5 | 切换 | checkout/switch | 切换到某分支 | `git switch <b>` | `checkout` |
+| 6 | 查看变更 | status/diff/log | 看工作区改动/差异/历史 | `git status` `git diff` `git log` | `status/diff/log` |
+| 7 | 暂存 | add | 把改动加入暂存区 | `git add -A` | `add` |
+| 8 | 提交 | commit | 把暂存区打包成一次提交 | `git commit -m "..."` | `commit` |
+| 9 | 同步 | fetch/pull/push | 拉取/合并/推送提交 | `git fetch` `git pull` `git push` | `fetch/pull/push/push-main` |
+|10| 合并 | merge/rebase | 合并分支历史 | `git merge` `git rebase` | `merge/rebase`（谨慎） |
+|11| 暂存栈 | stash | 临时收起未提交改动 | `git stash` | `stash` |
+|12| 标签 | tag | 给提交打版本号 | `git tag` | `tag` |
+|13| 子模块 | submodule | 管理子仓库依赖 | `git submodule` | `submodule` |
+|14| GitHub 协作 | fork/PR | fork 后在自己仓库改，提交 PR 到上游 |（网页 + API） | `pr` |
+
+> 注：脚本的定位是“把常用基础操作变成可复用命令”。遇到复杂 rebase/冲突，仍建议用交互式终端处理。
+
+## 脚本命令清单（gh_sync.sh）
+
+| 序号 | command | 作用 |
+|---:|---|---|
+| 1 | `init` | 在当前目录初始化 git 仓库 |
+| 2 | `clone --url <url> [--dir <path>]` | clone 仓库到指定目录 |
+| 3 | `remotes` | 显示当前 remotes |
+| 4 | `add-remote --name <n> --url <url>` | 添加远端 |
+| 5 | `set-remote-url --name <n> --url <url>` | 修改远端 URL |
+| 6 | `remove-remote --name <n>` | 删除远端 |
+| 7 | `add-upstream --upstream <owner/repo>` | 添加 upstream remote |
+| 8 | `status` | `git status --porcelain` + 简要提示 |
+| 9 | `diff [--staged]` | 查看差异 |
+|10| `log [--n <k>]` | 查看最近提交 |
+|11| `branches` | 列出本地与远程分支 |
+|12| `create-branch --name <b> [--from <ref>]` | 创建分支 |
+|13| `checkout --name <b>` | 切换分支 |
+|14| `delete-branches --keep <branch>` | 删除除 keep 外的本地/远程分支 |
+|15| `add --path <p>` | `git add` |
+|16| `commit --message <m>` | `git commit` |
+|17| `fetch [--remote <n>]` | 拉取远端更新 |
+|18| `pull [--remote <n>] [--branch <b>]` | 拉取并合并 |
+|19| `push [--remote <n>] [--branch <b>]` | 推送 |
+|20| `push-main` | push 当前 main 到 origin（使用 token 非交互） |
+|21| `empty-dir --dir <path>` | 清空仓库内某目录但保留目录（用 .gitkeep） |
+|22| `restore-dir --src <path> --dst <path>` | 用本机目录覆盖恢复到仓库目录（会先删除 dst 内容） |
+|23| `pr --upstream <owner/repo> --head <owner:branch> --base <branch> --title <t> --body <b>` | 通过 GitHub API 创建 PR |
+
+## 典型工作流（示例）
+
+### 1）直推 main：清空目录 → 恢复目录 → push（你刚刚那套）
+
+```bash
+sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh empty-dir --dir self-improving-agent
+sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh restore-dir --src /var/minis/skills/self-improving-agent --dst self-improving-agent
+sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh commit --message "restore(self-improving-agent): sync from local"
+sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh push-main
+```
+
+### 2）删除除 main 外的所有分支（本地+远程）
+
+```bash
+sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh delete-branches --keep main
+```
+
+### 3）不建分支，fork:main → upstream:main 直接开 PR
+
+```bash
+sh /var/minis/skills/github-sync-helper/scripts/gh_sync.sh pr \
+  --upstream OpenMinis/MinisSkills \
+  --head mowenyun:main \
+  --base main \
+  --title "sync: ..." \
+  --body "..."
+```
+
+## 故障排查
+
+| 序号 | 现象 | 处理 |
+|---:|---|---|
+| 1 | push 报 `could not read Username` | 需要 env `GITHUB_TOKEN`，脚本会用 `GIT_ASKPASS` 非交互认证 |
+| 2 | API 401/403 | token 权限不足（repo/public_repo）或过期 |
+| 3 | `not inside a git repo` | 先 `cd` 到仓库目录（或用 `clone`/`init`） |

--- a/github-sync-helper/scripts/gh_sync.sh
+++ b/github-sync-helper/scripts/gh_sync.sh
@@ -8,6 +8,64 @@ need_cmd() { command -v "$1" >/dev/null 2>&1 || { err "missing command: $1"; exi
 need_env() { name="$1"; eval "val=\${$name-}"; [ -n "$val" ] || { err "missing env: $name"; exit 1; }; }
 repo_root() { git rev-parse --show-toplevel 2>/dev/null; }
 
+# Print and require --yes for dangerous commands
+need_yes() {
+  for a in "$@"; do
+    [ "$a" = "--yes" ] && return 0
+  done
+  err "dangerous operation: re-run with --yes to confirm"
+  exit 2
+}
+
+# Try infer owner/repo from current git remote (origin)
+# Supports https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git)
+# Echoes "owner/repo" or empty.
+infer_repo() {
+  u="$(git remote get-url origin 2>/dev/null || true)"
+  [ -n "$u" ] || { echo ""; return 0; }
+  case "$u" in
+    https://github.com/*)
+      s="${u#https://github.com/}";;
+    git@github.com:*)
+      s="${u#git@github.com:}";;
+    *)
+      echo ""; return 0;;
+  esac
+  s="${s%.git}"
+  # basic validation
+  case "$s" in
+    *"/"*) echo "$s";;
+    *) echo "";;
+  esac
+}
+
+# Minimal GitHub API wrapper. Prints JSON response to stdout. Exits non-zero on HTTP error.
+gh_api() {
+  need_env GITHUB_TOKEN
+  method="$1"; url="$2"; body_json="${3-}"
+  python3 -c 'import os,sys,json,urllib.request,urllib.error
+method=os.environ["M"]; url=os.environ["U"]; tok=os.environ["GITHUB_TOKEN"]; body=os.environ.get("B","")
+data=None
+if body:
+  data=body.encode("utf-8")
+req=urllib.request.Request(url,data=data,method=method)
+req.add_header("Authorization","Bearer "+tok)
+req.add_header("Accept","application/vnd.github+json")
+req.add_header("User-Agent","minis")
+if data is not None:
+  req.add_header("Content-Type","application/json")
+try:
+  with urllib.request.urlopen(req,timeout=30) as r:
+    raw=r.read().decode("utf-8","ignore")
+    print(raw)
+except urllib.error.HTTPError as e:
+  raw=e.read().decode("utf-8","ignore")
+  sys.stderr.write(f"HTTP {e.code} {url}\n")
+  sys.stderr.write(raw[:800]+"\n")
+  sys.exit(1)
+' M="$method" U="$url" B="$body_json"
+}
+
 ensure_git_identity() {
   [ -n "$(git config user.name || true)" ] || git config user.name "mowenyun"
   [ -n "$(git config user.email || true)" ] || git config user.email "mowenyun@users.noreply.github.com"
@@ -61,6 +119,11 @@ Usage:
   sh gh_sync.sh push-main
   sh gh_sync.sh pr --upstream <owner/repo> --head <owner:branch> --base <branch> --title <t> --body <b>
 
+  # PR management
+  sh gh_sync.sh gh-pr-list --repo <owner/repo> [--state open|closed|all]
+  sh gh_sync.sh gh-pr-close --repo <owner/repo> --number <n>
+  sh gh_sync.sh gh-pr-merge --repo <owner/repo> --number <n> [--method merge|squash|rebase]
+
   # GitHub platform APIs
   sh gh_sync.sh gh-issues-list --repo <owner/repo> [--state open|closed|all]
   sh gh_sync.sh gh-issue-create --repo <owner/repo> --title <t> [--body <b>]
@@ -72,6 +135,7 @@ Usage:
   sh gh_sync.sh gh-releases-list --repo <owner/repo>
   sh gh_sync.sh gh-release-create --repo <owner/repo> --tag <vX.Y.Z> --name <n> [--body <b>] [--draft true|false] [--prerelease true|false]
   sh gh_sync.sh gh-actions-list --repo <owner/repo>
+  sh gh_sync.sh gh-actions-runs --repo <owner/repo> [--status queued|in_progress|completed] [--branch <b>]
   sh gh_sync.sh gh-actions-dispatch --repo <owner/repo> --workflow <id_or_file> [--ref <branch>] [--inputs <json>]
 EOF
 }
@@ -279,7 +343,15 @@ case "$cmd" in
     ;;
 
   delete-branches)
-    keep="main"; [ "${1-}" = "--keep" ] && keep="$2"
+    keep="main"; yes=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --keep) keep="$2"; shift 2;;
+        --yes) yes="--yes"; shift 1;;
+        *) break;;
+      esac
+    done
+    need_yes "$yes"
     ensure_askpass
     i=1
     for b in $(git branch --format='%(refname:short)'); do [ "$b" = "$keep" ] && continue; git branch -D "$b" >/dev/null 2>&1 || true; add_row "$i" "delete local branch" OK "$b"; i=$((i+1)); done
@@ -287,8 +359,16 @@ case "$cmd" in
     ;;
 
   empty-dir)
-    dir=""; [ "${1-}" = "--dir" ] && dir="$2"
+    dir=""; yes=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --dir) dir="$2"; shift 2;;
+        --yes) yes="--yes"; shift 1;;
+        *) break;;
+      esac
+    done
     [ -n "$dir" ] || { err "--dir required"; usage; exit 1; }
+    need_yes "$yes"
     ensure_git_identity
     mkdir -p "$dir"
     git rm -r --ignore-unmatch "$dir"/* "$dir"/.[!.]* "$dir"/..?* >/dev/null 2>&1 || true
@@ -297,9 +377,17 @@ case "$cmd" in
     ;;
 
   restore-dir)
-    src=""; dst=""
-    while [ $# -gt 0 ]; do case "$1" in --src) src="$2"; shift 2;; --dst) dst="$2"; shift 2;; *) break;; esac; done
+    src=""; dst=""; yes=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --src) src="$2"; shift 2;;
+        --dst) dst="$2"; shift 2;;
+        --yes) yes="--yes"; shift 1;;
+        *) break;;
+      esac
+    done
     [ -n "$src" ] && [ -n "$dst" ] || { err "--src and --dst required"; usage; exit 1; }
+    need_yes "$yes"
     [ -d "$src" ] || { err "src not found: $src"; exit 1; }
     ensure_git_identity
     rm -f "$dst/.gitkeep" 2>/dev/null || true
@@ -311,6 +399,14 @@ case "$cmd" in
     ;;
 
   push-main)
+    yes=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --yes) yes="--yes"; shift 1;;
+        *) break;;
+      esac
+    done
+    need_yes "$yes"
     ensure_askpass
     ensure_git_identity
     git checkout main >/dev/null 2>&1 || true
@@ -330,13 +426,20 @@ try:
   resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))
 except urllib.error.HTTPError as e:
   err=e.read().decode("utf-8","ignore"); print("HTTP %s"%e.code+" "+err[:200])' 2>/dev/null)" || true
-    add_row 1 pr OK "$out"
+    if printf '%s' "$out" | grep -q '^https://'; then
+      add_row 1 pr OK "$out"
+    else
+      add_row 1 pr FAIL "$out"
+      print_summary
+      exit 1
+    fi
     ;;
 
   gh-issues-list)
     repo=""; state="open"
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --state) state="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" STATE="$state"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); state=os.environ.get("STATE","open"); url=f"https://api.github.com/repos/{owner}/{repo}/issues?state={state}&per_page=20"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); lines=[]
@@ -350,7 +453,8 @@ print("; ".join(lines))' 2>/dev/null)" || true
   gh-issue-create)
     repo=""; title=""; body=""
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --title) title="$2"; shift 2;; --body) body="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] && [ -n "$title" ] || { err "--repo --title required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$title" ] || { err "--repo (or origin remote) and --title required"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" TITLE="$title" BODY="$body"
     out="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"title":os.environ["TITLE"],"body":os.environ.get("BODY","")}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/issues",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json");
@@ -364,7 +468,8 @@ except urllib.error.HTTPError as e:
   gh-issue-close)
     repo=""; num=""
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --number) num="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] && [ -n "$num" ] || { err "--repo --number required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$num" ] || { err "--repo (or origin remote) and --number required"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" NUM="$num"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); num=os.environ["NUM"]; payload={"state":"closed"}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/issues/{num}",data=data,method="PATCH"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("state",""))' 2>/dev/null)" || true
@@ -373,7 +478,8 @@ except urllib.error.HTTPError as e:
 
   gh-labels-list)
     repo=""; [ "${1-}" = "--repo" ] && repo="$2"
-    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); url=f"https://api.github.com/repos/{owner}/{repo}/labels?per_page=50"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); print("; ".join([it.get("name","") for it in data]))' 2>/dev/null)" || true
@@ -383,7 +489,8 @@ except urllib.error.HTTPError as e:
   gh-label-create)
     repo=""; name=""; color=""; desc=""
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --name) name="$2"; shift 2;; --color) color="$2"; shift 2;; --description) desc="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] && [ -n "$name" ] || { err "--repo --name required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$name" ] || { err "--repo (or origin remote) and --name required"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" NAME="$name" COLOR="$color" DESC="$desc"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"name":os.environ["NAME"],"color":(os.environ.get("COLOR") or "ededed"),"description":os.environ.get("DESC","")}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/labels",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("name",""))' 2>/dev/null)" || true
@@ -393,7 +500,8 @@ except urllib.error.HTTPError as e:
   gh-milestones-list)
     repo=""; state="open"
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --state) state="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" STATE="$state"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); state=os.environ.get("STATE","open"); url=f"https://api.github.com/repos/{owner}/{repo}/milestones?state={state}&per_page=30"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); print("; ".join([f"#{it['number']} {it['title']}" for it in data]))' 2>/dev/null)" || true
@@ -403,7 +511,8 @@ except urllib.error.HTTPError as e:
   gh-milestone-create)
     repo=""; title=""; desc=""; due=""
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --title) title="$2"; shift 2;; --description) desc="$2"; shift 2;; --due) due="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] && [ -n "$title" ] || { err "--repo --title required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$title" ] || { err "--repo (or origin remote) and --title required"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" TITLE="$title" DESC="$desc" DUE="$due"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"title":os.environ["TITLE"],"description":os.environ.get("DESC","")}; due=os.environ.get("DUE","");
@@ -414,7 +523,8 @@ data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://a
 
   gh-releases-list)
     repo=""; [ "${1-}" = "--repo" ] && repo="$2"
-    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); url=f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=10"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); print("; ".join([it.get("tag_name","") for it in data]))' 2>/dev/null)" || true
@@ -424,7 +534,8 @@ data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://a
   gh-release-create)
     repo=""; tag=""; name=""; body=""; draft="false"; pre="false"
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --tag) tag="$2"; shift 2;; --name) name="$2"; shift 2;; --body) body="$2"; shift 2;; --draft) draft="$2"; shift 2;; --prerelease) pre="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] && [ -n "$tag" ] && [ -n "$name" ] || { err "--repo --tag --name required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$tag" ] && [ -n "$name" ] || { err "--repo (or origin remote), --tag, --name required"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" TAG="$tag" NAME="$name" BODY="$body" DRAFT="$draft" PRE="$pre"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"tag_name":os.environ["TAG"],"name":os.environ["NAME"],"body":os.environ.get("BODY","")}; payload["draft"]= (os.environ.get("DRAFT","false").lower()=="true"); payload["prerelease"]= (os.environ.get("PRE","false").lower()=="true"); data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/releases",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))' 2>/dev/null)" || true
@@ -433,17 +544,36 @@ data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://a
 
   gh-actions-list)
     repo=""; [ "${1-}" = "--repo" ] && repo="$2"
-    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo"
     out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); url=f"https://api.github.com/repos/{owner}/{repo}/actions/workflows?per_page=50"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); w=data.get("workflows",[]); print("; ".join([f"{it['id']} {it['name']}" for it in w[:20]]))' 2>/dev/null)" || true
     add_row 1 gh-actions-list OK "$out"
     ;;
 
+  gh-actions-runs)
+    repo=""; status=""; branch=""
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --status) status="$2"; shift 2;; --branch) branch="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" STATUS="$status" BRANCH="$branch"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); status=os.environ.get("STATUS",""); branch=os.environ.get("BRANCH",""); qs=["per_page=10"]; 
+if status: qs.append("status="+status)
+if branch: qs.append("branch="+branch)
+url=f"https://api.github.com/repos/{owner}/{repo}/actions/runs?"+"&".join(qs); req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); d=json.load(urllib.request.urlopen(req,timeout=30)); runs=d.get("workflow_runs",[]); lines=[]
+for r in runs[:10]:
+  lines.append(f"#{r.get('run_number')} {r.get('name')} {r.get('status')} {r.get('conclusion')}")
+print("; ".join(lines))' 2>/dev/null)" || true
+    add_row 1 gh-actions-runs OK "$out"
+    ;;
+
   gh-actions-dispatch)
     repo=""; wf=""; ref="main"; inputs="{}"
     while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --workflow) wf="$2"; shift 2;; --ref) ref="$2"; shift 2;; --inputs) inputs="$2"; shift 2;; *) break;; esac; done
-    [ -n "$repo" ] && [ -n "$wf" ] || { err "--repo --workflow required"; exit 1; }
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$wf" ] || { err "--repo (or origin remote) and --workflow required"; exit 1; }
     need_env GITHUB_TOKEN
     export REPO="$repo" WF="$wf" REF="$ref" INPUTS="$inputs"
     out="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); wf=os.environ["WF"]; ref=os.environ.get("REF","main");
@@ -457,6 +587,39 @@ try:
 except urllib.error.HTTPError as e:
   print(e.code)' 2>/dev/null)" || true
     add_row 1 gh-actions-dispatch OK "$out"
+    ;;
+
+  gh-pr-list)
+    repo=""; state="open"
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --state) state="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] || { err "--repo required (or set origin remote)"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" STATE="$state"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); state=os.environ.get("STATE","open"); url=f"https://api.github.com/repos/{owner}/{repo}/pulls?state={state}&per_page=20"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); arr=json.load(urllib.request.urlopen(req,timeout=30)); lines=[f"#{p.get('number')} {p.get('title')} ({p.get('state')})" for p in arr[:20]]; print("; ".join(lines))' 2>/dev/null)" || true
+    add_row 1 gh-pr-list OK "$out"
+    ;;
+
+  gh-pr-close)
+    repo=""; num=""
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --number) num="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$num" ] || { err "--repo (or origin remote) and --number required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" NUM="$num"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); num=os.environ["NUM"]; payload={"state":"closed"}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/pulls/{num}",data=data,method="PATCH"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); d=json.load(urllib.request.urlopen(req,timeout=30)); print(d.get("state",""))' 2>/dev/null)" || true
+    add_row 1 gh-pr-close OK "$out"
+    ;;
+
+  gh-pr-merge)
+    repo=""; num=""; method="merge"
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --number) num="$2"; shift 2;; --method) method="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] || repo="$(infer_repo)"
+    [ -n "$repo" ] && [ -n "$num" ] || { err "--repo (or origin remote) and --number required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" NUM="$num" METHOD="$method"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); num=os.environ["NUM"]; method=os.environ.get("METHOD","merge"); payload={"merge_method":method}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/pulls/{num}/merge",data=data,method="PUT"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); d=json.load(urllib.request.urlopen(req,timeout=30)); print("merged" if d.get("merged") else "not merged")' 2>/dev/null)" || true
+    add_row 1 gh-pr-merge OK "$out"
     ;;
 
   *)

--- a/github-sync-helper/scripts/gh_sync.sh
+++ b/github-sync-helper/scripts/gh_sync.sh
@@ -3,31 +3,14 @@
 # Requirements: git, python3, env GITHUB_TOKEN
 set -e
 
-# ---------- helpers ----------
 err() { printf '%s\n' "$*" >&2; }
-
-need_cmd() {
-  command -v "$1" >/dev/null 2>&1 || { err "missing command: $1"; exit 1; }
-}
-
-need_env() {
-  name="$1"
-  eval "val=\${$name-}"
-  [ -n "$val" ] || { err "missing env: $name"; exit 1; }
-}
-
-repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null
-}
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { err "missing command: $1"; exit 1; }; }
+need_env() { name="$1"; eval "val=\${$name-}"; [ -n "$val" ] || { err "missing env: $name"; exit 1; }; }
+repo_root() { git rev-parse --show-toplevel 2>/dev/null; }
 
 ensure_git_identity() {
-  # Keep it local to repo; do not fail if already set
-  if [ -z "$(git config user.name || true)" ]; then
-    git config user.name "mowenyun"
-  fi
-  if [ -z "$(git config user.email || true)" ]; then
-    git config user.email "mowenyun@users.noreply.github.com"
-  fi
+  [ -n "$(git config user.name || true)" ] || git config user.name "mowenyun"
+  [ -n "$(git config user.email || true)" ] || git config user.email "mowenyun@users.noreply.github.com"
 }
 
 ensure_askpass() {
@@ -77,42 +60,41 @@ Usage:
   sh gh_sync.sh restore-dir --src <path> --dst <path>
   sh gh_sync.sh push-main
   sh gh_sync.sh pr --upstream <owner/repo> --head <owner:branch> --base <branch> --title <t> --body <b>
+
+  # GitHub platform APIs
+  sh gh_sync.sh gh-issues-list --repo <owner/repo> [--state open|closed|all]
+  sh gh_sync.sh gh-issue-create --repo <owner/repo> --title <t> [--body <b>]
+  sh gh_sync.sh gh-issue-close --repo <owner/repo> --number <n>
+  sh gh_sync.sh gh-labels-list --repo <owner/repo>
+  sh gh_sync.sh gh-label-create --repo <owner/repo> --name <n> [--color <rrggbb>] [--description <d>]
+  sh gh_sync.sh gh-milestones-list --repo <owner/repo> [--state open|closed|all]
+  sh gh_sync.sh gh-milestone-create --repo <owner/repo> --title <t> [--description <d>] [--due <YYYY-MM-DD>]
+  sh gh_sync.sh gh-releases-list --repo <owner/repo>
+  sh gh_sync.sh gh-release-create --repo <owner/repo> --tag <vX.Y.Z> --name <n> [--body <b>] [--draft true|false] [--prerelease true|false]
+  sh gh_sync.sh gh-actions-list --repo <owner/repo>
+  sh gh_sync.sh gh-actions-dispatch --repo <owner/repo> --workflow <id_or_file> [--ref <branch>] [--inputs <json>]
 EOF
 }
 
 cmd="$1"; shift || true
-
 need_cmd git
 need_cmd python3
-
-ROOT="$(repo_root)"
-[ -n "$ROOT" ] || { err "not inside a git repo"; exit 1; }
+ROOT="$(repo_root)"; [ -n "$ROOT" ] || { err "not inside a git repo"; exit 1; }
 cd "$ROOT"
 
-enable_table_summary() {
-  # call: enable_table_summary; then append to $SUMMARY
-  SUMMARY=""
-}
-
-add_row() {
-  # add_row idx col2 col3 col4
-  i="$1"; c2="$2"; c3="$3"; c4="$4"
-  SUMMARY="$SUMMARY
-| $i | $c2 | $c3 | $c4 |"
-}
-
+SUMMARY=""
+add_row() { SUMMARY="$SUMMARY
+| $1 | $2 | $3 | $4 |"; }
 print_summary() {
   printf '%s\n' "| 序号 | 动作 | 结果 | 备注 |"
   printf '%s\n' "|---:|---|---|---|"
   printf '%s\n' "$SUMMARY" | sed '1{/^$/d;}'
 }
 
-enable_table_summary
-
 case "$cmd" in
   init)
-    git init >\/dev\/null 2>&1 || true
-    add_row 1 init "OK" "initialized"
+    git init >/dev/null 2>&1 || true
+    add_row 1 init OK initialized
     ;;
 
   clone)
@@ -126,12 +108,17 @@ case "$cmd" in
     done
     [ -n "$url" ] || { err "--url required"; usage; exit 1; }
     if [ -n "$dir" ]; then
-      git clone "$url" "$dir" >\/dev\/null
-      add_row 1 clone "OK" "$url -> $dir"
+      git clone "$url" "$dir" >/dev/null
+      add_row 1 clone OK "$url -> $dir"
     else
-      git clone "$url" >\/dev\/null
-      add_row 1 clone "OK" "$url"
+      git clone "$url" >/dev/null
+      add_row 1 clone OK "$url"
     fi
+    ;;
+
+  remotes)
+    out="$(git remote -v 2>/dev/null || true)"
+    add_row 1 remotes OK "$(printf '%s' "$out" | tr '\n' '; ' | sed 's/; $//')"
     ;;
 
   add-remote)
@@ -145,7 +132,7 @@ case "$cmd" in
     done
     [ -n "$name" ] && [ -n "$url" ] || { err "--name and --url required"; usage; exit 1; }
     git remote add "$name" "$url"
-    add_row 1 add-remote "OK" "$name=$url"
+    add_row 1 add-remote OK "$name=$url"
     ;;
 
   set-remote-url)
@@ -159,7 +146,7 @@ case "$cmd" in
     done
     [ -n "$name" ] && [ -n "$url" ] || { err "--name and --url required"; usage; exit 1; }
     git remote set-url "$name" "$url"
-    add_row 1 set-remote-url "OK" "$name=$url"
+    add_row 1 set-remote-url OK "$name=$url"
     ;;
 
   remove-remote)
@@ -172,219 +159,7 @@ case "$cmd" in
     done
     [ -n "$name" ] || { err "--name required"; usage; exit 1; }
     git remote remove "$name"
-    add_row 1 remove-remote "OK" "$name"
-    ;;
-
-  status)
-    s="$(git status --porcelain 2>\/dev\/null || true)"
-    if [ -n "$s" ]; then
-      add_row 1 status "DIRTY" "$(printf '%s' "$s" | tr '\n' '; ' | sed 's/; $//')"
-    else
-      add_row 1 status "CLEAN" "no changes"
-    fi
-    ;;
-
-  diff)
-    staged=0
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --staged) staged=1; shift 1;;
-        *) break;;
-      esac
-    done
-    if [ "$staged" -eq 1 ]; then
-      d="$(git diff --staged --name-status)"
-    else
-      d="$(git diff --name-status)"
-    fi
-    add_row 1 diff "OK" "$(printf '%s' "$d" | tr '\n' '; ' | sed 's/; $//')"
-    ;;
-
-  log)
-    n=10
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --n) n="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    l="$(git log -n "$n" --oneline 2>\/dev\/null || true)"
-    add_row 1 log "OK" "$(printf '%s' "$l" | tr '\n' '; ' | sed 's/; $//')"
-    ;;
-
-  create-branch)
-    name=""; from=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --name) name="$2"; shift 2;;
-        --from) from="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
-    if [ -n "$from" ]; then
-      git checkout -b "$name" "$from" >\/dev\/null
-    else
-      git checkout -b "$name" >\/dev\/null
-    fi
-    add_row 1 create-branch "OK" "$name"
-    ;;
-
-  checkout)
-    name=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --name) name="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
-    git checkout "$name" >\/dev\/null
-    add_row 1 checkout "OK" "$name"
-    ;;
-
-  add)
-    path="-A"
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --path) path="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    git add "$path"
-    add_row 1 add "OK" "$path"
-    ;;
-
-  commit)
-    msg=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --message) msg="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    [ -n "$msg" ] || { err "--message required"; usage; exit 1; }
-    ensure_git_identity
-    git commit -m "$msg" >\/dev\/null
-    add_row 1 commit "OK" "$msg"
-    ;;
-
-  fetch)
-    remote="origin"
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --remote) remote="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    git fetch "$remote" >\/dev\/null
-    add_row 1 fetch "OK" "$remote"
-    ;;
-
-  pull)
-    remote="origin"; br=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --remote) remote="$2"; shift 2;;
-        --branch) br="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    if [ -n "$br" ]; then
-      git pull "$remote" "$br" >\/dev\/null
-      add_row 1 pull "OK" "$remote/$br"
-    else
-      git pull >\/dev\/null
-      add_row 1 pull "OK" "default"
-    fi
-    ;;
-
-  push)
-    remote="origin"; br=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --remote) remote="$2"; shift 2;;
-        --branch) br="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    ensure_askpass
-    if [ -n "$br" ]; then
-      git push "$remote" "$br" >\/dev\/null
-      add_row 1 push "OK" "$remote/$br"
-    else
-      git push >\/dev\/null
-      add_row 1 push "OK" "default"
-    fi
-    ;;
-
-  stash)
-    sub="list"
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --pop) sub="pop"; shift 1;;
-        --apply) sub="apply"; shift 1;;
-        --save) sub="save"; msg="$2"; shift 2;;
-        --list) sub="list"; shift 1;;
-        *) break;;
-      esac
-    done
-    case "$sub" in
-      save) git stash push -m "${msg:-wip}" >\/dev\/null; add_row 1 stash "OK" "saved";;
-      pop) git stash pop >\/dev\/null || true; add_row 1 stash "OK" "popped";;
-      apply) git stash apply >\/dev\/null || true; add_row 1 stash "OK" "applied";;
-      list) l="$(git stash list || true)"; add_row 1 stash "OK" "$(printf '%s' "$l" | tr '\n' '; ' | sed 's/; $//')";;
-    esac
-    ;;
-
-  tag)
-    name=""; msg=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --name) name="$2"; shift 2;;
-        --message) msg="$2"; shift 2;;
-        *) break;;
-      esac
-    done
-    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
-    if [ -n "$msg" ]; then
-      git tag -a "$name" -m "$msg"
-    else
-      git tag "$name"
-    fi
-    add_row 1 tag "OK" "$name"
-    ;;
-
-  submodule)
-    action="status"; url=""; path=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --add) action="add"; url="$2"; path="$3"; shift 3;;
-        --update) action="update"; shift 1;;
-        --status) action="status"; shift 1;;
-        *) break;;
-      esac
-    done
-    case "$action" in
-      add)
-        [ -n "$url" ] && [ -n "$path" ] || { err "--add <url> <path> required"; exit 1; }
-        git submodule add "$url" "$path" >\/dev\/null
-        add_row 1 submodule "OK" "add $path"
-        ;;
-      update)
-        git submodule update --init --recursive >\/dev\/null
-        add_row 1 submodule "OK" "update"
-        ;;
-      status)
-        s="$(git submodule status 2>\/dev\/null || true)"
-        add_row 1 submodule "OK" "$(printf '%s' "$s" | tr '\n' '; ' | sed 's/; $//')"
-        ;;
-    esac
-    ;;
-
-  remotes)
-    out="$(git remote -v 2>/dev/null || true)"
-    add_row 1 remotes "OK" "$(printf '%s' "$out" | tr '\n' '; ' | sed 's/; $//')"
+    add_row 1 remove-remote OK "$name"
     ;;
 
   add-upstream)
@@ -397,88 +172,142 @@ case "$cmd" in
     done
     [ -n "$upstream" ] || { err "--upstream required"; usage; exit 1; }
     if git remote get-url upstream >/dev/null 2>&1; then
-      add_row 1 add-upstream "SKIP" "upstream already exists"
+      add_row 1 add-upstream SKIP "upstream exists"
     else
       git remote add upstream "https://github.com/$upstream.git"
-      add_row 1 add-upstream "OK" "$upstream"
+      add_row 1 add-upstream OK "$upstream"
     fi
+    ;;
+
+  status)
+    s="$(git status --porcelain 2>/dev/null || true)"
+    if [ -n "$s" ]; then add_row 1 status DIRTY "$(printf '%s' "$s" | tr '\n' '; ' | sed 's/; $//')";
+    else add_row 1 status CLEAN "no changes"; fi
+    ;;
+
+  diff)
+    staged=0
+    [ "${1-}" = "--staged" ] && staged=1
+    if [ "$staged" -eq 1 ]; then d="$(git diff --staged --name-status)"; else d="$(git diff --name-status)"; fi
+    add_row 1 diff OK "$(printf '%s' "$d" | tr '\n' '; ' | sed 's/; $//')"
+    ;;
+
+  log)
+    n=10
+    [ "${1-}" = "--n" ] && { n="$2"; }
+    l="$(git log -n "$n" --oneline 2>/dev/null || true)"
+    add_row 1 log OK "$(printf '%s' "$l" | tr '\n' '; ' | sed 's/; $//')"
     ;;
 
   branches)
     l="$(git branch --format='%(refname:short)' | tr '\n' ', ' | sed 's/, $//')"
     r="$(git branch -r --format='%(refname:short)' | tr '\n' ', ' | sed 's/, $//')"
-    add_row 1 local "OK" "$l"
-    add_row 2 remote "OK" "$r"
+    add_row 1 local OK "$l"; add_row 2 remote OK "$r"
+    ;;
+
+  create-branch)
+    name=""; from=""
+    while [ $# -gt 0 ]; do case "$1" in --name) name="$2"; shift 2;; --from) from="$2"; shift 2;; *) break;; esac; done
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    [ -n "$from" ] && git checkout -b "$name" "$from" >/dev/null || git checkout -b "$name" >/dev/null
+    add_row 1 create-branch OK "$name"
+    ;;
+
+  checkout)
+    [ "${1-}" = "--name" ] && name="$2" || name="${1-}"
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    git checkout "$name" >/dev/null
+    add_row 1 checkout OK "$name"
+    ;;
+
+  add)
+    path="-A"; [ "${1-}" = "--path" ] && path="$2"
+    git add "$path"; add_row 1 add OK "$path"
+    ;;
+
+  commit)
+    msg=""; [ "${1-}" = "--message" ] && msg="$2"
+    [ -n "$msg" ] || { err "--message required"; usage; exit 1; }
+    ensure_git_identity
+    git commit -m "$msg" >/dev/null
+    add_row 1 commit OK "$msg"
+    ;;
+
+  fetch)
+    remote="origin"; [ "${1-}" = "--remote" ] && remote="$2"
+    git fetch "$remote" >/dev/null; add_row 1 fetch OK "$remote"
+    ;;
+
+  pull)
+    remote="origin"; br=""
+    while [ $# -gt 0 ]; do case "$1" in --remote) remote="$2"; shift 2;; --branch) br="$2"; shift 2;; *) break;; esac; done
+    [ -n "$br" ] && git pull "$remote" "$br" >/dev/null || git pull >/dev/null
+    add_row 1 pull OK "${remote}${br:+/$br}"
+    ;;
+
+  push)
+    remote="origin"; br=""
+    while [ $# -gt 0 ]; do case "$1" in --remote) remote="$2"; shift 2;; --branch) br="$2"; shift 2;; *) break;; esac; done
+    ensure_askpass
+    [ -n "$br" ] && git push "$remote" "$br" >/dev/null || git push >/dev/null
+    add_row 1 push OK "${remote}${br:+/$br}"
+    ;;
+
+  stash)
+    case "${1-}" in
+      --save) git stash push -m "${2:-wip}" >/dev/null; add_row 1 stash OK saved;;
+      --pop) git stash pop >/dev/null || true; add_row 1 stash OK popped;;
+      --apply) git stash apply >/dev/null || true; add_row 1 stash OK applied;;
+      *) l="$(git stash list || true)"; add_row 1 stash OK "$(printf '%s' "$l" | tr '\n' '; ' | sed 's/; $//')";;
+    esac
+    ;;
+
+  tag)
+    name=""; msg=""
+    while [ $# -gt 0 ]; do case "$1" in --name) name="$2"; shift 2;; --message) msg="$2"; shift 2;; *) break;; esac; done
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    [ -n "$msg" ] && git tag -a "$name" -m "$msg" || git tag "$name"
+    add_row 1 tag OK "$name"
+    ;;
+
+  submodule)
+    case "${1-}" in
+      --add) git submodule add "$2" "$3" >/dev/null; add_row 1 submodule OK "add $3";;
+      --update) git submodule update --init --recursive >/dev/null; add_row 1 submodule OK update;;
+      *) s="$(git submodule status 2>/dev/null || true)"; add_row 1 submodule OK "$(printf '%s' "$s" | tr '\n' '; ' | sed 's/; $//')";;
+    esac
     ;;
 
   delete-branches)
-    keep="main"
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --keep) keep="$2"; shift 2;;
-        *) break;;
-      esac
-    done
+    keep="main"; [ "${1-}" = "--keep" ] && keep="$2"
     ensure_askpass
-    # local delete
     i=1
-    for b in $(git branch --format='%(refname:short)'); do
-      [ "$b" = "$keep" ] && continue
-      git branch -D "$b" >/dev/null 2>&1 || true
-      add_row "$i" "delete local branch" "OK" "$b"
-      i=$((i+1))
-    done
-    # remote delete (origin only)
-    for rb in $(git branch -r --format='%(refname:short)' | grep '^origin/' | sed 's#^origin/##'); do
-      [ "$rb" = "$keep" ] && continue
-      git push origin --delete "$rb" >/dev/null 2>&1 || true
-      add_row "$i" "delete remote branch" "OK" "origin/$rb"
-      i=$((i+1))
-    done
+    for b in $(git branch --format='%(refname:short)'); do [ "$b" = "$keep" ] && continue; git branch -D "$b" >/dev/null 2>&1 || true; add_row "$i" "delete local branch" OK "$b"; i=$((i+1)); done
+    for rb in $(git branch -r --format='%(refname:short)' | grep '^origin/' | sed 's#^origin/##'); do [ "$rb" = "$keep" ] && continue; git push origin --delete "$rb" >/dev/null 2>&1 || true; add_row "$i" "delete remote branch" OK "origin/$rb"; i=$((i+1)); done
     ;;
 
   empty-dir)
-    dir=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --dir) dir="$2"; shift 2;;
-        *) break;;
-      esac
-    done
+    dir=""; [ "${1-}" = "--dir" ] && dir="$2"
     [ -n "$dir" ] || { err "--dir required"; usage; exit 1; }
     ensure_git_identity
     mkdir -p "$dir"
-    # remove tracked files (including dotfiles)
     git rm -r --ignore-unmatch "$dir"/* "$dir"/.[!.]* "$dir"/..?* >/dev/null 2>&1 || true
-    mkdir -p "$dir"
-    : > "$dir/.gitkeep"
-    git add "$dir/.gitkeep"
-    add_row 1 empty-dir "OK" "$dir (kept via .gitkeep)"
+    mkdir -p "$dir"; : > "$dir/.gitkeep"; git add "$dir/.gitkeep"
+    add_row 1 empty-dir OK "$dir (kept via .gitkeep)"
     ;;
 
   restore-dir)
     src=""; dst=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --src) src="$2"; shift 2;;
-        --dst) dst="$2"; shift 2;;
-        *) break;;
-      esac
-    done
+    while [ $# -gt 0 ]; do case "$1" in --src) src="$2"; shift 2;; --dst) dst="$2"; shift 2;; *) break;; esac; done
     [ -n "$src" ] && [ -n "$dst" ] || { err "--src and --dst required"; usage; exit 1; }
-    ensure_git_identity
     [ -d "$src" ] || { err "src not found: $src"; exit 1; }
-    mkdir -p "$dst"
-    # delete placeholder if any
-    rm -f "$dst/.gitkeep" || true
-    # remove tracked files under dst
+    ensure_git_identity
+    rm -f "$dst/.gitkeep" 2>/dev/null || true
     git rm -r --ignore-unmatch "$dst"/* "$dst"/.[!.]* "$dst"/..?* >/dev/null 2>&1 || true
-    mkdir -p "$dst"
-    cp -a "$src"/. "$dst"/
-    # make common scripts executable if present
+    mkdir -p "$dst"; cp -a "$src"/. "$dst"/
     find "$dst"/scripts -type f -name '*.sh' -exec chmod +x {} \; 2>/dev/null || true
     git add -A "$dst"
-    add_row 1 restore-dir "OK" "$src -> $dst"
+    add_row 1 restore-dir OK "$src -> $dst"
     ;;
 
   push-main)
@@ -487,35 +316,147 @@ case "$cmd" in
     git checkout main >/dev/null 2>&1 || true
     git pull --ff-only origin main >/dev/null 2>&1 || true
     git push origin main >/dev/null
-    add_row 1 push-main "OK" "pushed to origin/main"
+    add_row 1 push-main OK pushed
     ;;
 
   pr)
     upstream=""; head=""; base="main"; title=""; body=""
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        --upstream) upstream="$2"; shift 2;;
-        --head) head="$2"; shift 2;;
-        --base) base="$2"; shift 2;;
-        --title) title="$2"; shift 2;;
-        --body) body="$2"; shift 2;;
-        *) break;;
-      esac
-    done
+    while [ $# -gt 0 ]; do case "$1" in --upstream) upstream="$2"; shift 2;; --head) head="$2"; shift 2;; --base) base="$2"; shift 2;; --title) title="$2"; shift 2;; --body) body="$2"; shift 2;; *) break;; esac; done
     [ -n "$upstream" ] && [ -n "$head" ] && [ -n "$title" ] || { err "--upstream --head --title required"; usage; exit 1; }
     need_env GITHUB_TOKEN
-    url="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; upstream=os.environ["UP"]; owner,repo=upstream.split("/",1); payload={"title":os.environ["TITLE"],"head":os.environ["HEAD"],"base":os.environ.get("BASE","main"),"body":os.environ.get("BODY","")}; data=json.dumps(payload).encode("utf-8"); api="https://api.github.com"; req=urllib.request.Request(f"{api}/repos/{owner}/{repo}/pulls",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json");
+    export UP="$upstream" HEAD="$head" BASE="$base" TITLE="$title" BODY="$body"
+    out="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["UP"].split("/",1); payload={"title":os.environ["TITLE"],"head":os.environ["HEAD"],"base":os.environ.get("BASE","main"),"body":os.environ.get("BODY","")}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/pulls",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json");
 try:
- resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))
+  resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))
 except urllib.error.HTTPError as e:
- err=e.read().decode("utf-8","ignore"); print("HTTP %s"%e.code); print(err[:300])' )" || true
-    if printf '%s' "$url" | grep -q '^https://'; then
-      add_row 1 pr "OK" "$url"
-    else
-      add_row 1 pr "FAIL" "$(printf '%s' "$url" | tr '\n' ' ' | sed 's/  */ /g')"
-      print_summary
-      exit 1
-    fi
+  err=e.read().decode("utf-8","ignore"); print("HTTP %s"%e.code+" "+err[:200])' 2>/dev/null)" || true
+    add_row 1 pr OK "$out"
+    ;;
+
+  gh-issues-list)
+    repo=""; state="open"
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --state) state="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" STATE="$state"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); state=os.environ.get("STATE","open"); url=f"https://api.github.com/repos/{owner}/{repo}/issues?state={state}&per_page=20"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); lines=[]
+for it in data:
+  if "pull_request" in it: continue
+  lines.append(f"#{it['number']} {it['title']}")
+print("; ".join(lines))' 2>/dev/null)" || true
+    add_row 1 gh-issues-list OK "$out"
+    ;;
+
+  gh-issue-create)
+    repo=""; title=""; body=""
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --title) title="$2"; shift 2;; --body) body="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] && [ -n "$title" ] || { err "--repo --title required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" TITLE="$title" BODY="$body"
+    out="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"title":os.environ["TITLE"],"body":os.environ.get("BODY","")}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/issues",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json");
+try:
+  resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))
+except urllib.error.HTTPError as e:
+  err=e.read().decode("utf-8","ignore"); print("HTTP %s"%e.code+" "+err[:120])' 2>/dev/null)" || true
+    add_row 1 gh-issue-create OK "$out"
+    ;;
+
+  gh-issue-close)
+    repo=""; num=""
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --number) num="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] && [ -n "$num" ] || { err "--repo --number required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" NUM="$num"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); num=os.environ["NUM"]; payload={"state":"closed"}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/issues/{num}",data=data,method="PATCH"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("state",""))' 2>/dev/null)" || true
+    add_row 1 gh-issue-close OK "$out"
+    ;;
+
+  gh-labels-list)
+    repo=""; [ "${1-}" = "--repo" ] && repo="$2"
+    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); url=f"https://api.github.com/repos/{owner}/{repo}/labels?per_page=50"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); print("; ".join([it.get("name","") for it in data]))' 2>/dev/null)" || true
+    add_row 1 gh-labels-list OK "$out"
+    ;;
+
+  gh-label-create)
+    repo=""; name=""; color=""; desc=""
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --name) name="$2"; shift 2;; --color) color="$2"; shift 2;; --description) desc="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] && [ -n "$name" ] || { err "--repo --name required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" NAME="$name" COLOR="$color" DESC="$desc"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"name":os.environ["NAME"],"color":(os.environ.get("COLOR") or "ededed"),"description":os.environ.get("DESC","")}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/labels",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("name",""))' 2>/dev/null)" || true
+    add_row 1 gh-label-create OK "$out"
+    ;;
+
+  gh-milestones-list)
+    repo=""; state="open"
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --state) state="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" STATE="$state"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); state=os.environ.get("STATE","open"); url=f"https://api.github.com/repos/{owner}/{repo}/milestones?state={state}&per_page=30"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); print("; ".join([f"#{it['number']} {it['title']}" for it in data]))' 2>/dev/null)" || true
+    add_row 1 gh-milestones-list OK "$out"
+    ;;
+
+  gh-milestone-create)
+    repo=""; title=""; desc=""; due=""
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --title) title="$2"; shift 2;; --description) desc="$2"; shift 2;; --due) due="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] && [ -n "$title" ] || { err "--repo --title required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" TITLE="$title" DESC="$desc" DUE="$due"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"title":os.environ["TITLE"],"description":os.environ.get("DESC","")}; due=os.environ.get("DUE","");
+if due: payload["due_on"]=due+"T00:00:00Z";
+data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/milestones",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("title",""))' 2>/dev/null)" || true
+    add_row 1 gh-milestone-create OK "$out"
+    ;;
+
+  gh-releases-list)
+    repo=""; [ "${1-}" = "--repo" ] && repo="$2"
+    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); url=f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=10"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); print("; ".join([it.get("tag_name","") for it in data]))' 2>/dev/null)" || true
+    add_row 1 gh-releases-list OK "$out"
+    ;;
+
+  gh-release-create)
+    repo=""; tag=""; name=""; body=""; draft="false"; pre="false"
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --tag) tag="$2"; shift 2;; --name) name="$2"; shift 2;; --body) body="$2"; shift 2;; --draft) draft="$2"; shift 2;; --prerelease) pre="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] && [ -n "$tag" ] && [ -n "$name" ] || { err "--repo --tag --name required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" TAG="$tag" NAME="$name" BODY="$body" DRAFT="$draft" PRE="$pre"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); payload={"tag_name":os.environ["TAG"],"name":os.environ["NAME"],"body":os.environ.get("BODY","")}; payload["draft"]= (os.environ.get("DRAFT","false").lower()=="true"); payload["prerelease"]= (os.environ.get("PRE","false").lower()=="true"); data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/releases",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json"); resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))' 2>/dev/null)" || true
+    add_row 1 gh-release-create OK "$out"
+    ;;
+
+  gh-actions-list)
+    repo=""; [ "${1-}" = "--repo" ] && repo="$2"
+    [ -n "$repo" ] || { err "--repo required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo"
+    out="$(python3 -c 'import os,json,urllib.request; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); url=f"https://api.github.com/repos/{owner}/{repo}/actions/workflows?per_page=50"; req=urllib.request.Request(url,headers={"Authorization":"Bearer "+tok,"Accept":"application/vnd.github+json","User-Agent":"minis"}); data=json.load(urllib.request.urlopen(req,timeout=30)); w=data.get("workflows",[]); print("; ".join([f"{it['id']} {it['name']}" for it in w[:20]]))' 2>/dev/null)" || true
+    add_row 1 gh-actions-list OK "$out"
+    ;;
+
+  gh-actions-dispatch)
+    repo=""; wf=""; ref="main"; inputs="{}"
+    while [ $# -gt 0 ]; do case "$1" in --repo) repo="$2"; shift 2;; --workflow) wf="$2"; shift 2;; --ref) ref="$2"; shift 2;; --inputs) inputs="$2"; shift 2;; *) break;; esac; done
+    [ -n "$repo" ] && [ -n "$wf" ] || { err "--repo --workflow required"; exit 1; }
+    need_env GITHUB_TOKEN
+    export REPO="$repo" WF="$wf" REF="$ref" INPUTS="$inputs"
+    out="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; owner,repo=os.environ["REPO"].split("/",1); wf=os.environ["WF"]; ref=os.environ.get("REF","main");
+try:
+  inputs=json.loads(os.environ.get("INPUTS","{}") or "{}")
+except Exception:
+  inputs={}
+payload={"ref":ref,"inputs":inputs}; data=json.dumps(payload).encode("utf-8"); req=urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{wf}/dispatches",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json");
+try:
+  r=urllib.request.urlopen(req,timeout=30); print(getattr(r,"status",204))
+except urllib.error.HTTPError as e:
+  print(e.code)' 2>/dev/null)" || true
+    add_row 1 gh-actions-dispatch OK "$out"
     ;;
 
   *)

--- a/github-sync-helper/scripts/gh_sync.sh
+++ b/github-sync-helper/scripts/gh_sync.sh
@@ -1,0 +1,527 @@
+#!/bin/sh
+# github-sync-helper: reusable GitHub sync workflows for Minis
+# Requirements: git, python3, env GITHUB_TOKEN
+set -e
+
+# ---------- helpers ----------
+err() { printf '%s\n' "$*" >&2; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { err "missing command: $1"; exit 1; }
+}
+
+need_env() {
+  name="$1"
+  eval "val=\${$name-}"
+  [ -n "$val" ] || { err "missing env: $name"; exit 1; }
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null
+}
+
+ensure_git_identity() {
+  # Keep it local to repo; do not fail if already set
+  if [ -z "$(git config user.name || true)" ]; then
+    git config user.name "mowenyun"
+  fi
+  if [ -z "$(git config user.email || true)" ]; then
+    git config user.email "mowenyun@users.noreply.github.com"
+  fi
+}
+
+ensure_askpass() {
+  need_env GITHUB_TOKEN
+  ASKPASS="/var/minis/workspace/.git_askpass.sh"
+  if [ ! -f "$ASKPASS" ]; then
+    cat > "$ASKPASS" <<'EOF'
+#!/bin/sh
+case "$1" in
+  *Username*) echo "x-access-token" ;;
+  *Password*) echo "$GITHUB_TOKEN" ;;
+  *) echo "" ;;
+esac
+EOF
+    chmod +x "$ASKPASS"
+  fi
+  export GIT_ASKPASS="$ASKPASS"
+  export GIT_TERMINAL_PROMPT=0
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sh gh_sync.sh init
+  sh gh_sync.sh clone --url <url> [--dir <path>]
+  sh gh_sync.sh remotes
+  sh gh_sync.sh add-remote --name <n> --url <url>
+  sh gh_sync.sh set-remote-url --name <n> --url <url>
+  sh gh_sync.sh remove-remote --name <n>
+  sh gh_sync.sh add-upstream --upstream <owner/repo>
+  sh gh_sync.sh status
+  sh gh_sync.sh diff [--staged]
+  sh gh_sync.sh log [--n <k>]
+  sh gh_sync.sh branches
+  sh gh_sync.sh create-branch --name <b> [--from <ref>]
+  sh gh_sync.sh checkout --name <b>
+  sh gh_sync.sh add [--path <p>]
+  sh gh_sync.sh commit --message <m>
+  sh gh_sync.sh fetch [--remote <n>]
+  sh gh_sync.sh pull [--remote <n>] [--branch <b>]
+  sh gh_sync.sh push [--remote <n>] [--branch <b>]
+  sh gh_sync.sh stash [--save <msg> | --pop | --apply | --list]
+  sh gh_sync.sh tag --name <tag> [--message <msg>]
+  sh gh_sync.sh submodule [--add <url> <path> | --update | --status]
+  sh gh_sync.sh delete-branches --keep <branch>
+  sh gh_sync.sh empty-dir --dir <path>
+  sh gh_sync.sh restore-dir --src <path> --dst <path>
+  sh gh_sync.sh push-main
+  sh gh_sync.sh pr --upstream <owner/repo> --head <owner:branch> --base <branch> --title <t> --body <b>
+EOF
+}
+
+cmd="$1"; shift || true
+
+need_cmd git
+need_cmd python3
+
+ROOT="$(repo_root)"
+[ -n "$ROOT" ] || { err "not inside a git repo"; exit 1; }
+cd "$ROOT"
+
+enable_table_summary() {
+  # call: enable_table_summary; then append to $SUMMARY
+  SUMMARY=""
+}
+
+add_row() {
+  # add_row idx col2 col3 col4
+  i="$1"; c2="$2"; c3="$3"; c4="$4"
+  SUMMARY="$SUMMARY
+| $i | $c2 | $c3 | $c4 |"
+}
+
+print_summary() {
+  printf '%s\n' "| 序号 | 动作 | 结果 | 备注 |"
+  printf '%s\n' "|---:|---|---|---|"
+  printf '%s\n' "$SUMMARY" | sed '1{/^$/d;}'
+}
+
+enable_table_summary
+
+case "$cmd" in
+  init)
+    git init >\/dev\/null 2>&1 || true
+    add_row 1 init "OK" "initialized"
+    ;;
+
+  clone)
+    url=""; dir=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --url) url="$2"; shift 2;;
+        --dir) dir="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$url" ] || { err "--url required"; usage; exit 1; }
+    if [ -n "$dir" ]; then
+      git clone "$url" "$dir" >\/dev\/null
+      add_row 1 clone "OK" "$url -> $dir"
+    else
+      git clone "$url" >\/dev\/null
+      add_row 1 clone "OK" "$url"
+    fi
+    ;;
+
+  add-remote)
+    name=""; url=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --name) name="$2"; shift 2;;
+        --url) url="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$name" ] && [ -n "$url" ] || { err "--name and --url required"; usage; exit 1; }
+    git remote add "$name" "$url"
+    add_row 1 add-remote "OK" "$name=$url"
+    ;;
+
+  set-remote-url)
+    name=""; url=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --name) name="$2"; shift 2;;
+        --url) url="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$name" ] && [ -n "$url" ] || { err "--name and --url required"; usage; exit 1; }
+    git remote set-url "$name" "$url"
+    add_row 1 set-remote-url "OK" "$name=$url"
+    ;;
+
+  remove-remote)
+    name=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --name) name="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    git remote remove "$name"
+    add_row 1 remove-remote "OK" "$name"
+    ;;
+
+  status)
+    s="$(git status --porcelain 2>\/dev\/null || true)"
+    if [ -n "$s" ]; then
+      add_row 1 status "DIRTY" "$(printf '%s' "$s" | tr '\n' '; ' | sed 's/; $//')"
+    else
+      add_row 1 status "CLEAN" "no changes"
+    fi
+    ;;
+
+  diff)
+    staged=0
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --staged) staged=1; shift 1;;
+        *) break;;
+      esac
+    done
+    if [ "$staged" -eq 1 ]; then
+      d="$(git diff --staged --name-status)"
+    else
+      d="$(git diff --name-status)"
+    fi
+    add_row 1 diff "OK" "$(printf '%s' "$d" | tr '\n' '; ' | sed 's/; $//')"
+    ;;
+
+  log)
+    n=10
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --n) n="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    l="$(git log -n "$n" --oneline 2>\/dev\/null || true)"
+    add_row 1 log "OK" "$(printf '%s' "$l" | tr '\n' '; ' | sed 's/; $//')"
+    ;;
+
+  create-branch)
+    name=""; from=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --name) name="$2"; shift 2;;
+        --from) from="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    if [ -n "$from" ]; then
+      git checkout -b "$name" "$from" >\/dev\/null
+    else
+      git checkout -b "$name" >\/dev\/null
+    fi
+    add_row 1 create-branch "OK" "$name"
+    ;;
+
+  checkout)
+    name=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --name) name="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    git checkout "$name" >\/dev\/null
+    add_row 1 checkout "OK" "$name"
+    ;;
+
+  add)
+    path="-A"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --path) path="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    git add "$path"
+    add_row 1 add "OK" "$path"
+    ;;
+
+  commit)
+    msg=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --message) msg="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$msg" ] || { err "--message required"; usage; exit 1; }
+    ensure_git_identity
+    git commit -m "$msg" >\/dev\/null
+    add_row 1 commit "OK" "$msg"
+    ;;
+
+  fetch)
+    remote="origin"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --remote) remote="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    git fetch "$remote" >\/dev\/null
+    add_row 1 fetch "OK" "$remote"
+    ;;
+
+  pull)
+    remote="origin"; br=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --remote) remote="$2"; shift 2;;
+        --branch) br="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    if [ -n "$br" ]; then
+      git pull "$remote" "$br" >\/dev\/null
+      add_row 1 pull "OK" "$remote/$br"
+    else
+      git pull >\/dev\/null
+      add_row 1 pull "OK" "default"
+    fi
+    ;;
+
+  push)
+    remote="origin"; br=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --remote) remote="$2"; shift 2;;
+        --branch) br="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    ensure_askpass
+    if [ -n "$br" ]; then
+      git push "$remote" "$br" >\/dev\/null
+      add_row 1 push "OK" "$remote/$br"
+    else
+      git push >\/dev\/null
+      add_row 1 push "OK" "default"
+    fi
+    ;;
+
+  stash)
+    sub="list"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --pop) sub="pop"; shift 1;;
+        --apply) sub="apply"; shift 1;;
+        --save) sub="save"; msg="$2"; shift 2;;
+        --list) sub="list"; shift 1;;
+        *) break;;
+      esac
+    done
+    case "$sub" in
+      save) git stash push -m "${msg:-wip}" >\/dev\/null; add_row 1 stash "OK" "saved";;
+      pop) git stash pop >\/dev\/null || true; add_row 1 stash "OK" "popped";;
+      apply) git stash apply >\/dev\/null || true; add_row 1 stash "OK" "applied";;
+      list) l="$(git stash list || true)"; add_row 1 stash "OK" "$(printf '%s' "$l" | tr '\n' '; ' | sed 's/; $//')";;
+    esac
+    ;;
+
+  tag)
+    name=""; msg=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --name) name="$2"; shift 2;;
+        --message) msg="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$name" ] || { err "--name required"; usage; exit 1; }
+    if [ -n "$msg" ]; then
+      git tag -a "$name" -m "$msg"
+    else
+      git tag "$name"
+    fi
+    add_row 1 tag "OK" "$name"
+    ;;
+
+  submodule)
+    action="status"; url=""; path=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --add) action="add"; url="$2"; path="$3"; shift 3;;
+        --update) action="update"; shift 1;;
+        --status) action="status"; shift 1;;
+        *) break;;
+      esac
+    done
+    case "$action" in
+      add)
+        [ -n "$url" ] && [ -n "$path" ] || { err "--add <url> <path> required"; exit 1; }
+        git submodule add "$url" "$path" >\/dev\/null
+        add_row 1 submodule "OK" "add $path"
+        ;;
+      update)
+        git submodule update --init --recursive >\/dev\/null
+        add_row 1 submodule "OK" "update"
+        ;;
+      status)
+        s="$(git submodule status 2>\/dev\/null || true)"
+        add_row 1 submodule "OK" "$(printf '%s' "$s" | tr '\n' '; ' | sed 's/; $//')"
+        ;;
+    esac
+    ;;
+
+  remotes)
+    out="$(git remote -v 2>/dev/null || true)"
+    add_row 1 remotes "OK" "$(printf '%s' "$out" | tr '\n' '; ' | sed 's/; $//')"
+    ;;
+
+  add-upstream)
+    upstream=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --upstream) upstream="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$upstream" ] || { err "--upstream required"; usage; exit 1; }
+    if git remote get-url upstream >/dev/null 2>&1; then
+      add_row 1 add-upstream "SKIP" "upstream already exists"
+    else
+      git remote add upstream "https://github.com/$upstream.git"
+      add_row 1 add-upstream "OK" "$upstream"
+    fi
+    ;;
+
+  branches)
+    l="$(git branch --format='%(refname:short)' | tr '\n' ', ' | sed 's/, $//')"
+    r="$(git branch -r --format='%(refname:short)' | tr '\n' ', ' | sed 's/, $//')"
+    add_row 1 local "OK" "$l"
+    add_row 2 remote "OK" "$r"
+    ;;
+
+  delete-branches)
+    keep="main"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --keep) keep="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    ensure_askpass
+    # local delete
+    i=1
+    for b in $(git branch --format='%(refname:short)'); do
+      [ "$b" = "$keep" ] && continue
+      git branch -D "$b" >/dev/null 2>&1 || true
+      add_row "$i" "delete local branch" "OK" "$b"
+      i=$((i+1))
+    done
+    # remote delete (origin only)
+    for rb in $(git branch -r --format='%(refname:short)' | grep '^origin/' | sed 's#^origin/##'); do
+      [ "$rb" = "$keep" ] && continue
+      git push origin --delete "$rb" >/dev/null 2>&1 || true
+      add_row "$i" "delete remote branch" "OK" "origin/$rb"
+      i=$((i+1))
+    done
+    ;;
+
+  empty-dir)
+    dir=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --dir) dir="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$dir" ] || { err "--dir required"; usage; exit 1; }
+    ensure_git_identity
+    mkdir -p "$dir"
+    # remove tracked files (including dotfiles)
+    git rm -r --ignore-unmatch "$dir"/* "$dir"/.[!.]* "$dir"/..?* >/dev/null 2>&1 || true
+    mkdir -p "$dir"
+    : > "$dir/.gitkeep"
+    git add "$dir/.gitkeep"
+    add_row 1 empty-dir "OK" "$dir (kept via .gitkeep)"
+    ;;
+
+  restore-dir)
+    src=""; dst=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --src) src="$2"; shift 2;;
+        --dst) dst="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$src" ] && [ -n "$dst" ] || { err "--src and --dst required"; usage; exit 1; }
+    ensure_git_identity
+    [ -d "$src" ] || { err "src not found: $src"; exit 1; }
+    mkdir -p "$dst"
+    # delete placeholder if any
+    rm -f "$dst/.gitkeep" || true
+    # remove tracked files under dst
+    git rm -r --ignore-unmatch "$dst"/* "$dst"/.[!.]* "$dst"/..?* >/dev/null 2>&1 || true
+    mkdir -p "$dst"
+    cp -a "$src"/. "$dst"/
+    # make common scripts executable if present
+    find "$dst"/scripts -type f -name '*.sh' -exec chmod +x {} \; 2>/dev/null || true
+    git add -A "$dst"
+    add_row 1 restore-dir "OK" "$src -> $dst"
+    ;;
+
+  push-main)
+    ensure_askpass
+    ensure_git_identity
+    git checkout main >/dev/null 2>&1 || true
+    git pull --ff-only origin main >/dev/null 2>&1 || true
+    git push origin main >/dev/null
+    add_row 1 push-main "OK" "pushed to origin/main"
+    ;;
+
+  pr)
+    upstream=""; head=""; base="main"; title=""; body=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --upstream) upstream="$2"; shift 2;;
+        --head) head="$2"; shift 2;;
+        --base) base="$2"; shift 2;;
+        --title) title="$2"; shift 2;;
+        --body) body="$2"; shift 2;;
+        *) break;;
+      esac
+    done
+    [ -n "$upstream" ] && [ -n "$head" ] && [ -n "$title" ] || { err "--upstream --head --title required"; usage; exit 1; }
+    need_env GITHUB_TOKEN
+    url="$(python3 -c 'import os,json,urllib.request,urllib.error; tok=os.environ["GITHUB_TOKEN"]; upstream=os.environ["UP"]; owner,repo=upstream.split("/",1); payload={"title":os.environ["TITLE"],"head":os.environ["HEAD"],"base":os.environ.get("BASE","main"),"body":os.environ.get("BODY","")}; data=json.dumps(payload).encode("utf-8"); api="https://api.github.com"; req=urllib.request.Request(f"{api}/repos/{owner}/{repo}/pulls",data=data,method="POST"); req.add_header("Authorization","Bearer "+tok); req.add_header("Accept","application/vnd.github+json"); req.add_header("User-Agent","minis"); req.add_header("Content-Type","application/json");
+try:
+ resp=json.load(urllib.request.urlopen(req,timeout=30)); print(resp.get("html_url",""))
+except urllib.error.HTTPError as e:
+ err=e.read().decode("utf-8","ignore"); print("HTTP %s"%e.code); print(err[:300])' )" || true
+    if printf '%s' "$url" | grep -q '^https://'; then
+      add_row 1 pr "OK" "$url"
+    else
+      add_row 1 pr "FAIL" "$(printf '%s' "$url" | tr '\n' ' ' | sed 's/  */ /g')"
+      print_summary
+      exit 1
+    fi
+    ;;
+
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+print_summary


### PR DESCRIPTION
Adds new skill `github-sync-helper` with:
- Git basics helper commands (init/clone/remote/branch/commit/push/pull/tag/stash/submodule)
- Workflow helpers (empty-dir/restore-dir/delete-branches/pr)
- GitHub platform API helpers: issues/labels/milestones/releases/actions

Note: opened from fork main as requested (no new branch).