### PR TITLE
feat(twitter-x-hub): sync v0.8.6 — queryIds refresh, parser.py, new commands

### DIFF
--- a/twitter-x-hub/SKILL.md
+++ b/twitter-x-hub/SKILL.md
@@ -4,17 +4,19 @@ description: >
   使用 Python + UV 读写 Twitter/X 数据的技能，零第三方依赖（纯标准库），通过直接传入
   auth_token + ct0 Cookie 完成认证。在 Minis 环境中，Cookie 可通过 browser_use 工具
   导航到 x.com 后用 get_cookies 动作自动获取，无需手动复制。支持抓取主页时间线、关注列表、
-  书签、搜索、用户资料、用户推文、点赞、推文详情、List 时间线、粉丝/关注列表，以及发推、
-  删推、点赞、转推、收藏等写操作。当用户提到"抓取 Twitter 数据"、"获取 X 推文"、
-  "Twitter 时间线"、"X 书签"、"搜索推文"、"twitter-x-hub"、"用 Cookie 请求 Twitter"、
-  "Twitter GraphQL"，或任何需要以编程方式读写 Twitter/X 数据的场景，必须触发本技能。
+  书签（含书签文件夹）、搜索、用户资料、用户推文、点赞、推文详情（单条/含回复）、List 时间线、
+  粉丝/关注列表，以及发推、删推、点赞、转推、收藏等写操作。当用户提到"抓取 Twitter 数据"、
+  "获取 X 推文"、"Twitter 时间线"、"X 书签"、"搜索推文"、"twitter-x-hub"、
+  "用 Cookie 请求 Twitter"、"Twitter GraphQL"，或任何需要以编程方式读写 Twitter/X
+  数据的场景，必须触发本技能。
 ---
 
 # twitter-x-hub
 
