### PR TITLE
feat(qbt-hub): add peers command

### DIFF
--- a/qbt-hub/SKILL.md
+++ b/qbt-hub/SKILL.md
@@ -73,7 +73,8 @@ python3 qbt.py status                 # DL/UL speed, totals, limits, turtle mode
 ### Task details
 
 ```bash
-python3 qbt.py info ubuntu            # progress, files, trackers, peers
+python3 qbt.py info ubuntu            # progress, files, trackers + top peers summary
+python3 qbt.py peers ubuntu           # full peer list: IP, country, client, DL/UL speed, progress, flags
 ```
 
 ### Pause / Resume / Recheck

--- a/qbt-hub/scripts/qbt.py
+++ b/qbt-hub/scripts/qbt.py
@@ -209,6 +209,9 @@ class QBTClient:
     def properties(self, h): return self._json("torrents/properties", {"hash": h})
     def files(self, h):      return self._json("torrents/files",      {"hash": h})
     def trackers(self, h):   return self._json("torrents/trackers",   {"hash": h})
+    def peers(self, h):
+        data = self._json("sync/torrentPeers", {"hash": h, "rid": "0"})
+        return data.get("peers", {}) if data else {}
 
     def get_global_dl_limit(self):    return int(self._get("transfer/downloadLimit") or 0)
     def get_global_ul_limit(self):    return int(self._get("transfer/uploadLimit") or 0)
@@ -363,6 +366,19 @@ def cmd_info(client, keyword):
         print(f"\n  Trackers ({len(trks)} total):")
         for tk in active_trks[:5]:
             print(f"    [{tk.get('status','?')}]  {tk.get('url','?')[:60]}")
+    # peers summary
+    peers = client.peers(h)
+    if peers:
+        seeders  = sum(1 for p in peers.values() if p.get("progress", 0) >= 1.0)
+        leechers = len(peers) - seeders
+        active   = [p for p in peers.values() if p.get("dl_speed", 0) > 0]
+        top_dl   = sorted(peers.values(), key=lambda x: x.get("dl_speed", 0), reverse=True)[:3]
+        print(f"\n  Peers ({len(peers)} total — {seeders} seeding / {leechers} leeching):")
+        for p in top_dl:
+            if p.get("dl_speed", 0) > 0:
+                print(f"    {p.get('ip','?'):<18} {p.get('country_code','--')}  {p.get('client','?')[:24]:<26}  DL: {fmt_speed(p.get('dl_speed',0))}")
+        if len(peers) > 3:
+            print(f"    ... run 'peers' command for full list")
     print()
 
 def cmd_limit(client, keyword, dl, ul):
@@ -491,6 +507,36 @@ def cmd_top(client, n, sort_by):
     sorted_list = sorted(torrents, key=key_map.get(sort_by, key_map["size"]), reverse=True)[:n]
     print_torrents(sorted_list, title=f"Top {n} by {label_map.get(sort_by, sort_by)}")
 
+def cmd_peers(client, keyword):
+    matches = client.find(keyword)
+    if not matches:
+        print(f'ERROR: no task matched "{keyword}"')
+        return
+    t = matches[0]
+    peers = client.peers(t["hash"])
+    if not peers:
+        print("No peers connected.")
+        return
+    seeders  = [p for p in peers.values() if p.get("progress", 0) >= 1.0]
+    leechers = [p for p in peers.values() if p.get("progress", 0) < 1.0]
+    sep(100)
+    print(f"  Peers for: {t['name'][:60]}")
+    print(f"  {len(peers)} total — {len(seeders)} seeding / {len(leechers)} leeching")
+    sep(100)
+    print(f"  {'IP':<24} {'CC':<4} {'Client':<28} {'DL':>10} {'UL':>10} {'Progress':>9}  Flags")
+    sep(100)
+    for p in sorted(peers.values(), key=lambda x: x.get("dl_speed", 0), reverse=True):
+        ip       = f"{p.get('ip','?')}:{p.get('port','')}"
+        cc       = p.get("country_code", "--")
+        client_s = p.get("client", "?")[:26]
+        dl       = fmt_speed(p.get("dl_speed", 0))
+        ul       = fmt_speed(p.get("up_speed", 0))
+        progress = f"{p.get('progress', 0)*100:.1f}%"
+        flags    = p.get("flags", "")
+        print(f"  {ip:<24} {cc:<4} {client_s:<28} {dl:>10} {ul:>10} {progress:>9}  {flags}")
+    print()
+
+
 def cmd_rss(client, action, url, path, rule_name, rule_pattern, rule_category):
     if action == "list":
         items = client.rss_items()
@@ -617,6 +663,9 @@ examples:
     p = sub.add_parser("info", help="Show task details")
     p.add_argument("keyword")
 
+    p = sub.add_parser("peers", help="Show peer list for a task")
+    p.add_argument("keyword")
+
     p = sub.add_parser("limit", help="Set per-task speed limit")
     p.add_argument("keyword")
     p.add_argument("--dl", type=float, help="DL limit KB/s (0=unlimited)")
@@ -683,6 +732,7 @@ examples:
     elif cmd == "resume":     cmd_resume(client, args.keyword)
     elif cmd == "delete":     cmd_delete(client, args.keyword, args.files)
     elif cmd == "info":       cmd_info(client, args.keyword)
+    elif cmd == "peers":      cmd_peers(client, args.keyword)
     elif cmd == "limit":      cmd_limit(client, args.keyword, args.dl, args.ul)
     elif cmd == "speedlimit": cmd_speedlimit(client, args.dl, args.ul, args.alt)
     elif cmd == "tag":        cmd_tag(client, args.keyword, args.tags)


### PR DESCRIPTION
## Changes

Add `peers` command to qbt-hub skill.

### New: `peers <keyword>`

Full peer table for a task:

```
python3 qbt.py peers ubuntu
```

Output:
```
IP                       CC   Client                         DL         UL  Progress  Flags
59.63.155.196:51413      cn   Transmission 4.0.5       95.2 KB/s    0.0 B/s    100.0%  D H X
218.90.196.172:9252      cn   qBittorrent/4.6.7        19.1 KB/s 373.3 KB/s      2.2%  D U H X P
...
```

### Updated: `info <keyword>`

Now includes a top active peers summary inline, so you don't need to run `peers` separately for a quick overview.