### PR TITLE
fix(qbt-hub): remove hardcoded default credentials

### DIFF
--- a/qbt-hub/scripts/qbt.py
+++ b/qbt-hub/scripts/qbt.py
@@ -30,9 +30,9 @@ Authentication (priority: CLI args > env vars > defaults):
 
 import os, sys, json, argparse, urllib.request, urllib.parse, urllib.error, http.cookiejar, datetime
 
-DEFAULT_HOST = "http://qbt.wsen.me"
-DEFAULT_USER = "admin"
-DEFAULT_PASS = "adminadmin"
+DEFAULT_HOST = ""
+DEFAULT_USER = ""
+DEFAULT_PASS = ""
 
 STATUS_MAP = {
     "downloading":        "Downloading",


### PR DESCRIPTION
Remove hardcoded `DEFAULT_HOST`, `DEFAULT_USER`, `DEFAULT_PASS` values.

Auth now fully relies on env vars:
- `QBT_HOST`
- `QBT_USER`  
- `QBT_PASS`