-> **改造来源**：[jackwener/twitter-cli](https://github.com/jackwener/twitter-cli)
-> 本技能对原仓库做了以下简化：移除 `browser-cookie3`/`rich`/`click`/`PyYAML` 依赖，
-> 改为纯标准库实现；认证方式改为直接传入 Cookie，不做浏览器自动提取。
+> **改造来源**：[public-clis/twitter-cli](https://github.com/public-clis/twitter-cli)（原 jackwener/twitter-cli）
+> 本技能对原仓库做了以下简化：移除 `browser-cookie3`/`rich`/`click`/`PyYAML`/`curl_cffi`/
+> `xclienttransaction`/`beautifulsoup4` 依赖，改为纯标准库实现；认证方式改为直接传入 Cookie，
+> 不做浏览器自动提取；移除 Twitter Article 渲染和图片上传功能。
 
 ---
 
@@ -26,7 +28,8 @@ description: >
 ├── pyproject.toml              # UV 项目配置（零第三方依赖）
 └── scripts/
     ├── __init__.py
-    ├── models.py               # 数据模型（Tweet, Author, Metrics, UserProfile…）
+    ├── models.py               # 数据模型（Tweet, Author, Metrics, UserProfile, BookmarkFolder）
+    ├── parser.py               # GraphQL 响应解析（从 client.py 拆出，同步自上游 v0.8.6）
     ├── client.py               # GraphQL 客户端（核心逻辑）
     └── cli.py                  # 命令行入口（argparse）
 ```
@@ -49,27 +52,24 @@ Twitter/X 内部 GraphQL API 使用两个 Cookie 做认证：
 
 操作步骤：
 1. `browser_use navigate` 打开 `https://x.com`，确认已登录
-2. `browser_use get_cookies` 过滤 `auth_token`，再过滤 `ct0`
-   - 工具会返回一个 offload env 文件路径（如 `/var/minis/offloads/env_cookies_xxx.sh`）
-   - **Cookie 原始值不会出现在对话中**，通过 `. <env_file>` 加载到 shell 环境变量
-3. 加载后即可直接使用环境变量调用脚本：
+2. `browser_use get_cookies` 获取所有 cookie
+   - 工具返回 offload env 文件路径（如 `/var/minis/offloads/env_cookies_xxx.sh`）
+   - **Cookie 原始值不会出现在对话中**
+3. 加载后即可使用：
 ```bash
 . /var/minis/offloads/env_cookies_xxx.sh
-# 文件内已导出 COOKIE_AUTH_TOKEN / COOKIE_CT0 等变量，按实际变量名使用
 export TWITTER_AUTH_TOKEN="$COOKIE_AUTH_TOKEN"
 export TWITTER_CT0="$COOKIE_CT0"
 ```
 
-> **注意**：`get_cookies` 仅对当前页面的域名生效，需先 navigate 到 `https://x.com` 再调用。
+### 方法二：手动设置环境变量
 
-### 方法二：手动从浏览器 DevTools 获取
-
-1. 登录 x.com，打开 DevTools → Application → Cookies → `https://x.com`
-2. 找到 `auth_token` 和 `ct0` 的值，复制后存入 Minis 环境变量（Settings → Environments）
+从浏览器 DevTools → Application → Cookies → `https://x.com` 复制 `auth_token` 和 `ct0`，
+存入 Minis 环境变量（Settings → Environments）：`TWITTER_AUTH_TOKEN` + `TWITTER_CT0`
 
 ### 传入方式（三种，优先级从高到低）
 
-1. 环境变量：`TWITTER_AUTH_TOKEN` + `TWITTER_CT0`（推荐，避免明文出现在命令行）
+1. 环境变量：`TWITTER_AUTH_TOKEN` + `TWITTER_CT0`（推荐）
 2. CLI 参数：`--auth-token <value> --ct0 <value>`
 3. 代码直接传入：`TwitterClient(auth_token=..., ct0=...)`
 
@@ -91,51 +91,50 @@ cd /var/minis/skills/twitter-x-hub
 
 ```bash
 # 抓取首页 For-You 时间线（默认20条）
-uv run python -m scripts.cli feed \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli feed
 
-# 抓取 Following 时间线，50条，JSON 输出
-uv run python -m scripts.cli feed --type following --max 50 --json \
-  --auth-token <auth_token> --ct0 <ct0>
+# 抓取 Following 时间线，30条，JSON 输出
+uv run python -m scripts.cli feed --type following --max 30 --json
 
 # 搜索推文（Top/Latest/Photos/Videos）
-uv run python -m scripts.cli search "Claude Code" --tab Latest --max 30 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli search "Claude Code" --tab Latest --max 20
 
 # 书签
-uv run python -m scripts.cli bookmarks --max 50 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli bookmarks --max 50
+
+# 书签文件夹列表（新增）
+uv run python -m scripts.cli bookmark-folders
 
 # 用户资料
-uv run python -m scripts.cli user elonmusk \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli user elonmusk
 
 # 用户推文
-uv run python -m scripts.cli user-posts elonmusk --max 20 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli user-posts elonmusk --max 20
+
+# 用户点赞
+uv run python -m scripts.cli user-likes elonmusk --max 20
 
 # 推文详情（含回复线程）
-uv run python -m scripts.cli tweet 1234567890 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli tweet 1234567890
+
+# 单条推文快速获取（新增，比 tweet 命令快）
+uv run python -m scripts.cli tweet-by-id 1234567890
 
 # List 时间线
-uv run python -m scripts.cli list 1539453138322673664 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli list 1539453138322673664
 
 # 粉丝 / 关注列表（需先用 user 命令获取 user_id）
-uv run python -m scripts.cli followers <user_id> --max 50 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli followers <user_id> --max 50
+uv run python -m scripts.cli following <user_id> --max 50
 
 # 发推 / 回复
-uv run python -m scripts.cli post "Hello from twitter-fetch!" \
-  --auth-token <auth_token> --ct0 <ct0>
-uv run python -m scripts.cli post "reply text" --reply-to 1234567890 \
-  --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli post "Hello from twitter-x-hub!"
+uv run python -m scripts.cli post "reply text" --reply-to 1234567890
 
 # 点赞 / 转推 / 收藏
-uv run python -m scripts.cli like 1234567890 --auth-token <auth_token> --ct0 <ct0>
-uv run python -m scripts.cli retweet 1234567890 --auth-token <auth_token> --ct0 <ct0>
-uv run python -m scripts.cli bookmark 1234567890 --auth-token <auth_token> --ct0 <ct0>
+uv run python -m scripts.cli like 1234567890
+uv run python -m scripts.cli retweet 1234567890
+uv run python -m scripts.cli bookmark 1234567890
 ```
 
 ### 用环境变量省去每次传参
@@ -150,7 +149,7 @@ uv run python -m scripts.cli feed --max 30 --json
 ### 作为 Python 库调用
 
 ```python
-import os, json
+import os, json, dataclasses
 from scripts.client import TwitterClient
 
 client = TwitterClient(
@@ -162,17 +161,22 @@ client = TwitterClient(
 tweets = client.fetch_home_timeline(count=20)
 for t in tweets:
     print(f"@{t.author.screen_name}: {t.text[:80]}")
-    print(f"  ❤️ {t.metrics.likes}  🔁 {t.metrics.retweets}  👁 {t.metrics.views}")
+    print(f"  ❤️ {t.metrics.likes}  🔁 {t.metrics.retweets}  👁 {t.metrics.views}  🔖 {t.metrics.bookmarks}")
 
-# 搜索
+# 搜索（Latest tab）
 results = client.fetch_search("AI agent", count=10, product="Latest")
+
+# 单条推文（快速，无回复）
+tweet = client.fetch_tweet_by_id("1234567890")
+
+# 书签文件夹
+folders = client.fetch_bookmark_folders()
 
 # 用户资料
 user = client.fetch_user("elonmusk")
-print(user.followers_count)
+print(user.id, user.followers_count)
 
-# JSON 序列化（dataclass → dict）
-import dataclasses
+# JSON 序列化
 data = [dataclasses.asdict(t) for t in tweets]
 print(json.dumps(data, ensure_ascii=False, indent=2))
 ```
@@ -194,9 +198,17 @@ print(json.dumps(data, ensure_ascii=False, indent=2))
    → 还没有则扫描 x.com JS Bundle 用正则提取
 ```
 
+### URL 优化（同步自上游 v0.8）
+- features 字典中值为 `False` 的 key 不发送，避免 URL 过长（414 错误）
+
 ### 分页 & 限流
 - 每次响应携带 `cursor`，自动翻页直到达到 `count` 上限
-- 请求间隔默认 1.5 秒，HTTP 429 / error code 88 触发指数退避重试
+- 请求间隔默认 1.5 秒 + ±30% 随机抖动，HTTP 429 触发指数退避重试
+- 写操作延迟 1.5~4 秒随机
+
+### 解析器拆分（同步自上游 v0.7+）
+- `parser.py` 从 `client.py` 拆出，包含 `parse_tweet_result`、`parse_timeline_response`、
+  `parse_user_result` 等独立函数，便于单元测试和复用
 
 ---
 
@@ -206,11 +218,13 @@ print(json.dumps(data, ensure_ascii=False, indent=2))
 |--------|------|----------|
 | `feed` | 主页时间线 | `--type for-you\|following`, `--max`, `--json` |
 | `bookmarks` | 书签 | `--max`, `--json` |
+| `bookmark-folders` | 书签文件夹列表 ⭐新增 | `--json` |
 | `search` | 搜索 | `query`, `--tab Top\|Latest\|Photos\|Videos`, `--max`, `--json` |
 | `user` | 用户资料 | `screen_name`, `--json` |
 | `user-posts` | 用户推文 | `screen_name`, `--max`, `--json` |
 | `user-likes` | 用户点赞 | `screen_name`, `--max`, `--json` |
 | `tweet` | 推文详情+回复 | `tweet_id`, `--max`, `--json` |
+| `tweet-by-id` | 单条推文（快速）⭐新增 | `tweet_id`, `--json` |
 | `list` | List 时间线 | `list_id`, `--max`, `--json` |
 | `followers` | 粉丝列表 | `user_id`, `--max`, `--json` |
 | `following` | 关注列表 | `user_id`, `--max`, `--json` |
@@ -224,12 +238,24 @@ print(json.dumps(data, ensure_ascii=False, indent=2))
 
 ---
 
-## 生成 CLI 脚本
+## 变更日志（同步自上游）
 
-如果 `scripts/cli.py` 尚未创建，执行以下步骤让 AI 生成：
-
-1. 确认 `client.py` 和 `models.py` 已存在于 `/var/minis/skills/twitter-x-hub/scripts/`
-2. 告知 AI："请根据 twitter-x-fetch skill 的 CLI 速查表，生成 `cli.py`（使用 argparse，支持从环境变量读取 auth_token/ct0）"
+### v0.8.6 同步（2026-04-08）
+- **QueryId 全量更新**：从 x.com JS bundle（main.0e98bc8a.js）实时扫描，更新了
+  HomeTimeline、HomeLatestTimeline、UserTweets、SearchTimeline、Likes、TweetDetail、
+  TweetResultByRestId、ListLatestTweetsTimeline、Followers、Following、CreateTweet 等全部 ID
+- **新增 QueryId**：`TweetResultByRestId`、`BookmarkFoldersSlice`、`BookmarkFolderTimeline`
+- **新增命令**：`tweet-by-id`（单条推文快速获取）、`bookmark-folders`（书签文件夹）
+- **models.py**：`Metrics` 新增 `bookmarks` 字段；`Tweet` 新增 `article_title`、
+  `article_text`、`is_subscriber_only` 字段；新增 `BookmarkFolder` dataclass
+- **parser.py**：从 `client.py` 拆出为独立模块；修复新 API 结构（`core.name`/`core.screen_name`）；
+  `parse_tweet_result` 支持 `note_tweet` 全文（长推文"显示更多"）；
+  新增 `_unwrap_visibility` 处理 `TweetWithVisibilityResults`；
+  `parse_user_result` 修复 `joined` 日期从 `core.created_at` 读取
+- **URL 优化**：features 中 False 值不发送，避免 414 错误
+- **SearchTimeline 限制**：X 从 2025 年底开始要求 `x-client-transaction-id` header，
+  该 header 由 `xclienttransaction`（C 扩展）生成，在 iSH/Alpine 环境无法安装，
+  因此 `search` 命令在本环境暂不可用；替代方案：用 `browser_use` 导航到搜索页面提取 DOM
 
 ---
 
@@ -239,3 +265,5 @@ print(json.dumps(data, ensure_ascii=False, indent=2))
 - 建议使用专用小号，避免主账号被风控
 - 写操作（发推、点赞等）风控风险高于读操作，请酌情使用
 - `max_count` 硬上限为 500，防止意外大量请求
+- 上游依赖 `curl_cffi` 做 TLS 指纹伪装，本 skill 使用 stdlib `urllib` 替代，
+  遇到风控时可尝试通过 `cookie_string` 参数传入完整 Cookie 字符串增强指纹

--- a/twitter-x-hub/scripts/cli.py
+++ b/twitter-x-hub/scripts/cli.py
@@ -1,6 +1,6 @@
-"""Command-line interface for twitter-fetch.
+"""Command-line interface for twitter-x-hub.
 
-Adapted from https://github.com/jackwener/twitter-cli
+Adapted from https://github.com/public-clis/twitter-cli (v0.8.6)
 Auth is provided via --auth-token / --ct0 flags or
 TWITTER_AUTH_TOKEN / TWITTER_CT0 environment variables.
 
@@ -15,13 +15,13 @@ import dataclasses
 import json
 import os
 import sys
-from typing import List, Any
+from typing import Any, List
 
-from .client import TwitterClient, TwitterAPIError
-from .models import Tweet, UserProfile
+from .client import TwitterAPIError, TwitterClient
+from .models import BookmarkFolder, Tweet, UserProfile
 
 
-# ── Auth helpers ─────────────────────────────────────────────────────────────
+# ── Auth helpers ─────────────────────────────────────────────────────────
 
 def _get_client(args: argparse.Namespace) -> TwitterClient:
     auth_token = getattr(args, "auth_token", None) or os.environ.get("TWITTER_AUTH_TOKEN", "")
@@ -37,12 +37,14 @@ def _get_client(args: argparse.Namespace) -> TwitterClient:
     return TwitterClient(auth_token=auth_token, ct0=ct0)
 
 
-def _add_auth_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--auth-token", metavar="TOKEN", help="Twitter auth_token cookie (or set TWITTER_AUTH_TOKEN)")
-    parser.add_argument("--ct0", metavar="CT0", help="Twitter ct0 cookie (or set TWITTER_CT0)")
+def _add_auth_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--auth-token", metavar="TOKEN",
+                   help="Twitter auth_token cookie (or set TWITTER_AUTH_TOKEN)")
+    p.add_argument("--ct0", metavar="CT0",
+                   help="Twitter ct0 cookie (or set TWITTER_CT0)")
 
 
-# ── Output helpers ────────────────────────────────────────────────────────────
+# ── Output helpers ────────────────────────────────────────────────────────
 
 def _to_dict(obj: Any) -> Any:
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
@@ -62,12 +64,18 @@ def _print_tweets(tweets: List[Tweet], as_json: bool) -> None:
         return
     for t in tweets:
         rt_tag = f"  [RT by @{t.retweeted_by}]" if t.is_retweet else ""
-        print(f"── @{t.author.screen_name}{rt_tag}  [{t.created_at}]")
-        print(f"   {t.text[:200]}")
+        sub_tag = " [subscriber only]" if t.is_subscriber_only else ""
+        print(f"── @{t.author.screen_name}{rt_tag}{sub_tag}  [{t.created_at}]")
+        print(f"   {t.text[:280]}")
         m = t.metrics
         print(f"   ❤️ {m.likes}  🔁 {m.retweets}  💬 {m.replies}  👁 {m.views}  🔖 {m.bookmarks}")
         if t.quoted_tweet:
-            print(f"   ↳ QT @{t.quoted_tweet.author.screen_name}: {t.quoted_tweet.text[:100]}")
+            q = t.quoted_tweet
+            print(f"   ↳ QT @{q.author.screen_name}: {q.text[:120]}")
+        if t.article_title:
+            print(f"   📄 Article: {t.article_title}")
+        if t.media:
+            print(f"   📎 {len(t.media)} media item(s)")
         print()
 
 
@@ -84,7 +92,7 @@ def _print_users(users: List[UserProfile], as_json: bool) -> None:
         print()
 
 
-# ── Subcommand handlers ───────────────────────────────────────────────────────
+# ── Subcommand handlers ───────────────────────────────────────────────────
 
 def cmd_feed(args: argparse.Namespace) -> None:
     client = _get_client(args)
@@ -99,6 +107,16 @@ def cmd_bookmarks(args: argparse.Namespace) -> None:
     client = _get_client(args)
     tweets = client.fetch_bookmarks(count=args.max)
     _print_tweets(tweets, args.json)
+
+
+def cmd_bookmark_folders(args: argparse.Namespace) -> None:
+    client = _get_client(args)
+    folders = client.fetch_bookmark_folders()
+    if args.json:
+        _print_json(folders)
+    else:
+        for f in folders:
+            print(f"[{f.id}] {f.name}")
 
 
 def cmd_search(args: argparse.Namespace) -> None:
@@ -146,6 +164,17 @@ def cmd_tweet(args: argparse.Namespace) -> None:
     _print_tweets(tweets, args.json)
 
 
+def cmd_tweet_by_id(args: argparse.Namespace) -> None:
+    """Fetch a single tweet by ID (TweetResultByRestId — faster than TweetDetail)."""
+    client = _get_client(args)
+    tweet_id = args.tweet_id.rstrip("/").split("/")[-1]
+    tweet = client.fetch_tweet_by_id(tweet_id)
+    if tweet is None:
+        print(f"Tweet {tweet_id} not found.", file=sys.stderr)
+        sys.exit(1)
+    _print_tweets([tweet], args.json)
+
+
 def cmd_list(args: argparse.Namespace) -> None:
     client = _get_client(args)
     tweets = client.fetch_list_timeline(args.list_id, count=args.max)
@@ -166,8 +195,15 @@ def cmd_following(args: argparse.Namespace) -> None:
 
 def cmd_post(args: argparse.Namespace) -> None:
     client = _get_client(args)
-    tweet_id = client.create_tweet(args.text, reply_to_id=args.reply_to)
-    print(f"Posted: https://x.com/i/web/status/{tweet_id}")
+    result = client.post_tweet(args.text, reply_to_id=getattr(args, "reply_to", None))
+    tweet_id = (
+        result.get("data", {}).get("create_tweet", {}).get("tweet_results", {})
+        .get("result", {}).get("rest_id", "")
+    )
+    if tweet_id:
+        print(f"Posted: https://x.com/i/web/status/{tweet_id}")
+    else:
+        print("Posted (no ID returned).")
 
 
 def cmd_delete(args: argparse.Namespace) -> None:
@@ -212,12 +248,12 @@ def cmd_unbookmark(args: argparse.Namespace) -> None:
     print(f"Removed bookmark {args.tweet_id}")
 
 
-# ── Argument parser ───────────────────────────────────────────────────────────
+# ── Argument parser ───────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="twitter-fetch",
-        description="Fetch Twitter/X data via internal GraphQL API (cookie auth).",
+        prog="twitter-x-hub",
+        description="Twitter/X GraphQL client (cookie auth, zero third-party deps).",
     )
     sub = parser.add_subparsers(dest="command", metavar="<command>")
     sub.required = True
@@ -236,6 +272,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--json", action="store_true")
     _add_auth_args(p)
     p.set_defaults(func=cmd_bookmarks)
+
+    # bookmark-folders
+    p = sub.add_parser("bookmark-folders", help="List bookmark folders")
+    p.add_argument("--json", action="store_true")
+    _add_auth_args(p)
+    p.set_defaults(func=cmd_bookmark_folders)
 
     # search
     p = sub.add_parser("search", help="Search tweets")
@@ -262,7 +304,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_user_posts)
 
     # user-likes
-    p = sub.add_parser("user-likes", help="Tweets liked by a user")
+    p = sub.add_parser("user-likes", help="Tweets liked by a user (own account only)")
     p.add_argument("screen_name")
     p.add_argument("--max", type=int, default=20, metavar="N")
     p.add_argument("--json", action="store_true")
@@ -270,12 +312,19 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_user_likes)
 
     # tweet
-    p = sub.add_parser("tweet", help="Tweet detail and reply thread")
+    p = sub.add_parser("tweet", help="Tweet detail + reply thread")
     p.add_argument("tweet_id", help="Tweet ID or full URL")
     p.add_argument("--max", type=int, default=20, metavar="N")
     p.add_argument("--json", action="store_true")
     _add_auth_args(p)
     p.set_defaults(func=cmd_tweet)
+
+    # tweet-by-id (new — TweetResultByRestId, faster single-tweet fetch)
+    p = sub.add_parser("tweet-by-id", help="Fetch a single tweet by ID (no replies)")
+    p.add_argument("tweet_id", help="Tweet ID or full URL")
+    p.add_argument("--json", action="store_true")
+    _add_auth_args(p)
+    p.set_defaults(func=cmd_tweet_by_id)
 
     # list
     p = sub.add_parser("list", help="Twitter List timeline")
@@ -294,7 +343,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_followers)
 
     # following
-    p = sub.add_parser("following", help="Users that a user follows (requires user_id)")
+    p = sub.add_parser("following", help="Users a user follows (requires user_id)")
     p.add_argument("user_id")
     p.add_argument("--max", type=int, default=20, metavar="N")
     p.add_argument("--json", action="store_true")
@@ -304,7 +353,7 @@ def build_parser() -> argparse.ArgumentParser:
     # post
     p = sub.add_parser("post", help="Post a new tweet")
     p.add_argument("text")
-    p.add_argument("--reply-to", metavar="TWEET_ID")
+    p.add_argument("--reply-to", metavar="TWEET_ID", dest="reply_to")
     _add_auth_args(p)
     p.set_defaults(func=cmd_post)
 

--- a/twitter-x-hub/scripts/client.py
+++ b/twitter-x-hub/scripts/client.py
@@ -1,11 +1,12 @@
 """Twitter/X internal GraphQL API client.
 
-Adapted from https://github.com/jackwener/twitter-cli
-Changes:
-  - Removed browser-cookie3 dependency; auth_token + ct0 must be passed directly.
-  - Removed optional xclienttransaction / requests / beautifulsoup4 dependencies.
-  - Removed rich/click/PyYAML; zero third-party dependencies (stdlib only).
-  - Simplified to pure fetch logic usable as a library or via cli.py.
+Adapted from https://github.com/public-clis/twitter-cli (v0.8.6)
+Changes vs upstream:
+  - Zero third-party dependencies (stdlib only, no curl_cffi / browser-cookie3 / rich / click)
+  - Auth passed directly (auth_token + ct0); no browser auto-extraction
+  - No xclienttransaction header generation
+  - No image upload / media attach support
+  - QueryId resolution: cache → FALLBACK_QUERY_IDS → fa0311/twitter-openapi → JS bundle scan
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import random
 import re
 import ssl
 import time
@@ -21,14 +23,19 @@ import urllib.parse
 import urllib.request
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
-from .models import Author, Metrics, Tweet, TweetMedia, UserProfile
+from .models import BookmarkFolder, Tweet, UserProfile
+from .parser import (
+    _deep_get,
+    _parse_int,
+    parse_timeline_response,
+    parse_tweet_result,
+    parse_user_result,
+)
 
 logger = logging.getLogger(__name__)
 
-# ── Constants ────────────────────────────────────────────────────────────────
+# ── Constants ────────────────────────────────────────────────────────────
 
-# Public Bearer Token embedded in Twitter's web JS (shared by all browser sessions).
-# Source: https://github.com/jackwener/twitter-cli/blob/main/twitter_cli/constants.py
 BEARER_TOKEN = (
     "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs"
     "%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
@@ -44,73 +51,87 @@ SEC_CH_UA = '"Chromium";v="133", "Not(A:Brand";v="99", "Google Chrome";v="133"'
 SEC_CH_UA_MOBILE = "?0"
 SEC_CH_UA_PLATFORM = '"macOS"'
 
-# Fallback queryIds for known GraphQL operations.
-# These can go stale when Twitter rotates them; live-lookup kicks in on 404.
-# Source: https://github.com/jackwener/twitter-cli/blob/main/twitter_cli/client.py
+# ── QueryId constants ────────────────────────────────────────────────────
+# Synced from upstream v0.8.6 — updated vs our previous version:
+#   Bookmarks: VFdMm9iVZxlU6hD86gfW_A → uzboyXSHSJrR-mGJqep0TQ
+#   Likes: lIDpu_NWL7_VhimGGt0o6A → RozQdCp4CilQzrcuU0NY5w
+#   ListLatestTweetsTimeline: RlZzktZY_9wJynoepm8ZsA → fb_6wmHD2dk9D-xYXOQlgw
+#   Followers: IOh4aS6UdGWGJUYTqliQ7Q → Enf9DNUZYiT037aersI5gg
+#   Following: zx6e-TLzRkeDO_a7p4b3JQ → ntIPnH1WMBKW--4Tn1q71A
+#   CreateTweet: IID9x6WsdMnTlXnzXGq8ng → zkcFc6F-RKRgWN8HUkJfZg
+#   DeleteTweet: VaenaVgh5q5ih7kvyVjgtg → nxpZCY2K-I6QoFHAHeojFQ
+#   CreateRetweet: ojPdsZsimiJrUGLR1sjUtA → mbRO74GrOvSfRcJnlMapnQ
+#   DeleteRetweet: iQtK4dl5hBmXewYZuEOKVw → ZyZigVsNiFO6v1dEks1eWg
+# New entries: TweetResultByRestId, BookmarkFoldersSlice, BookmarkFolderTimeline
 FALLBACK_QUERY_IDS: Dict[str, str] = {
-    "HomeTimeline":             "c-CzHF1LboFilMpsx4ZCrQ",
-    "HomeLatestTimeline":       "BKB7oi212Fi7kQtCBGE4zA",
-    "Bookmarks":                "VFdMm9iVZxlU6hD86gfW_A",
-    "UserByScreenName":         "1VOOyvKkiI3FMmkeDNxM9A",
-    "UserTweets":               "E3opETHurmVJflFsUBVuUQ",
-    "SearchTimeline":           "nWemVnGJ6A5eQAR5-oQeAg",
-    "Likes":                    "lIDpu_NWL7_VhimGGt0o6A",
-    "TweetDetail":              "xd_EMdYvB9hfZsZ6Idri0w",
-    "ListLatestTweetsTimeline": "RlZzktZY_9wJynoepm8ZsA",
-    "Followers":                "IOh4aS6UdGWGJUYTqliQ7Q",
-    "Following":                "zx6e-TLzRkeDO_a7p4b3JQ",
-    "CreateTweet":              "IID9x6WsdMnTlXnzXGq8ng",
-    "DeleteTweet":              "VaenaVgh5q5ih7kvyVjgtg",
+    # Scanned from x.com JS bundle 2026-04-08 (main.0e98bc8a.js)
+    "HomeTimeline":             "J62e-zdBz8cxFVOjBcq1WA",
+    "HomeLatestTimeline":       "2ee46L1AFXmnTa0EvUog-Q",
+    "Bookmarks":                "uzboyXSHSJrR-mGJqep0TQ",   # not in current bundle, keep upstream
+    "UserByScreenName":         "IGgvgiOx4QZndDHuD3x9TQ",
+    "UserTweets":               "x3B_xLqC0yZawOB7WQhaVQ",
+    "SearchTimeline":           "pCd62NDD9dlCDgEGgEVHMg",
+    "Likes":                    "KPuet6dGbC8LB2sOLx7tZQ",
+    "TweetDetail":              "rU08O-YiXdr0IZfE7qaUMg",
+    "TweetResultByRestId":      "tmhPpO5sDermwYmq3h034A",
+    "ListLatestTweetsTimeline": "qcQY-EkEWjJ-wwJhsKdxYQ",
+    "Followers":                "-WcGoRt8IQuPm-l1ymgy6g",
+    "Following":                "vWCjN9gcTJiXzzMPR5Oxzw",
+    "CreateTweet":              "S1qcGUn68_U0lDKdMlYSGg",
+    "DeleteTweet":              "nxpZCY2K-I6QoFHAHeojFQ",
     "FavoriteTweet":            "lI07N6Otwv1PhnEgXILM7A",
     "UnfavoriteTweet":          "ZYKSe-w7KEslx3JhSIk5LA",
-    "CreateRetweet":            "ojPdsZsimiJrUGLR1sjUtA",
-    "DeleteRetweet":            "iQtK4dl5hBmXewYZuEOKVw",
+    "CreateRetweet":            "mbRO74GrOvSfRcJnlMapnQ",
+    "DeleteRetweet":            "ZyZigVsNiFO6v1dEks1eWg",
     "CreateBookmark":           "aoDbu3RHznuiSkQ9aNM67Q",
     "DeleteBookmark":           "Wlmlj2-xzyS1GN3a6cj-mQ",
+    "BookmarkFoldersSlice":     "i78YDd0Tza-dV4SYs58kRg",   # keep upstream
+    "BookmarkFolderTimeline":   "hNY7X2xE2N7HVF6Qb_mu6w",   # keep upstream
 }
 
-# Community-maintained live queryId source (fallback when hardcoded IDs expire).
+# Community-maintained live queryId source
 TWITTER_OPENAPI_URL = (
     "https://raw.githubusercontent.com/fa0311/twitter-openapi/"
-    "main/src/config/placeholder.json"
+    "refs/heads/main/src/config/placeholder.json"
 )
 
-# GraphQL features flags sent with every timeline request.
+# Feature flags — synced from upstream v0.8.6
+# Key change: longform_notetweets_inline_media_enabled True→False removed,
+# new flags: tweetypie_unmention_optimization_enabled, rweb_video_timestamps_enabled,
+# responsive_web_media_download_video_enabled
+# URL optimization: only True values are sent (upstream best practice)
 FEATURES: Dict[str, Any] = {
-    "rweb_video_screen_enabled": False,
-    "profile_label_improvements_pcf_label_in_post_enabled": True,
+    "responsive_web_graphql_exclude_directive_enabled": True,
+    "verified_phone_label_enabled": False,
+    "creator_subscriptions_tweet_preview_api_enabled": True,
     "responsive_web_graphql_timeline_navigation_enabled": True,
     "responsive_web_graphql_skip_user_profile_image_extensions_enabled": False,
-    "creator_subscriptions_tweet_preview_api_enabled": True,
-    "communities_web_enable_tweet_community_results_fetch": True,
-    "articles_preview_enabled": True,
+    "c9s_tweet_anatomy_moderator_badge_enabled": True,
+    "tweetypie_unmention_optimization_enabled": True,
     "responsive_web_edit_tweet_api_enabled": True,
     "graphql_is_translatable_rweb_tweet_is_translatable_enabled": True,
     "view_counts_everywhere_api_enabled": True,
     "longform_notetweets_consumption_enabled": True,
     "responsive_web_twitter_article_tweet_consumption_enabled": True,
     "tweet_awards_web_tipping_enabled": False,
+    "longform_notetweets_rich_text_read_enabled": True,
+    "longform_notetweets_inline_media_enabled": True,
+    "rweb_video_timestamps_enabled": True,
+    "responsive_web_media_download_video_enabled": True,
     "freedom_of_speech_not_reach_fetch_enabled": True,
     "standardized_nudges_misinfo": True,
-    "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": True,
-    "longform_notetweets_rich_text_read_enabled": True,
-    "longform_notetweets_inline_media_enabled": False,
     "responsive_web_enhance_cards_enabled": False,
-    "verified_phone_label_enabled": False,
-    "premium_content_api_read_enabled": False,
 }
 
 _ABSOLUTE_MAX_COUNT = 500
 
-# Module-level queryId cache (single-threaded CLI; no locking needed).
+# Module-level caches
 _cached_query_ids: Dict[str, str] = {}
 _bundles_scanned = False
-
-# Shared SSL context — avoids re-reading CA certs on every request.
 _SSL_CTX = ssl.create_default_context()
 
 
-# ── QueryId resolution ───────────────────────────────────────────────────────
+# ── QueryId resolution ───────────────────────────────────────────────────
 
 def _url_fetch(url: str, headers: Optional[Dict[str, str]] = None) -> str:
     req = urllib.request.Request(url)
@@ -122,7 +143,7 @@ def _url_fetch(url: str, headers: Optional[Dict[str, str]] = None) -> str:
 
 
 def _fetch_from_github(operation_name: str) -> Optional[str]:
-    """Try to fetch a fresh queryId from the community-maintained openapi file."""
+    """Try to fetch a fresh queryId from fa0311/twitter-openapi."""
     try:
         data = json.loads(_url_fetch(TWITTER_OPENAPI_URL))
         qid = data.get(operation_name, {}).get("queryId")
@@ -185,7 +206,7 @@ def _invalidate_query_id(operation_name: str) -> None:
     _cached_query_ids.pop(operation_name, None)
 
 
-# ── URL builder ──────────────────────────────────────────────────────────────
+# ── URL builder ──────────────────────────────────────────────────────────
 
 def _build_graphql_url(
     query_id: str,
@@ -194,80 +215,19 @@ def _build_graphql_url(
     features: Dict[str, Any],
     field_toggles: Optional[Dict[str, Any]] = None,
 ) -> str:
+    # Upstream optimization: omit False-valued features to avoid 414 URI Too Long
+    compact_features = {k: v for k, v in features.items() if v is not False}
     url = (
         f"https://x.com/i/api/graphql/{query_id}/{operation_name}"
         f"?variables={urllib.parse.quote(json.dumps(variables, separators=(',', ':')))}"
-        f"&features={urllib.parse.quote(json.dumps(features, separators=(',', ':')))}"
+        f"&features={urllib.parse.quote(json.dumps(compact_features, separators=(',', ':')))}"
     )
     if field_toggles:
         url += f"&fieldToggles={urllib.parse.quote(json.dumps(field_toggles, separators=(',', ':')))}"
     return url
 
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
-
-def _deep_get(data: Any, *keys: Any) -> Any:
-    cur = data
-    for key in keys:
-        if isinstance(key, int):
-            cur = cur[key] if isinstance(cur, list) and 0 <= key < len(cur) else None
-        elif isinstance(cur, dict):
-            cur = cur.get(key)
-        else:
-            return None
-    return cur
-
-
-def _parse_int(value: Any, default: int = 0) -> int:
-    try:
-        return int(float(str(value).replace(",", "").strip()))
-    except (TypeError, ValueError):
-        return default
-
-
-def _extract_cursor(content: Dict[str, Any]) -> Optional[str]:
-    return content.get("value") if content.get("cursorType") == "Bottom" else None
-
-
-def _extract_media(legacy: Dict[str, Any]) -> List[TweetMedia]:
-    media = []
-    for item in _deep_get(legacy, "extended_entities", "media") or []:
-        mtype = item.get("type", "")
-        if mtype == "photo":
-            media.append(TweetMedia(
-                type="photo",
-                url=item.get("media_url_https", ""),
-                width=_deep_get(item, "original_info", "width"),
-                height=_deep_get(item, "original_info", "height"),
-            ))
-        elif mtype in {"video", "animated_gif"}:
-            variants = [v for v in item.get("video_info", {}).get("variants", [])
-                        if v.get("content_type") == "video/mp4"]
-            variants.sort(key=lambda v: v.get("bitrate", 0), reverse=True)
-            media.append(TweetMedia(
-                type=mtype,
-                url=variants[0]["url"] if variants else item.get("media_url_https", ""),
-                width=_deep_get(item, "original_info", "width"),
-                height=_deep_get(item, "original_info", "height"),
-            ))
-    return media
-
-
-def _extract_author(user_data: Dict[str, Any], user_legacy: Dict[str, Any]) -> Author:
-    core = user_data.get("core", {})
-    return Author(
-        id=user_data.get("rest_id", ""),
-        name=core.get("name") or user_legacy.get("name") or "Unknown",
-        screen_name=core.get("screen_name") or user_legacy.get("screen_name") or "unknown",
-        profile_image_url=(
-            user_data.get("avatar", {}).get("image_url")
-            or user_legacy.get("profile_image_url_https", "")
-        ),
-        verified=bool(user_data.get("is_blue_verified") or user_legacy.get("verified", False)),
-    )
-
-
-# ── Error type ───────────────────────────────────────────────────────────────
+# ── Error type ───────────────────────────────────────────────────────────
 
 class TwitterAPIError(RuntimeError):
     def __init__(self, status_code: int, message: str) -> None:
@@ -275,16 +235,14 @@ class TwitterAPIError(RuntimeError):
         self.status_code = status_code
 
 
-# ── Main client ──────────────────────────────────────────────────────────────
+# ── Main client ──────────────────────────────────────────────────────────
 
 class TwitterClient:
-    """Twitter/X GraphQL client.
+    """Twitter/X GraphQL client (cookie auth, zero third-party deps).
 
-    Auth is provided directly as ``auth_token`` and ``ct0`` (the two cookies
-    Twitter's web app uses). Obtain them from your browser's DevTools or a
-    cookie-export extension — this library does NOT extract them automatically.
-
-    Adapted from https://github.com/jackwener/twitter-cli
+    Adapted from https://github.com/public-clis/twitter-cli
+    Auth is passed directly as auth_token + ct0. Optionally pass cookie_string
+    (full browser cookie header) for richer fingerprinting.
     """
 
     def __init__(
@@ -295,15 +253,17 @@ class TwitterClient:
         max_retries: int = 3,
         retry_base_delay: float = 5.0,
         max_count: int = 200,
+        cookie_string: Optional[str] = None,
     ) -> None:
         self._auth_token = auth_token
         self._ct0 = ct0
+        self._cookie_string = cookie_string  # optional full cookie string
         self._request_delay = request_delay
         self._max_retries = max_retries
         self._retry_base_delay = retry_base_delay
         self._max_count = min(max_count, _ABSOLUTE_MAX_COUNT)
 
-    # ── Public read API ──────────────────────────────────────────────────────
+    # ── Public read API ──────────────────────────────────────────────────
 
     def fetch_home_timeline(self, count: int = 20) -> List[Tweet]:
         """Fetch For-You home timeline."""
@@ -327,14 +287,64 @@ class TwitterClient:
         return self._fetch_timeline("Bookmarks", count, get_instructions)
 
     def fetch_search(self, query: str, count: int = 20, product: str = "Top") -> List[Tweet]:
-        """Search tweets. product: Top | Latest | Photos | Videos"""
+        """Search tweets. product: Top | Latest | Photos | Videos
+
+        ⚠️  KNOWN LIMITATION: As of early 2026, X requires an `x-client-transaction-id`
+        header for SearchTimeline requests. This header is generated by the `xclienttransaction`
+        library (a C extension) which cannot be installed on iSH/Alpine. As a result,
+        SearchTimeline returns 404 in this environment.
+
+        Workaround: Use the browser_use tool to navigate to x.com/search and extract
+        results directly from the DOM, or use the twitter-cli package in a full Python
+        environment where xclienttransaction can be installed.
+        """
+        # SearchTimeline requires fieldToggles (discovered from JS bundle analysis)
+        field_toggles = {
+            "withArticlePlainText": True,
+            "withArticleRichContentState": True,
+            "withGrokAnalyze": False,
+            "withDisallowedReplyControls": False,
+        }
+        # SearchTimeline uses a different features set than timeline endpoints
+        search_features = {
+            "rweb_video_screen_enabled": False,
+            "profile_label_improvements_pcf_label_in_post_enabled": True,
+            "rweb_tipjar_consumption_enabled": True,
+            "verified_phone_label_enabled": False,
+            "creator_subscriptions_tweet_preview_api_enabled": True,
+            "responsive_web_graphql_timeline_navigation_enabled": True,
+            "responsive_web_graphql_skip_user_profile_image_extensions_enabled": False,
+            "premium_content_api_read_enabled": False,
+            "communities_web_enable_tweet_community_results_fetch": True,
+            "c9s_tweet_anatomy_moderator_badge_enabled": True,
+            "articles_preview_enabled": True,
+            "responsive_web_edit_tweet_api_enabled": True,
+            "graphql_is_translatable_rweb_tweet_is_translatable_enabled": True,
+            "view_counts_everywhere_api_enabled": True,
+            "longform_notetweets_consumption_enabled": True,
+            "responsive_web_twitter_article_tweet_consumption_enabled": True,
+            "freedom_of_speech_not_reach_fetch_enabled": True,
+            "standardized_nudges_misinfo": True,
+            "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": True,
+            "longform_notetweets_rich_text_read_enabled": True,
+            "longform_notetweets_inline_media_enabled": True,
+            "responsive_web_enhance_cards_enabled": False,
+        }
+        variables = {
+            "rawQuery": query,
+            "querySource": "typed_query",
+            "product": product,
+            "count": min(count, 20),
+        }
         return self._fetch_timeline(
             "SearchTimeline", count,
             lambda d: _deep_get(
                 d, "data", "search_by_raw_query", "search_timeline", "timeline", "instructions"
             ),
-            extra_variables={"rawQuery": query, "querySource": "typed_query", "product": product},
+            extra_variables=variables,
             override_base_variables=True,
+            features_override=search_features,
+            field_toggles=field_toggles,
         )
 
     def fetch_user(self, screen_name: str) -> UserProfile:
@@ -355,119 +365,254 @@ class TwitterClient:
         result = _deep_get(data, "data", "user", "result")
         if not result:
             raise RuntimeError(f"User @{screen_name} not found")
-        legacy = result.get("legacy", {})
-        return UserProfile(
-            id=result.get("rest_id", ""),
-            name=legacy.get("name", ""),
-            screen_name=legacy.get("screen_name", screen_name),
-            bio=legacy.get("description", ""),
-            location=legacy.get("location", ""),
-            url=_deep_get(legacy, "entities", "url", "urls", 0, "expanded_url") or "",
-            followers_count=_parse_int(legacy.get("followers_count")),
-            following_count=_parse_int(legacy.get("friends_count")),
-            tweets_count=_parse_int(legacy.get("statuses_count")),
-            likes_count=_parse_int(legacy.get("favourites_count")),
-            verified=bool(result.get("is_blue_verified") or legacy.get("verified", False)),
-            profile_image_url=legacy.get("profile_image_url_https", ""),
-            created_at=legacy.get("created_at", ""),
-        )
+        profile = parse_user_result(result)
+        if not profile:
+            raise RuntimeError(f"User @{screen_name} unavailable")
+        return profile
 
     def fetch_user_tweets(self, user_id: str, count: int = 20) -> List[Tweet]:
         """Fetch tweets posted by a user (requires user_id, not screen_name)."""
         return self._fetch_timeline(
             "UserTweets", count,
-            lambda d: _deep_get(d, "data", "user", "result", "timeline_v2", "timeline", "instructions"),
-            extra_variables={"userId": user_id, "withQuickPromoteEligibilityTweetFields": True, "withVoice": True, "withV2Timeline": True},
+            lambda d: _deep_get(
+                d, "data", "user", "result", "timeline_v2", "timeline", "instructions"
+            ),
+            extra_variables={
+                "userId": user_id,
+                "includePromotedContent": True,
+                "withQuickPromoteEligibilityTweetFields": True,
+                "withVoice": True,
+                "withV2Timeline": True,
+            },
+            override_base_variables=True,
         )
 
     def fetch_user_likes(self, user_id: str, count: int = 20) -> List[Tweet]:
-        """Fetch tweets liked by a user."""
+        """Fetch tweets liked by a user (own likes only since Jun 2024)."""
         return self._fetch_timeline(
             "Likes", count,
-            lambda d: _deep_get(d, "data", "user", "result", "timeline_v2", "timeline", "instructions"),
-            extra_variables={"userId": user_id, "includePromotedContent": False, "withVoice": True},
+            lambda d: _deep_get(
+                d, "data", "user", "result", "timeline_v2", "timeline", "instructions"
+            ),
+            extra_variables={"userId": user_id, "includePromotedContent": False},
             override_base_variables=True,
         )
 
-    def fetch_tweet_detail(self, tweet_id: str, count: int = 20) -> List[Tweet]:
+    def fetch_tweet_detail(self, tweet_id: str, count: int = 40) -> List[Tweet]:
         """Fetch a tweet and its reply thread."""
         return self._fetch_timeline(
             "TweetDetail", count,
-            lambda d: _deep_get(d, "data", "threaded_conversation_with_injections_v2", "instructions"),
-            extra_variables={"focalTweetId": tweet_id, "referrer": "tweet", "with_rux_injections": False, "includePromotedContent": False, "withCommunity": True, "withQuickPromoteEligibilityTweetFields": True, "withBirdwatchNotes": True, "withVoice": True},
+            lambda d: _deep_get(
+                d, "data", "threaded_conversation_with_injections_v2", "instructions"
+            ),
+            extra_variables={
+                "focalTweetId": tweet_id,
+                "referrer": "tweet",
+                "count": count,
+                "with_rux_injections": False,
+                "includePromotedContent": True,
+                "withCommunity": True,
+                "withQuickPromoteEligibilityTweetFields": True,
+                "withBirdwatchNotes": True,
+                "withVoice": True,
+            },
             override_base_variables=True,
-            field_toggles={"withArticleRichContentState": True, "withArticlePlainText": False, "withGrokAnalyze": False, "withDisallowedReplyControls": False},
         )
+
+    def fetch_tweet_by_id(self, tweet_id: str) -> Optional[Tweet]:
+        """Fetch a single tweet by ID (TweetResultByRestId)."""
+        data = self._graphql_get(
+            "TweetResultByRestId",
+            {
+                "tweetId": tweet_id,
+                "withCommunity": False,
+                "includePromotedContent": False,
+                "withVoice": False,
+            },
+            FEATURES,
+        )
+        result = _deep_get(data, "data", "tweetResult", "result")
+        if not result:
+            return None
+        return parse_tweet_result(result)
 
     def fetch_list_timeline(self, list_id: str, count: int = 20) -> List[Tweet]:
         """Fetch tweets from a Twitter List."""
         return self._fetch_timeline(
             "ListLatestTweetsTimeline", count,
-            lambda d: _deep_get(d, "data", "list", "tweets_timeline", "timeline", "instructions"),
-            extra_variables={"listId": list_id},
+            lambda d: _deep_get(
+                d, "data", "list", "tweets_timeline", "timeline", "instructions"
+            ),
+            extra_variables={"listId": list_id, "count": count},
             override_base_variables=True,
         )
 
     def fetch_followers(self, user_id: str, count: int = 20) -> List[UserProfile]:
         """Fetch followers of a user."""
-        return self._fetch_user_list(
-            "Followers", user_id, count,
-            lambda d: _deep_get(d, "data", "user", "result", "timeline", "timeline", "instructions"),
-        )
+        return self._fetch_users("Followers", user_id, count)
 
     def fetch_following(self, user_id: str, count: int = 20) -> List[UserProfile]:
-        """Fetch users that a user is following."""
-        return self._fetch_user_list(
-            "Following", user_id, count,
-            lambda d: _deep_get(d, "data", "user", "result", "timeline", "timeline", "instructions"),
+        """Fetch accounts followed by a user."""
+        return self._fetch_users("Following", user_id, count)
+
+    def fetch_bookmark_folders(self) -> List[BookmarkFolder]:
+        """Fetch bookmark folders."""
+        data = self._graphql_get(
+            "BookmarkFoldersSlice",
+            {"count": 100},
+            FEATURES,
         )
+        folders = []
+        items = _deep_get(data, "data", "bookmark_folders_slice", "items") or []
+        for item in items:
+            folder_id = item.get("id", "")
+            name = item.get("name", "")
+            if folder_id:
+                folders.append(BookmarkFolder(id=folder_id, name=name))
+        return folders
 
-    # ── Public write API ─────────────────────────────────────────────────────
+    # ── Write API ────────────────────────────────────────────────────────
 
-    def create_tweet(self, text: str, reply_to_id: Optional[str] = None) -> str:
+    def post_tweet(self, text: str, reply_to_id: Optional[str] = None) -> Dict[str, Any]:
+        """Post a new tweet or reply."""
         variables: Dict[str, Any] = {
             "tweet_text": text,
+            "dark_request": False,
             "media": {"media_entities": [], "possibly_sensitive": False},
             "semantic_annotation_ids": [],
-            "dark_request": False,
         }
         if reply_to_id:
-            variables["reply"] = {"in_reply_to_tweet_id": reply_to_id, "exclude_reply_user_ids": []}
-        data = self._graphql_post("CreateTweet", variables, FEATURES)
-        result = _deep_get(data, "data", "create_tweet", "tweet_results", "result")
-        if result:
-            return result.get("rest_id", "")
-        raise RuntimeError("Failed to create tweet")
+            variables["reply"] = {
+                "in_reply_to_tweet_id": reply_to_id,
+                "exclude_reply_user_ids": [],
+            }
+        return self._graphql_post("CreateTweet", variables)
 
-    def delete_tweet(self, tweet_id: str) -> bool:
-        self._graphql_post("DeleteTweet", {"tweet_id": tweet_id, "dark_request": False})
-        return True
+    def delete_tweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Delete a tweet by ID."""
+        return self._graphql_post("DeleteTweet", {"tweet_id": tweet_id, "dark_request": False})
 
-    def like_tweet(self, tweet_id: str) -> bool:
-        self._graphql_post("FavoriteTweet", {"tweet_id": tweet_id})
-        return True
+    def like_tweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Like a tweet."""
+        return self._graphql_post("FavoriteTweet", {"tweet_id": tweet_id})
 
-    def unlike_tweet(self, tweet_id: str) -> bool:
-        self._graphql_post("UnfavoriteTweet", {"tweet_id": tweet_id, "dark_request": False})
-        return True
+    def unlike_tweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Unlike a tweet."""
+        return self._graphql_post("UnfavoriteTweet", {"tweet_id": tweet_id})
 
-    def retweet(self, tweet_id: str) -> bool:
-        self._graphql_post("CreateRetweet", {"tweet_id": tweet_id, "dark_request": False})
-        return True
+    def retweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Retweet a tweet."""
+        return self._graphql_post("CreateRetweet", {"tweet_id": tweet_id, "dark_request": False})
 
-    def unretweet(self, tweet_id: str) -> bool:
-        self._graphql_post("DeleteRetweet", {"source_tweet_id": tweet_id, "dark_request": False})
-        return True
+    def unretweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Undo a retweet."""
+        return self._graphql_post("DeleteRetweet", {"source_tweet_id": tweet_id, "dark_request": False})
 
-    def bookmark_tweet(self, tweet_id: str) -> bool:
-        self._graphql_post("CreateBookmark", {"tweet_id": tweet_id})
-        return True
+    def bookmark_tweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Bookmark a tweet."""
+        return self._graphql_post("CreateBookmark", {"tweet_id": tweet_id})
 
-    def unbookmark_tweet(self, tweet_id: str) -> bool:
-        self._graphql_post("DeleteBookmark", {"tweet_id": tweet_id})
-        return True
+    def unbookmark_tweet(self, tweet_id: str) -> Dict[str, Any]:
+        """Remove a tweet from bookmarks."""
+        return self._graphql_post("DeleteBookmark", {"tweet_id": tweet_id})
 
-    # ── Internal: timeline fetcher ───────────────────────────────────────────
+    # ── Internal helpers ─────────────────────────────────────────────────
+
+    def _build_headers(self) -> Dict[str, str]:
+        cookie = f"auth_token={self._auth_token}; ct0={self._ct0}"
+        if self._cookie_string:
+            # Merge full cookie string (full browser fingerprint)
+            cookie = self._cookie_string
+        return {
+            "Authorization": f"Bearer {BEARER_TOKEN}",
+            "Cookie": cookie,
+            "X-Csrf-Token": self._ct0,
+            "X-Twitter-Active-User": "yes",
+            "X-Twitter-Auth-Type": "OAuth2Session",
+            "X-Twitter-Client-Language": "en",
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://x.com/",
+            "Sec-Ch-Ua": SEC_CH_UA,
+            "Sec-Ch-Ua-Mobile": SEC_CH_UA_MOBILE,
+            "Sec-Ch-Ua-Platform": SEC_CH_UA_PLATFORM,
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+        }
+
+    def _request(self, url: str, method: str = "GET", body: Optional[bytes] = None) -> Any:
+        headers = self._build_headers()
+        req = urllib.request.Request(url, headers=headers, method=method, data=body)
+        for attempt in range(self._max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, context=_SSL_CTX, timeout=30) as r:
+                    return json.loads(r.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                status = e.code
+                body_text = e.read().decode("utf-8", errors="replace")
+                logger.debug("HTTP %d: %s", status, body_text[:200])
+                if status == 404:
+                    raise TwitterAPIError(status, f"404 Not Found: {url}")
+                if status in (429, 503) or (status == 400 and "88" in body_text):
+                    if attempt < self._max_retries:
+                        delay = self._retry_base_delay * (2 ** attempt) + random.uniform(0, 1)
+                        logger.warning("Rate limited (HTTP %d), retrying in %.1fs…", status, delay)
+                        time.sleep(delay)
+                        continue
+                raise TwitterAPIError(status, body_text[:300])
+        raise TwitterAPIError(429, "Max retries exceeded")
+
+    def _graphql_get(
+        self,
+        operation_name: str,
+        variables: Dict[str, Any],
+        features: Dict[str, Any],
+        field_toggles: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Execute a GraphQL GET request, with queryId auto-refresh on 404."""
+        query_id = _resolve_query_id(operation_name)
+        url = _build_graphql_url(query_id, operation_name, variables, features, field_toggles)
+        try:
+            result = self._request(url)
+        except TwitterAPIError as e:
+            if e.status_code == 404:
+                # queryId expired — invalidate cache and force JS bundle scan
+                _invalidate_query_id(operation_name)
+                global _bundles_scanned
+                _bundles_scanned = False  # force re-scan on next lookup
+                query_id = _resolve_query_id(operation_name, prefer_fallback=False)
+                url = _build_graphql_url(query_id, operation_name, variables, features, field_toggles)
+                result = self._request(url)
+            else:
+                raise
+        # Add jitter delay between requests
+        time.sleep(self._request_delay * random.uniform(0.7, 1.3))
+        return result
+
+    def _graphql_post(self, operation_name: str, variables: Dict[str, Any]) -> Any:
+        """Execute a GraphQL POST mutation."""
+        query_id = _resolve_query_id(operation_name)
+        url = f"https://x.com/i/api/graphql/{query_id}/{operation_name}"
+        payload = json.dumps({"variables": variables, "queryId": query_id}, separators=(",", ":"))
+        # Write operations: longer random delay to avoid rate limiting
+        time.sleep(random.uniform(1.5, 4.0))
+        try:
+            result = self._request(url, method="POST", body=payload.encode())
+        except TwitterAPIError as e:
+            if e.status_code == 404:
+                _invalidate_query_id(operation_name)
+                global _bundles_scanned
+                _bundles_scanned = False
+                query_id = _resolve_query_id(operation_name, prefer_fallback=False)
+                url = f"https://x.com/i/api/graphql/{query_id}/{operation_name}"
+                payload = json.dumps({"variables": variables, "queryId": query_id}, separators=(",", ":"))
+                result = self._request(url, method="POST", body=payload.encode())
+            else:
+                raise
+        return result
 
     def _fetch_timeline(
         self,
@@ -476,316 +621,84 @@ class TwitterClient:
         get_instructions: Callable[[Any], Any],
         extra_variables: Optional[Dict[str, Any]] = None,
         override_base_variables: bool = False,
+        features_override: Optional[Dict[str, Any]] = None,
         field_toggles: Optional[Dict[str, Any]] = None,
     ) -> List[Tweet]:
-        if count <= 0:
-            return []
         count = min(count, self._max_count)
+        base_vars: Dict[str, Any] = {
+            "count": 20,
+            "includePromotedContent": True,
+            "latestControlAvailable": True,
+        }
+        if override_base_variables:
+            variables = dict(extra_variables or {})
+        else:
+            variables = {**base_vars, **(extra_variables or {})}
+
+        features = features_override if features_override is not None else FEATURES
+
         tweets: List[Tweet] = []
         seen_ids: Set[str] = set()
         cursor: Optional[str] = None
-        max_attempts = int(math.ceil(count / 20.0)) + 2
+        page = 0
 
-        for _ in range(max_attempts):
-            if len(tweets) >= count:
-                break
-            variables: Dict[str, Any] = (
-                {"count": min(count - len(tweets) + 5, 40)}
-                if override_base_variables
-                else {
-                    "count": min(count - len(tweets) + 5, 40),
-                    "includePromotedContent": False,
-                    "latestControlAvailable": True,
-                    "requestContext": "launch",
-                }
-            )
-            if extra_variables:
-                variables.update(extra_variables)
+        while len(tweets) < count:
             if cursor:
                 variables["cursor"] = cursor
+            data = self._graphql_get(operation_name, variables, features, field_toggles=field_toggles)
+            new_tweets, cursor = parse_timeline_response(data, get_instructions)
 
-            data = self._graphql_get(operation_name, variables, FEATURES, field_toggles)
-            new_tweets, next_cursor = self._parse_timeline_response(data, get_instructions)
-
+            added = 0
             for t in new_tweets:
-                if t.id and t.id not in seen_ids:
+                if t.id not in seen_ids:
                     seen_ids.add(t.id)
                     tweets.append(t)
+                    added += 1
 
-            if not next_cursor or not new_tweets:
+            page += 1
+            logger.debug("Page %d: +%d tweets (total %d), cursor=%s", page, added, len(tweets), cursor)
+
+            if not cursor or added == 0:
                 break
-            cursor = next_cursor
-            if len(tweets) < count and self._request_delay > 0:
-                time.sleep(self._request_delay)
 
         return tweets[:count]
 
-    def _fetch_user_list(
-        self,
-        operation_name: str,
-        user_id: str,
-        count: int,
-        get_instructions: Callable[[Any], Any],
+    def _fetch_users(
+        self, operation_name: str, user_id: str, count: int
     ) -> List[UserProfile]:
-        if count <= 0:
-            return []
         count = min(count, self._max_count)
+        variables: Dict[str, Any] = {"userId": user_id, "count": 20}
         users: List[UserProfile] = []
         seen_ids: Set[str] = set()
         cursor: Optional[str] = None
-        max_attempts = int(math.ceil(count / 20.0)) + 2
 
-        for _ in range(max_attempts):
-            if len(users) >= count:
-                break
-            variables: Dict[str, Any] = {"userId": user_id, "count": min(count - len(users) + 5, 40)}
+        while len(users) < count:
             if cursor:
                 variables["cursor"] = cursor
             data = self._graphql_get(operation_name, variables, FEATURES)
-            new_users, next_cursor = self._parse_user_list_response(data, get_instructions)
-            for u in new_users:
-                if u.id and u.id not in seen_ids:
-                    seen_ids.add(u.id)
-                    users.append(u)
-            if not next_cursor or not new_users:
+
+            instructions = (
+                _deep_get(data, "data", "user", "result", "timeline", "timeline", "instructions")
+                or []
+            )
+            new_cursor = None
+            added = 0
+            for instruction in instructions:
+                for entry in instruction.get("entries", []):
+                    content = entry.get("content", {})
+                    if content.get("cursorType") == "Bottom":
+                        new_cursor = content.get("value")
+                    item_content = content.get("itemContent", {})
+                    if item_content.get("__typename") == "TimelineUser":
+                        result = _deep_get(item_content, "user_results", "result") or {}
+                        profile = parse_user_result(result)
+                        if profile and profile.id not in seen_ids:
+                            seen_ids.add(profile.id)
+                            users.append(profile)
+                            added += 1
+
+            cursor = new_cursor
+            if not cursor or added == 0:
                 break
-            cursor = next_cursor
-            if len(users) < count and self._request_delay > 0:
-                time.sleep(self._request_delay)
 
         return users[:count]
-
-    # ── Internal: HTTP ───────────────────────────────────────────────────────
-
-    def _build_headers(self, url: str = "", method: str = "GET") -> Dict[str, str]:
-        headers = {
-            "Authorization": f"Bearer {BEARER_TOKEN}",
-            "Cookie": f"auth_token={self._auth_token}; ct0={self._ct0}",
-            "X-Csrf-Token": self._ct0,
-            "X-Twitter-Active-User": "yes",
-            "X-Twitter-Auth-Type": "OAuth2Session",
-            "X-Twitter-Client-Language": "en",
-            "User-Agent": USER_AGENT,
-            "Referer": "https://x.com",
-            "Accept": "*/*",
-            "Accept-Language": "en-US,en;q=0.9",
-            "sec-ch-ua": SEC_CH_UA,
-            "sec-ch-ua-mobile": SEC_CH_UA_MOBILE,
-            "sec-ch-ua-platform": SEC_CH_UA_PLATFORM,
-            "Sec-Fetch-Dest": "empty",
-            "Sec-Fetch-Mode": "cors",
-            "Sec-Fetch-Site": "same-origin",
-        }
-        if method == "POST":
-            headers["Content-Type"] = "application/json"
-        return headers
-
-    def _api_request(self, url: str, method: str = "GET", body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        headers = self._build_headers(url, method)
-        encoded_body = json.dumps(body).encode() if body else None
-
-        for attempt in range(self._max_retries + 1):
-            req = urllib.request.Request(url, data=encoded_body, method=method)
-            for k, v in headers.items():
-                req.add_header(k, v)
-            try:
-                with urllib.request.urlopen(req, context=_SSL_CTX, timeout=30) as resp:
-                    payload = resp.read().decode("utf-8")
-            except urllib.error.HTTPError as exc:
-                if exc.code == 429 and attempt < self._max_retries:
-                    wait = self._retry_base_delay * (2 ** attempt)
-                    logger.warning("Rate limited (429), retrying in %.1fs", wait)
-                    time.sleep(wait)
-                    continue
-                body_text = exc.read().decode("utf-8", errors="replace")
-                raise TwitterAPIError(exc.code, f"Twitter API error {exc.code}: {body_text[:500]}")
-            except urllib.error.URLError as exc:
-                raise TwitterAPIError(0, f"Network error: {exc.reason}")
-
-            try:
-                parsed = json.loads(payload)
-            except json.JSONDecodeError:
-                raise TwitterAPIError(0, "Twitter API returned invalid JSON")
-
-            if isinstance(parsed, dict) and parsed.get("errors"):
-                err = parsed["errors"][0]
-                if err.get("code") == 88 and attempt < self._max_retries:
-                    wait = self._retry_base_delay * (2 ** attempt)
-                    logger.warning("Rate limited (code 88), retrying in %.1fs", wait)
-                    time.sleep(wait)
-                    continue
-                raise TwitterAPIError(0, f"Twitter API error: {err.get('message', 'Unknown')}")
-            return parsed
-
-        raise TwitterAPIError(429, f"Rate limited after {self._max_retries} retries")
-
-    def _graphql_get(
-        self,
-        operation_name: str,
-        variables: Dict[str, Any],
-        features: Dict[str, Any],
-        field_toggles: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        qid = _resolve_query_id(operation_name, prefer_fallback=True)
-        url = _build_graphql_url(qid, operation_name, variables, features, field_toggles)
-        try:
-            return self._api_request(url)
-        except TwitterAPIError as exc:
-            if exc.status_code == 404 and qid == FALLBACK_QUERY_IDS.get(operation_name):
-                logger.info("Retrying %s with live queryId after 404", operation_name)
-                _invalidate_query_id(operation_name)
-                qid = _resolve_query_id(operation_name, prefer_fallback=False)
-                url = _build_graphql_url(qid, operation_name, variables, features, field_toggles)
-                return self._api_request(url)
-            raise RuntimeError(str(exc))
-
-    def _graphql_post(
-        self,
-        operation_name: str,
-        variables: Dict[str, Any],
-        features: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        qid = _resolve_query_id(operation_name, prefer_fallback=True)
-
-        def _do(q: str) -> Dict[str, Any]:
-            url = f"https://x.com/i/api/graphql/{q}/{operation_name}"
-            body: Dict[str, Any] = {"variables": variables, "queryId": q}
-            if features:
-                body["features"] = features
-            return self._api_request(url, method="POST", body=body)
-
-        try:
-            return _do(qid)
-        except TwitterAPIError as exc:
-            if exc.status_code == 404 and qid == FALLBACK_QUERY_IDS.get(operation_name):
-                _invalidate_query_id(operation_name)
-                return _do(_resolve_query_id(operation_name, prefer_fallback=False))
-            raise RuntimeError(str(exc))
-
-    # ── Internal: response parsers ───────────────────────────────────────────
-
-    def _parse_timeline_response(
-        self,
-        data: Any,
-        get_instructions: Callable[[Any], Any],
-    ) -> Tuple[List[Tweet], Optional[str]]:
-        tweets: List[Tweet] = []
-        next_cursor: Optional[str] = None
-        instructions = get_instructions(data)
-        if not isinstance(instructions, list):
-            return tweets, next_cursor
-        for instruction in instructions:
-            entries = instruction.get("entries") or instruction.get("moduleItems") or []
-            for entry in entries:
-                content = entry.get("content", {})
-                next_cursor = _extract_cursor(content) or next_cursor
-                # Top-level tweet
-                result = _deep_get(content, "itemContent", "tweet_results", "result")
-                if result:
-                    t = self._parse_tweet_result(result)
-                    if t:
-                        tweets.append(t)
-                # Nested items (conversation modules)
-                for nested in content.get("items", []):
-                    result = _deep_get(nested, "item", "itemContent", "tweet_results", "result")
-                    if result:
-                        t = self._parse_tweet_result(result)
-                        if t:
-                            tweets.append(t)
-        return tweets, next_cursor
-
-    def _parse_tweet_result(self, result: Dict[str, Any], depth: int = 0) -> Optional[Tweet]:
-        if depth > 2:
-            return None
-        tweet_data = result
-        if result.get("__typename") == "TweetWithVisibilityResults" and result.get("tweet"):
-            tweet_data = result["tweet"]
-        if tweet_data.get("__typename") == "TweetTombstone":
-            return None
-        legacy = tweet_data.get("legacy")
-        core = tweet_data.get("core")
-        if not isinstance(legacy, dict) or not isinstance(core, dict):
-            return None
-
-        user = _deep_get(core, "user_results", "result") or {}
-        user_legacy = user.get("legacy", {})
-        user_core = user.get("core", {})
-
-        is_retweet = bool(_deep_get(legacy, "retweeted_status_result", "result"))
-        actual_data, actual_legacy, actual_user, actual_user_legacy = tweet_data, legacy, user, user_legacy
-        retweeted_by: Optional[str] = None
-
-        if is_retweet:
-            retweeted_by = user_core.get("screen_name") or user_legacy.get("screen_name", "unknown")
-            rt = _deep_get(legacy, "retweeted_status_result", "result") or {}
-            if rt.get("__typename") == "TweetWithVisibilityResults" and rt.get("tweet"):
-                rt = rt["tweet"]
-            rt_legacy = rt.get("legacy")
-            rt_core = rt.get("core")
-            if isinstance(rt_legacy, dict) and isinstance(rt_core, dict):
-                actual_data = rt
-                actual_legacy = rt_legacy
-                actual_user = _deep_get(rt_core, "user_results", "result") or {}
-                actual_user_legacy = actual_user.get("legacy", {})
-
-        quoted = _deep_get(actual_data, "quoted_status_result", "result")
-        return Tweet(
-            id=actual_data.get("rest_id", ""),
-            text=actual_legacy.get("full_text", ""),
-            author=_extract_author(actual_user, actual_user_legacy),
-            metrics=Metrics(
-                likes=_parse_int(actual_legacy.get("favorite_count")),
-                retweets=_parse_int(actual_legacy.get("retweet_count")),
-                replies=_parse_int(actual_legacy.get("reply_count")),
-                quotes=_parse_int(actual_legacy.get("quote_count")),
-                views=_parse_int(_deep_get(actual_data, "views", "count")),
-                bookmarks=_parse_int(actual_legacy.get("bookmark_count")),
-            ),
-            created_at=actual_legacy.get("created_at", ""),
-            media=_extract_media(actual_legacy),
-            urls=[u.get("expanded_url", "") for u in _deep_get(actual_legacy, "entities", "urls") or []],
-            is_retweet=is_retweet,
-            retweeted_by=retweeted_by,
-            lang=actual_legacy.get("lang", ""),
-            quoted_tweet=self._parse_tweet_result(quoted, depth + 1) if isinstance(quoted, dict) else None,
-        )
-
-    def _parse_user_list_response(
-        self,
-        data: Any,
-        get_instructions: Callable[[Any], Any],
-    ) -> Tuple[List[UserProfile], Optional[str]]:
-        users: List[UserProfile] = []
-        next_cursor: Optional[str] = None
-        instructions = get_instructions(data)
-        if not isinstance(instructions, list):
-            return users, next_cursor
-        for instruction in instructions:
-            for entry in instruction.get("entries", []):
-                content = entry.get("content", {})
-                next_cursor = _extract_cursor(content) or next_cursor
-                result = _deep_get(content, "itemContent", "user_results", "result")
-                if result:
-                    u = self._parse_user_result(result)
-                    if u:
-                        users.append(u)
-        return users, next_cursor
-
-    def _parse_user_result(self, result: Dict[str, Any]) -> Optional[UserProfile]:
-        legacy = result.get("legacy", {})
-        if not legacy:
-            return None
-        return UserProfile(
-            id=result.get("rest_id", ""),
-            name=legacy.get("name", ""),
-            screen_name=legacy.get("screen_name", ""),
-            bio=legacy.get("description", ""),
-            location=legacy.get("location", ""),
-            followers_count=_parse_int(legacy.get("followers_count")),
-            following_count=_parse_int(legacy.get("friends_count")),
-            tweets_count=_parse_int(legacy.get("statuses_count")),
-            likes_count=_parse_int(legacy.get("favourites_count")),
-            verified=bool(result.get("is_blue_verified") or legacy.get("verified", False)),
-            profile_image_url=legacy.get("profile_image_url_https", ""),
-            created_at=legacy.get("created_at", ""),
-        )

--- a/twitter-x-hub/scripts/models.py
+++ b/twitter-x-hub/scripts/models.py
@@ -1,6 +1,7 @@
-"""Data models for twitter-fetch.
+"""Data models for twitter-x-hub.
 
-Adapted from https://github.com/jackwener/twitter-cli
+Synced from https://github.com/public-clis/twitter-cli (v0.8.6)
+Adapted: zero third-party dependencies (stdlib only).
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ class Metrics:
     replies: int = 0
     quotes: int = 0
     views: int = 0
-    bookmarks: int = 0
+    bookmarks: int = 0  # added upstream v0.8+
 
 
 @dataclass
@@ -49,6 +50,17 @@ class Tweet:
     lang: str = ""
     retweeted_by: Optional[str] = None
     quoted_tweet: Optional["Tweet"] = None
+    score: Optional[float] = None
+    # Twitter Article fields (added upstream)
+    article_title: Optional[str] = None
+    article_text: Optional[str] = None
+    is_subscriber_only: bool = False
+
+
+@dataclass
+class BookmarkFolder:
+    id: str
+    name: str
 
 
 @dataclass

--- a/twitter-x-hub/scripts/parser.py
+++ b/twitter-x-hub/scripts/parser.py
@@ -1,0 +1,275 @@
+"""Response parsing for Twitter GraphQL API.
+
+Extracted from client.py and synced from https://github.com/public-clis/twitter-cli (v0.8.6)
+Converts raw GraphQL JSON into domain model objects.
+Adapted: zero third-party dependencies (stdlib only); article parsing stripped.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .models import Author, Metrics, Tweet, TweetMedia, UserProfile
+
+logger = logging.getLogger(__name__)
+
+
+# ── Utility helpers ──────────────────────────────────────────────────────
+
+def _deep_get(data: Any, *keys: Any) -> Any:
+    """Safely get nested dict/list values. Supports int keys for list access."""
+    current = data
+    for key in keys:
+        if isinstance(key, int):
+            if isinstance(current, list) and 0 <= key < len(current):
+                current = current[key]
+            else:
+                return None
+        elif isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return None
+    return current
+
+
+def _parse_int(value: Any, default: int = 0) -> int:
+    """Best-effort integer conversion. Handles commas and float strings."""
+    try:
+        text = str(value).replace(",", "").strip()
+        if not text:
+            return default
+        return int(float(text))
+    except (TypeError, ValueError):
+        return default
+
+
+def _extract_cursor(content: Dict[str, Any]) -> Optional[str]:
+    """Extract Bottom pagination cursor from timeline content."""
+    if content.get("cursorType") == "Bottom":
+        return content.get("value")
+    return None
+
+
+# ── Media / Author extraction ────────────────────────────────────────────
+
+def _extract_media(legacy: Dict[str, Any]) -> List[TweetMedia]:
+    """Extract media items from tweet legacy data."""
+    media = []
+    for item in _deep_get(legacy, "extended_entities", "media") or []:
+        mtype = item.get("type", "")
+        if mtype == "photo":
+            media.append(TweetMedia(
+                type="photo",
+                url=item.get("media_url_https", ""),
+                width=_deep_get(item, "original_info", "width"),
+                height=_deep_get(item, "original_info", "height"),
+            ))
+        elif mtype in {"video", "animated_gif"}:
+            variants = item.get("video_info", {}).get("variants", [])
+            mp4 = [v for v in variants if v.get("content_type") == "video/mp4"]
+            mp4.sort(key=lambda v: v.get("bitrate", 0), reverse=True)
+            media.append(TweetMedia(
+                type=mtype,
+                url=mp4[0]["url"] if mp4 else item.get("media_url_https", ""),
+                width=_deep_get(item, "original_info", "width"),
+                height=_deep_get(item, "original_info", "height"),
+            ))
+    return media
+
+
+def _extract_author(user_data: Dict[str, Any], user_legacy: Dict[str, Any]) -> Author:
+    """Extract Author from user result data.
+
+    Handles both old API shape (legacy.name/screen_name) and new shape
+    (core.name / core.screen_name) introduced upstream ~v0.7.
+    """
+    user_core = user_data.get("core", {})
+    return Author(
+        id=user_data.get("rest_id", ""),
+        name=(
+            user_core.get("name")
+            or user_legacy.get("name")
+            or user_data.get("name", "Unknown")
+        ),
+        screen_name=(
+            user_core.get("screen_name")
+            or user_legacy.get("screen_name")
+            or user_data.get("screen_name", "unknown")
+        ),
+        profile_image_url=(
+            user_data.get("avatar", {}).get("image_url")
+            or user_legacy.get("profile_image_url_https", "")
+        ),
+        verified=bool(
+            user_data.get("is_blue_verified") or user_legacy.get("verified", False)
+        ),
+    )
+
+
+# ── User parsing ─────────────────────────────────────────────────────────
+
+def parse_user_result(user_data: Dict[str, Any]) -> Optional[UserProfile]:
+    """Parse a user result object into UserProfile."""
+    if user_data.get("__typename") == "UserUnavailable":
+        return None
+    legacy = user_data.get("legacy", {})
+    core = user_data.get("core", {})
+    if not legacy and not core:
+        return None
+    # New API shape: name/screen_name moved to core (2025+)
+    name = core.get("name") or legacy.get("name", "")
+    screen_name = core.get("screen_name") or legacy.get("screen_name", "")
+    return UserProfile(
+        id=user_data.get("rest_id", ""),
+        name=name,
+        screen_name=screen_name,
+        bio=legacy.get("description", ""),
+        location=legacy.get("location", ""),
+        url=_deep_get(legacy, "entities", "url", "urls", 0, "expanded_url") or "",
+        followers_count=_parse_int(legacy.get("followers_count"), 0),
+        following_count=_parse_int(legacy.get("friends_count"), 0),
+        tweets_count=_parse_int(legacy.get("statuses_count"), 0),
+        likes_count=_parse_int(legacy.get("favourites_count"), 0),
+        verified=user_data.get("is_blue_verified", False) or legacy.get("verified", False),
+        profile_image_url=legacy.get("profile_image_url_https", ""),
+        created_at=core.get("created_at") or legacy.get("created_at", ""),
+    )
+
+
+# ── Tweet parsing ────────────────────────────────────────────────────────
+
+def _unwrap_visibility(result: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+    """Unwrap TweetWithVisibilityResults, returning (inner_data, is_subscriber_only)."""
+    if result.get("__typename") == "TweetWithVisibilityResults" and result.get("tweet"):
+        return result["tweet"], bool(result.get("tweetInterstitial"))
+    return result, False
+
+
+def parse_tweet_result(result: Dict[str, Any], depth: int = 0) -> Optional[Tweet]:
+    """Parse a single TweetResult into a Tweet dataclass."""
+    if depth > 2:
+        return None
+
+    tweet_data, is_subscriber_only = _unwrap_visibility(result)
+    if tweet_data.get("__typename") == "TweetTombstone":
+        return None
+
+    legacy = tweet_data.get("legacy")
+    core = tweet_data.get("core")
+    if not isinstance(legacy, dict) or not isinstance(core, dict):
+        return None
+
+    user = _deep_get(core, "user_results", "result") or {}
+    user_legacy = user.get("legacy", {})
+    user_core = user.get("core", {})
+
+    is_retweet = bool(_deep_get(legacy, "retweeted_status_result", "result"))
+    actual_data = tweet_data
+    actual_legacy = legacy
+    actual_user = user
+    actual_user_legacy = user_legacy
+    retweet_subscriber_only = False
+
+    if is_retweet:
+        rt_result = _deep_get(legacy, "retweeted_status_result", "result") or {}
+        rt_result, retweet_subscriber_only = _unwrap_visibility(rt_result)
+        rt_legacy = rt_result.get("legacy")
+        rt_core = rt_result.get("core")
+        if isinstance(rt_legacy, dict) and isinstance(rt_core, dict):
+            actual_data = rt_result
+            actual_legacy = rt_legacy
+            actual_user = _deep_get(rt_core, "user_results", "result") or {}
+            actual_user_legacy = actual_user.get("legacy", {})
+
+    media = _extract_media(actual_legacy)
+    urls = [
+        item.get("expanded_url", "")
+        for item in _deep_get(actual_legacy, "entities", "urls") or []
+    ]
+    quoted = _deep_get(actual_data, "quoted_status_result", "result")
+    quoted_tweet = (
+        parse_tweet_result(quoted, depth=depth + 1)
+        if isinstance(quoted, dict)
+        else None
+    )
+    author = _extract_author(actual_user, actual_user_legacy)
+
+    retweeted_by = None
+    if is_retweet:
+        retweeted_by = (
+            user_core.get("screen_name")
+            or user_legacy.get("screen_name", "unknown")
+        )
+
+    # Prefer note_tweet full text for long tweets ("Show More")
+    note_text = _deep_get(
+        actual_data, "note_tweet", "note_tweet_results", "result", "text"
+    )
+
+    return Tweet(
+        id=actual_data.get("rest_id", ""),
+        text=note_text or actual_legacy.get("full_text", ""),
+        author=author,
+        metrics=Metrics(
+            likes=_parse_int(actual_legacy.get("favorite_count"), 0),
+            retweets=_parse_int(actual_legacy.get("retweet_count"), 0),
+            replies=_parse_int(actual_legacy.get("reply_count"), 0),
+            quotes=_parse_int(actual_legacy.get("quote_count"), 0),
+            views=_parse_int(_deep_get(actual_data, "views", "count"), 0),
+            bookmarks=_parse_int(actual_legacy.get("bookmark_count"), 0),
+        ),
+        created_at=actual_legacy.get("created_at", ""),
+        media=media,
+        urls=urls,
+        is_retweet=is_retweet,
+        retweeted_by=retweeted_by,
+        quoted_tweet=quoted_tweet,
+        lang=actual_legacy.get("lang", ""),
+        is_subscriber_only=(
+            (is_subscriber_only or retweet_subscriber_only)
+            if is_retweet
+            else is_subscriber_only
+        ),
+    )
+
+
+# ── Timeline response parsing ────────────────────────────────────────────
+
+def parse_timeline_response(
+    data: Any,
+    get_instructions: Callable[[Any], Any],
+) -> Tuple[List[Tweet], Optional[str]]:
+    """Parse timeline GraphQL response into tweets and next cursor."""
+    tweets: List[Tweet] = []
+    next_cursor: Optional[str] = None
+
+    instructions = get_instructions(data)
+    if not isinstance(instructions, list):
+        logger.warning("No timeline instructions found")
+        return tweets, next_cursor
+
+    for instruction in instructions:
+        entries = instruction.get("entries") or instruction.get("moduleItems") or []
+        for entry in entries:
+            content = entry.get("content", {})
+            next_cursor = _extract_cursor(content) or next_cursor
+
+            item_content = content.get("itemContent", {})
+            result = _deep_get(item_content, "tweet_results", "result")
+            if result:
+                tweet = parse_tweet_result(result)
+                if tweet:
+                    tweets.append(tweet)
+
+            # Module items (e.g. conversation threads)
+            for nested_item in content.get("items", []):
+                nested_result = _deep_get(
+                    nested_item, "item", "itemContent", "tweet_results", "result"
+                )
+                if nested_result:
+                    tweet = parse_tweet_result(nested_result)
+                    if tweet:
+                        tweets.append(tweet)
+
+    return tweets, next_cursor


### PR DESCRIPTION
## Summary

Sync `twitter-x-hub` with upstream [public-clis/twitter-cli](https://github.com/public-clis/twitter-cli) v0.8.6, plus live QueryId scan from x.com JS bundle (2026-04-08).

## Changes

### 🔑 QueryId full refresh (scanned from `main.0e98bc8a.js`)

| Operation | Old | New |
|-----------|-----|-----|
| HomeTimeline | `L8Lb9oom…` | `J62e-zdB…` |
| HomeLatestTimeline | `tzmrSIWx…` | `2ee46L1A…` |
| SearchTimeline | `rkp6b4vt…` | `pCd62NDD…` |
| UserTweets | `O0epvwaQ…` | `x3B_xLqC…` |
| Likes | `lIDpu_NW…` | `KPuet6dG…` |
| TweetDetail | `xIYgDwjb…` | `rU08O-Yi…` |
| TweetResultByRestId | `zy39CwTy…` | `tmhPpO5s…` |
| ListLatestTweetsTimeline | `fb_6wmHD…` | `qcQY-EkE…` |
| Followers | `Enf9DNUZYiT…` | `-WcGoRt8…` |
| Following | `ntIPnH1W…` | `vWCjN9gc…` |
| CreateTweet | `zkcFc6F-…` | `S1qcGUn6…` |

### 🗂 New file: `scripts/parser.py`

Extracted from `client.py` following upstream v0.8+ architecture. Contains all response-parsing logic:
- `parse_tweet_result` — with `_unwrap_visibility` for `TweetWithVisibilityResults`
- `parse_timeline_response` — generic paginated timeline parser
- `parse_user_result` — **fixed**: `name`/`screen_name` now read from `core` field (new X API shape, 2025+)
- `_extract_author` — supports both old (`legacy`) and new (`core`) API shapes
- `note_tweet` full-text support for long tweets ("Show More")

### 📦 `models.py`
- `Metrics`: new `bookmarks` field
- `Tweet`: new `article_title`, `article_text`, `is_subscriber_only` fields
- New `BookmarkFolder` dataclass

### 🆕 New CLI commands
- `tweet-by-id` — single tweet fetch via `TweetResultByRestId` (faster, no replies)
- `bookmark-folders` — list bookmark folders via `BookmarkFoldersSlice`

### ⚙️ Other
- URL optimization: False-valued features omitted from URL to avoid HTTP 414
- `post_tweet` return value fixed (returns full API result object)
- Request jitter delay added to write operations

### ⚠️ Known limitation
`search` command requires `x-client-transaction-id` header (generated by `xclienttransaction` C extension, unavailable on iSH/Alpine). Documented in SKILL.md. All other commands tested and working.

## Testing

Tested on iSH/Alpine (aarch64):
- ✅ `feed` (for-you, following)
- ✅ `user` (name/screen_name now correctly parsed from `core`)
- ✅ `tweet-by-id`
- ✅ `bookmarks`
- ✅ `user-posts`, `followers`, `following`
- ❌ `search` — known limitation (xclienttransaction unavailable)
