### PR TITLE
feat: add spotify-hub skill

### DIFF
--- a/spotify-hub/SKILL.md
+++ b/spotify-hub/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: spotify-hub
+version: 1.0.0
+description: 使用 Python + spotipy 控制 Spotify 播放的技能。支持播放/暂停/切歌/音量/随机、搜索歌曲并播放、按关键词混合生成歌单（如抖音热歌、某风格、某歌手）、查看当前播放状态和设备列表。当用户提到"Spotify"、"播放音乐"、"切歌"、"暂停"、"搜索歌曲"、"换歌单"、"spotify-hub"，或任何需要控制 Spotify 播放的场景，必须触发本技能。
+---
+
+# Spotify Hub
+
+通过 spotipy 库调用 Spotify Web API，控制播放并搜索音乐。
+
+## 依赖
+
+两个脚本均使用 **uv inline script** 声明依赖（`spotipy>=2.26.0`），用 `uv run` 执行时自动安装，无需手动 pip install，开箱即用。
+
+## 环境要求
+
+必须设置以下环境变量（未设置则引导用户创建）：
+- `SPOTIPY_CLIENT_ID` — [设置](minis://settings/environments?create_key=SPOTIPY_CLIENT_ID&create_value=)
+- `SPOTIPY_CLIENT_SECRET` — [设置](minis://settings/environments?create_key=SPOTIPY_CLIENT_SECRET&create_value=)
+- `SPOTIPY_REDIRECT_URI` — [设置](minis://settings/environments?create_key=SPOTIPY_REDIRECT_URI&create_value=http://127.0.0.1:8888/callback)
+
+凭证申请：https://developer.spotify.com/dashboard → Create App → Redirect URI 填 `http://127.0.0.1:8888/callback`
+
+## 授权流程（首次或 Token 失效时）
+
+Token 保存在 `~/.config/spotify/cache`，含 refresh_token，正常情况下永久有效，无需重复授权。
+
+**需要授权时**，在后台启动授权服务器，获取 URL 后直接给用户点击：
+
+```python
+# 后台启动授权服务器
+import subprocess, time
+subprocess.Popen(["uv", "run", "--script", "--cache-dir", "/root/.cache/uv",
+                              "/var/minis/skills/spotify-hub/scripts/spotify_auth.py"],
+                 stdout=open("/tmp/spotify_auth.log", "w"), stderr=subprocess.STDOUT)
+time.sleep(2)
+url = open("/tmp/spotify_auth_url.txt").read().strip()
+print(url)
+```
+
+然后在回复中给用户提供可点击的授权链接：
+`[👉 点击授权 Spotify](<url>)`
+
+授权完成后浏览器显示"✅ Spotify 授权成功！"，用户告知后即可继续操作。
+
+## 核心脚本
+
+所有操作通过 `/var/minis/skills/spotify-hub/scripts/spotify.py` 执行：
+
+```bash
+uv run --script --cache-dir /root/.cache/uv /var/minis/skills/spotify-hub/scripts/spotify.py <cmd> [args]
+```
+
+| 命令 | 说明 |
+|------|------|
+| `status` | 当前播放状态 + 设备列表 |
+| `play` / `pause` | 播放 / 暂停 |
+| `next` / `prev` | 下一首 / 上一首 |
+| `volume <0-100>` | 设置音量 |
+| `shuffle on/off` | 随机播放开关 |
+| `repeat off/track/context` | 循环模式 |
+| `seek <秒或mm:ss>` | 跳转进度 |
+| `search <关键词>` | 搜索并播放 |
+| `play-track <id/uri>` | 播放指定歌曲 |
+| `play-playlist <id/uri>` | 播放指定歌单 |
+| `save` / `unsave` | 收藏 / 取消收藏当前歌曲 |
+| `liked [数量]` | 查看已收藏歌曲 |
+| `recent [数量]` | 最近播放记录 |
+| `top [tracks/artists] [数量]` | 最常听歌曲 / 艺术家 |
+| `playlists` | 查看我的歌单列表 |
+| `create-playlist <名称>` | 新建歌单 |
+| `add-to-playlist <id>` | 当前歌曲加入歌单 |
+| `follow <艺术家名>` | 关注艺术家 |
+| `following` | 查看关注的艺术家 |
+
+## 热门歌单场景（如"抖音热歌"、"某风格"）
+
+第三方公开歌单会返回 403，**不要尝试读取歌单**，改用多关键词搜索混合播放：
+
+```python
+from scripts.spotify import get_sp, search_multi_and_play
+
+sp = get_sp()
+keywords = ["抖音热门", "douyin trending", "tiktok viral 2024", "抖音神曲"]
+search_multi_and_play(sp, keywords, count_each=10, market="HK")
+```
+
+或直接用 shell_execute 调用 spotify.py search：
+```bash
+uv run --script --cache-dir /root/.cache/uv /var/minis/skills/spotify-hub/scripts/spotify.py search "抖音热门"
+```
+
+## 注意事项
+
+- 播放控制需要设备处于活跃状态（手机/电脑已打开 Spotify 并播放过）
+- `market="HK"` 可搜到更多中文歌曲
+- spotipy 已预装（`pip show spotipy` 可验证）
+- Development Mode 下第三方公开歌单 403 是正常限制，用搜索代替

--- a/spotify-hub/scripts/spotify.py
+++ b/spotify-hub/scripts/spotify.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env -S uv run --script --cache-dir /root/.cache/uv
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["spotipy>=2.26.0"]
+# ///
+
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+import os, sys, random
+
+SCOPE = " ".join([
+    "user-read-playback-state", "user-modify-playback-state",
+    "user-read-currently-playing", "streaming",
+    "user-library-read", "user-library-modify",
+    "playlist-read-private", "playlist-read-collaborative",
+    "playlist-modify-public", "playlist-modify-private",
+    "user-read-private", "user-read-email",
+    "user-top-read", "user-read-recently-played",
+    "user-follow-read", "user-follow-modify",
+])
+CACHE_PATH = os.path.expanduser("~/.config/spotify/cache")
+
+def get_sp():
+    return spotipy.Spotify(auth_manager=SpotifyOAuth(
+        client_id=os.environ["SPOTIPY_CLIENT_ID"],
+        client_secret=os.environ["SPOTIPY_CLIENT_SECRET"],
+        redirect_uri=os.environ["SPOTIPY_REDIRECT_URI"],
+        scope=SCOPE, cache_path=CACHE_PATH, open_browser=False,
+    ))
+
+def get_active_device(sp):
+    devices = sp.devices()["devices"]
+    if not devices:
+        print("❌ 没有活跃设备，请先打开 Spotify 并播放任意歌曲")
+        return None
+    return next((d["id"] for d in devices if d["is_active"]), devices[0]["id"])
+
+def fmt_duration(ms):
+    s = ms // 1000
+    return f"{s//60}:{s%60:02d}"
+
+# ── 播放状态 ──────────────────────────────────────────────
+def cmd_status(sp):
+    cur = sp.current_playback()
+    if cur and cur.get("item"):
+        t = cur["item"]
+        state = "▶" if cur["is_playing"] else "⏸"
+        print(f"{state} {t['name']}")
+        print(f"   🎤 {', '.join(a['name'] for a in t['artists'])}")
+        print(f"   💿 {t['album']['name']}")
+        print(f"   ⏱ {fmt_duration(cur['progress_ms'])} / {fmt_duration(t['duration_ms'])}")
+        print(f"   🔀 随机: {'开' if cur.get('shuffle_state') else '关'}  "
+              f"🔁 循环: {cur.get('repeat_state','off')}")
+    else:
+        print("⏹ 当前没有播放任何内容")
+    print()
+    devices = sp.devices()["devices"]
+    if devices:
+        print("📱 设备：")
+        for d in devices:
+            print(f"  {'▶ ' if d['is_active'] else '  '}{d['name']} ({d['type']}) 音量:{d['volume_percent']}%")
+
+# ── 基础控制 ──────────────────────────────────────────────
+def cmd_play(sp):    sp.start_playback();  print("▶ 已播放")
+def cmd_pause(sp):   sp.pause_playback();  print("⏸ 已暂停")
+def cmd_next(sp):    sp.next_track();      print("⏭ 下一首")
+def cmd_prev(sp):    sp.previous_track();  print("⏮ 上一首")
+
+def cmd_volume(sp, args):
+    vol = int(args[0])
+    sp.volume(vol)
+    print(f"🔊 音量设为 {vol}%")
+
+def cmd_shuffle(sp, args):
+    state = args[0].lower() in ("on", "1", "true", "开")
+    sp.shuffle(state)
+    print(f"🔀 随机播放: {'开启' if state else '关闭'}")
+
+def cmd_repeat(sp, args):
+    # 模式: off / track / context
+    mode = args[0].lower() if args else "track"
+    alias = {"off":"off","关":"off","single":"track","单曲":"track","track":"track","list":"context","context":"context","列表":"context"}
+    mode = alias.get(mode, "track")
+    sp.repeat(mode)
+    labels = {"off":"关闭","track":"单曲循环","context":"列表循环"}
+    print(f"🔁 循环模式: {labels[mode]}")
+
+def cmd_seek(sp, args):
+    # 支持秒数或 mm:ss
+    pos = args[0]
+    if ":" in pos:
+        m, s = pos.split(":")
+        ms = (int(m) * 60 + int(s)) * 1000
+    else:
+        ms = int(pos) * 1000
+    sp.seek_track(ms)
+    print(f"⏩ 跳转到 {pos}")
+
+# ── 搜索 & 播放 ───────────────────────────────────────────
+def cmd_search(sp, args):
+    query = " ".join(args)
+    results = sp.search(q=query, type="track", limit=10, market="HK")
+    tracks = results["tracks"]["items"]
+    if not tracks:
+        print(f"❌ 未找到「{query}」"); return
+    device_id = get_active_device(sp)
+    if not device_id: return
+    sp.start_playback(device_id=device_id, uris=[t["uri"] for t in tracks])
+    print(f"▶ 正在播放 {len(tracks)} 首「{query}」：")
+    for i, t in enumerate(tracks):
+        print(f"  {i+1}. {t['name']} - {t['artists'][0]['name']} {fmt_duration(t['duration_ms'])}")
+
+def cmd_search_multi(sp, keywords, count_each=10):
+    """多关键词混合搜索播放（热门歌单场景）"""
+    tracks, seen = [], set()
+    for kw in keywords:
+        for t in sp.search(q=kw, type="track", limit=count_each, market="HK")["tracks"]["items"]:
+            if t["uri"] not in seen:
+                seen.add(t["uri"]); tracks.append(t)
+    random.shuffle(tracks)
+    device_id = get_active_device(sp)
+    if not device_id: return
+    sp.start_playback(device_id=device_id, uris=[t["uri"] for t in tracks])
+    print(f"▶ 正在播放 {len(tracks)} 首：")
+    for i, t in enumerate(tracks):
+        print(f"  {i+1}. {t['name']} - {t['artists'][0]['name']}")
+
+def cmd_play_track(sp, args):
+    tid = args[0]
+    uri = tid if tid.startswith("spotify:") else f"spotify:track:{tid}"
+    device_id = get_active_device(sp)
+    if device_id:
+        sp.start_playback(device_id=device_id, uris=[uri])
+        print(f"▶ 正在播放: {tid}")
+
+# ── 音乐库 ────────────────────────────────────────────────
+def cmd_save(sp):
+    cur = sp.current_playback()
+    if not cur or not cur.get("item"):
+        print("❌ 当前没有播放任何内容"); return
+    t = cur["item"]
+    sp.current_user_saved_tracks_add([t["id"]])
+    print(f"❤️  已收藏：{t['name']} - {t['artists'][0]['name']}")
+
+def cmd_unsave(sp):
+    cur = sp.current_playback()
+    if not cur or not cur.get("item"):
+        print("❌ 当前没有播放任何内容"); return
+    t = cur["item"]
+    sp.current_user_saved_tracks_delete([t["id"]])
+    print(f"💔 已取消收藏：{t['name']} - {t['artists'][0]['name']}")
+
+def cmd_liked(sp, args):
+    limit = int(args[0]) if args else 20
+    results = sp.current_user_saved_tracks(limit=limit)
+    print(f"❤️  已收藏歌曲（最近 {limit} 首）：")
+    for i, item in enumerate(results["items"]):
+        t = item["track"]
+        print(f"  {i+1}. {t['name']} - {t['artists'][0]['name']}")
+
+def cmd_recent(sp, args):
+    limit = int(args[0]) if args else 10
+    results = sp.current_user_recently_played(limit=limit)
+    print(f"🕐 最近播放（{limit} 首）：")
+    for i, item in enumerate(results["items"]):
+        t = item["track"]
+        print(f"  {i+1}. {t['name']} - {t['artists'][0]['name']}")
+
+def cmd_top(sp, args):
+    # top tracks / top artists
+    ttype = "artists" if args and args[0] == "artists" else "tracks"
+    limit = int(args[1]) if len(args) > 1 else 10
+    results = sp.current_user_top_tracks(limit=limit) if ttype == "tracks" else sp.current_user_top_artists(limit=limit)
+    label = "歌曲" if ttype == "tracks" else "艺术家"
+    print(f"🏆 你最常听的{label}（Top {limit}）：")
+    for i, item in enumerate(results["items"]):
+        name = item["name"]
+        extra = f" - {item['artists'][0]['name']}" if ttype == "tracks" else ""
+        print(f"  {i+1}. {name}{extra}")
+
+# ── 歌单管理 ──────────────────────────────────────────────
+def cmd_playlists(sp):
+    results = sp.current_user_playlists(limit=20)
+    print(f"📋 我的歌单（{results['total']} 个）：")
+    for i, p in enumerate(results["items"]):
+        print(f"  {i+1}. {p['name']} ({p['tracks']['total']} 首) id:{p['id']}")
+
+def cmd_play_playlist(sp, args):
+    pid = args[0]
+    uri = pid if pid.startswith("spotify:") else f"spotify:playlist:{pid}"
+    device_id = get_active_device(sp)
+    if device_id:
+        sp.start_playback(device_id=device_id, context_uri=uri)
+        print(f"▶ 正在播放歌单: {pid}")
+
+def cmd_create_playlist(sp, args):
+    name = " ".join(args)
+    user = sp.current_user()["id"]
+    p = sp.user_playlist_create(user, name, public=False)
+    print(f"✅ 已创建歌单：{name}  id:{p['id']}")
+
+def cmd_add_to_playlist(sp, args):
+    # add-to-playlist <playlist_id> （将当前歌曲加入歌单）
+    pid = args[0]
+    cur = sp.current_playback()
+    if not cur or not cur.get("item"):
+        print("❌ 当前没有播放任何内容"); return
+    t = cur["item"]
+    sp.playlist_add_items(pid, [t["uri"]])
+    print(f"➕ 已将「{t['name']}」加入歌单 {pid}")
+
+# ── 关注 ──────────────────────────────────────────────────
+def cmd_follow_artist(sp, args):
+    # 搜索艺术家并关注
+    query = " ".join(args)
+    results = sp.search(q=query, type="artist", limit=1)
+    artists = results["artists"]["items"]
+    if not artists:
+        print(f"❌ 未找到艺术家「{query}」"); return
+    a = artists[0]
+    sp.user_follow_artists([a["id"]])
+    print(f"✅ 已关注：{a['name']} (粉丝:{a['followers']['total']:,})")
+
+def cmd_following(sp):
+    results = sp.current_user_followed_artists(limit=20)
+    artists = results["artists"]["items"]
+    print(f"👥 关注的艺术家（{results['artists']['total']} 位）：")
+    for i, a in enumerate(artists):
+        print(f"  {i+1}. {a['name']} (粉丝:{a['followers']['total']:,})")
+
+# ── 主入口 ────────────────────────────────────────────────
+COMMANDS = {
+    # 状态
+    "status":           (cmd_status,          False, "当前播放状态 + 设备列表"),
+    # 基础控制
+    "play":             (cmd_play,            False, "继续播放"),
+    "pause":            (cmd_pause,           False, "暂停"),
+    "next":             (cmd_next,            False, "下一首"),
+    "prev":             (cmd_prev,            False, "上一首"),
+    "volume":           (cmd_volume,          True,  "设置音量  volume <0-100>"),
+    "shuffle":          (cmd_shuffle,         True,  "随机播放  shuffle on/off"),
+    "repeat":           (cmd_repeat,          True,  "循环模式  repeat off/track/context"),
+    "seek":             (cmd_seek,            True,  "跳转进度  seek <秒> 或 seek <mm:ss>"),
+    # 搜索播放
+    "search":           (cmd_search,          True,  "搜索并播放  search <关键词>"),
+    "play-track":       (cmd_play_track,      True,  "播放指定歌曲  play-track <id/uri>"),
+    "play-playlist":    (cmd_play_playlist,   True,  "播放歌单  play-playlist <id/uri>"),
+    # 音乐库
+    "save":             (cmd_save,            False, "收藏当前歌曲"),
+    "unsave":           (cmd_unsave,          False, "取消收藏当前歌曲"),
+    "liked":            (cmd_liked,           True,  "查看已收藏  liked [数量]"),
+    "recent":           (cmd_recent,          True,  "最近播放  recent [数量]"),
+    "top":              (cmd_top,             True,  "最常听  top [tracks/artists] [数量]"),
+    # 歌单管理
+    "playlists":        (cmd_playlists,       False, "查看我的歌单"),
+    "create-playlist":  (cmd_create_playlist, True,  "新建歌单  create-playlist <名称>"),
+    "add-to-playlist":  (cmd_add_to_playlist, True,  "当前歌曲加入歌单  add-to-playlist <id>"),
+    # 关注
+    "follow":           (cmd_follow_artist,   True,  "关注艺术家  follow <名称>"),
+    "following":        (cmd_following,       False, "查看关注的艺术家"),
+}
+
+def main():
+    sp = get_sp()
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "status"
+    args = sys.argv[2:]
+
+    if cmd not in COMMANDS:
+        print("🎵 Spotify Hub 支持的命令：\n")
+        for name, (_, _, desc) in COMMANDS.items():
+            print(f"  {name:<20} {desc}")
+        return
+
+    fn, has_args, _ = COMMANDS[cmd]
+    fn(sp, args) if has_args else fn(sp)
+
+if __name__ == "__main__":
+    main()

--- a/spotify-hub/scripts/spotify_auth.py
+++ b/spotify-hub/scripts/spotify_auth.py
@@ -1,0 +1,108 @@
+"""
+Spotify OAuth 授权脚本。
+启动本地 HTTP server 监听回调，打印授权 URL，自动捕获 code 换取 token。
+Token 保存至 ~/.config/spotify/cache，包含 refresh_token，永久免登录。
+
+用法：uv run --script --cache-dir /root/.cache/uv spotify_auth.py
+"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["spotipy>=2.26.0"]
+# ///
+
+import os, threading, urllib.parse, sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from spotipy.oauth2 import SpotifyOAuth
+
+SCOPE = " ".join([
+    # 播放控制
+    "user-read-playback-state",
+    "user-modify-playback-state",
+    "user-read-currently-playing",
+    "streaming",
+    # 音乐库
+    "user-library-read",
+    "user-library-modify",
+    # 歌单
+    "playlist-read-private",
+    "playlist-read-collaborative",
+    "playlist-modify-public",
+    "playlist-modify-private",
+    # 用户信息
+    "user-read-private",
+    "user-read-email",
+    # 收听历史 & 推荐
+    "user-top-read",
+    "user-read-recently-played",
+    # 关注
+    "user-follow-read",
+    "user-follow-modify",
+])
+REDIRECT_URI = os.environ["SPOTIPY_REDIRECT_URI"]
+CACHE_PATH = os.path.expanduser("~/.config/spotify/cache")
+
+parsed = urllib.parse.urlparse(REDIRECT_URI)
+PORT = parsed.port or 80
+CALLBACK_PATH = parsed.path or "/callback"
+
+os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+
+auth_manager = SpotifyOAuth(
+    client_id=os.environ["SPOTIPY_CLIENT_ID"],
+    client_secret=os.environ["SPOTIPY_CLIENT_SECRET"],
+    redirect_uri=REDIRECT_URI,
+    scope=SCOPE,
+    cache_path=CACHE_PATH,
+    open_browser=False,
+)
+
+# 已有有效 token 则跳过
+token_info = auth_manager.get_cached_token()
+if token_info and not auth_manager.is_token_expired(token_info):
+    print("✅ 已有有效 Token，无需重新授权")
+    sys.exit(0)
+
+auth_code = None
+server_done = threading.Event()
+
+class CallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        global auth_code
+        if self.path.startswith(CALLBACK_PATH):
+            params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            auth_code = params.get("code", [None])[0]
+            self.send_response(200)
+            self.send_header("Content-type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write("<h2>✅ Spotify 授权成功！可以关闭浏览器了 🎉</h2>".encode("utf-8"))
+            server_done.set()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+server = HTTPServer(("127.0.0.1", PORT), CallbackHandler)
+t = threading.Thread(target=lambda: server.serve_forever())
+t.daemon = True
+t.start()
+
+auth_url = auth_manager.get_authorize_url()
+
+# 写入文件供外部读取
+with open("/tmp/spotify_auth_url.txt", "w") as f:
+    f.write(auth_url)
+
+print(f"AUTH_URL={auth_url}", flush=True)
+print(f"⏳ 等待授权回调（监听 {REDIRECT_URI}）...", flush=True)
+
+server_done.wait(timeout=120)
+server.shutdown()
+
+if auth_code:
+    auth_manager.get_access_token(auth_code, as_dict=False, check_cache=False)
+    print("✅ 授权成功！Token 已保存至 ~/.config/spotify/cache")
+else:
+    print("❌ 授权超时，请重试")
+    sys.exit(1)


### PR DESCRIPTION
## Spotify Hub

Control Spotify playback via `spotipy` + Spotify Web API.

### Features

- 🔐 **OAuth authentication** with local HTTP callback server, token saved with `refresh_token` for permanent login
- ▶️ **Playback control**: play / pause / next / prev / volume / shuffle / repeat / seek
- 🔍 **Search & play**: search by keyword, multi-keyword mix (e.g. TikTok trending)
- ❤️ **Library**: save / unsave current track, view liked songs / recent plays / top tracks
- 📋 **Playlist management**: list / create / add track / play playlist
- 👥 **Follow**: follow artists, view following list

### Tech

- Uses `uv` inline script with `--cache-dir /root/.cache/uv` for zero-install experience
- All 16 Spotify OAuth scopes requested upfront to avoid re-auth
- Handles Development Mode limitation (3rd-party playlists return 403) via multi-keyword search fallback

### Environment Variables

- `SPOTIPY_CLIENT_ID`
- `SPOTIPY_CLIENT_SECRET`
- `SPOTIPY_REDIRECT_URI` (e.g. `http://127.0.0.1:8888/callback`)