### PR TITLE
feat: add codex-image skill (gpt-image-2 via ChatGPT session)

### DIFF
--- a/codex-image/SKILL.md
+++ b/codex-image/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: codex-image
+description: Generate images using OpenAI's Codex backend API with gpt-image-2 tool. Use when the user asks to generate images via Codex, ChatGPT image generation, or gpt-image-2. Triggers on "codex image", "codex generate", "gpt-image", "chatgpt generate image". Token is auto-fetched from chatgpt.com session — no manual token setup needed.
+---
+
+# Codex Image Generation
+
+Generate images via `chatgpt.com/backend-api/codex/responses` using the `image_generation` tool (gpt-image-2).
+
+## Requirements
+
+- A ChatGPT account (token is fetched automatically via browser session)
+- No manual token setup needed — the skill handles auth automatically
+
+## Auth Token Resolution (in order)
+
+1. `--token` argument (CLI only)
+2. `CODEX_IMAGE_TOKEN` environment variable
+3. `--token-file` argument (CLI only)
+4. `~/.chatgpt_auth.json` cache (valid for 8 hours)
+5. **Auto login flow** — fetches from `https://chatgpt.com/api/auth/session` via `minis-browser-use`:
+   - If already logged in → token extracted immediately
+   - If not logged in → opens `chatgpt.com/auth/login` in the browser, then polls every 30s in a new tab for up to 5 minutes
+   - On success → saves token to `~/.chatgpt_auth.json` (chmod 600)
+
+## Usage
+
+```bash
+python3 scripts/codex_image.py "a cute rabbit on a light background" \
+  --output rabbit.png \
+  --model gpt-5.4 \
+  --effort low
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `prompt` | (required) | Image description |
+| `--output` | `codex_image.png` | Output file path |
+| `--model` | `gpt-5.4` | Codex model |
+| `--effort` | `low` | Reasoning effort: low/medium/high |
+| `--token` | - | Access token directly (skips auto auth) |
+| `--token-file` | - | File containing token (skips auto auth) |
+
+### Output
+
+JSON with `success`, `path`, `size`, `revised_prompt` on success.
+
+## Auth Script (standalone)
+
+```bash
+python3 scripts/get_auth.py
+```
+
+Returns JSON `{"success": true, "accessToken": "...", "source": "cache|session|login"}`.
+Can be used independently to refresh or pre-fetch the token.
+
+## Workflow
+
+1. **Token**: auto-resolved via `get_auth.py`:
+   - Already cached → use directly
+   - Already logged in (browser session) → extract immediately
+   - Not logged in → `minis-open` pops the ChatGPT login page to the user in foreground, then polls every 10s (up to 5 min) until login is detected
+2. Construct the prompt from the user's request.
+3. Run `scripts/codex_image.py` with appropriate arguments.
+4. Send the generated image to the user.
+
+## Notes
+
+- Token is cached in `~/.chatgpt_auth.json` for 8 hours (chmod 600).
+- The endpoint requires `stream: true`; the script handles SSE parsing internally.
+- Token is a ChatGPT session token, not an OpenAI API key. It expires and is refreshed automatically on next use.
+- Image generation uses `gpt-image-2` under the hood with auto quality/size.
+- Token usage is split: main `usage` tracks text tokens, `tool_usage.image_gen` tracks image tokens separately.
+- This uses an internal/unofficial API endpoint. Availability may change.

--- a/codex-image/SKILL.md
+++ b/codex-image/SKILL.md
@@ -19,9 +19,10 @@ Generate images via `chatgpt.com/backend-api/codex/responses` using the `image_g
 3. `--token-file` argument (CLI only)
 4. `~/.chatgpt_auth.json` cache (valid for 8 hours)
 5. **Auto login flow** — fetches from `https://chatgpt.com/api/auth/session` via `minis-browser-use`:
-   - If already logged in → token extracted immediately
-   - If not logged in → opens `chatgpt.com/auth/login` in the browser, then polls every 30s in a new tab for up to 5 minutes
-   - On success → saves token to `~/.chatgpt_auth.json` (chmod 600)
+   - If already logged in → token extracted and saved to cache immediately
+   - If not logged in → opens `chatgpt.com/auth/login` in the browser, then polls every 10s in a new tab for up to 5 minutes
+   - On success → saves token to `~/.chatgpt_auth.json` (chmod 600, token + timestamp only)
+   - **Token is never printed to stdout or logs** — it stays in the cache file only
 
 ## Usage
 
@@ -53,8 +54,7 @@ JSON with `success`, `path`, `size`, `revised_prompt` on success.
 python3 scripts/get_auth.py
 ```
 
-Returns JSON `{"success": true, "accessToken": "...", "source": "cache|session|login"}`.
-Can be used independently to refresh or pre-fetch the token.
+Returns JSON `{"success": true, "source": "cache|session|login"}` — **the token itself is never printed to stdout**. It is written only to `~/.chatgpt_auth.json` (chmod 600, token + timestamp only, no PII). This prevents the token from appearing in shell logs, conversation context, or screenshots.
 
 ## Workflow
 
@@ -68,7 +68,8 @@ Can be used independently to refresh or pre-fetch the token.
 
 ## Notes
 
-- Token is cached in `~/.chatgpt_auth.json` for 8 hours (chmod 600).
+- Token is cached in `~/.chatgpt_auth.json` for 8 hours (chmod 600, token + timestamp only — no PII stored).
+- **Token is never printed to stdout or conversation context** — always read from cache file internally.
 - The endpoint requires `stream: true`; the script handles SSE parsing internally.
 - Token is a ChatGPT session token, not an OpenAI API key. It expires and is refreshed automatically on next use.
 - Image generation uses `gpt-image-2` under the hood with auto quality/size.

--- a/codex-image/scripts/codex_image.py
+++ b/codex-image/scripts/codex_image.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Codex Image Generation via ChatGPT backend API.
+Uses gpt-image-2 through the Codex responses endpoint with stream=true.
+"""
+import json, re, base64, http.client, ssl, sys, os, time, subprocess
+
+AUTH_CACHE = os.path.expanduser("~/.chatgpt_auth.json")
+
+
+def get_token_auto(no_login=False) -> str:
+    """Get ChatGPT access token via get_auth.py (auto login flow).
+    
+    Args:
+        no_login: If True, only check session/cache, don't open login page.
+    """
+    script = os.path.join(os.path.dirname(__file__), "get_auth.py")
+    cmd = [sys.executable, script]
+    if no_login:
+        cmd.append("--no-login")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=360)
+    # Print auth progress to stderr
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    stdout = result.stdout.strip()
+    if not stdout:
+        raise RuntimeError(f"get_auth.py returned no output. stderr: {result.stderr[:300]}")
+    data = json.loads(stdout)
+    if not data.get("success"):
+        raise RuntimeError(data.get("error", "Auth failed"))
+    return data["accessToken"]
+
+def is_oauth_error(result: dict) -> bool:
+    """Check if the error is an OAuth/auth related error."""
+    err = result.get("error", "")
+    return any(k in err.lower() for k in ["401", "403", "unauthorized", "forbidden", "oauth", "token", "invalid_api_key", "authentication"])
+
+
+def generate_image(token: str, prompt: str, output_path: str, model: str = "gpt-5.4", effort: str = "low") -> dict:
+    """Generate an image via Codex image_generation tool.
+    
+    Args:
+        token: ChatGPT access token (Bearer token from chatgpt.com)
+        prompt: Image generation prompt
+        output_path: Output file path for the generated image
+        model: Model to use (default: gpt-5.4)
+        effort: Reasoning effort level (default: low)
+    
+    Returns:
+        dict with keys: success, path, revised_prompt, usage, error
+    """
+    payload = json.dumps({
+        "model": model,
+        "instructions": "You are a helpful assistant. Use tools when available.",
+        "input": [{"role": "user", "content": f"Use the image generation tool to create: {prompt}"}],
+        "store": False,
+        "tools": [{"type": "image_generation"}],
+        "reasoning": {"effort": effort},
+        "include": [],
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "stream": True
+    })
+
+    ctx = ssl.create_default_context()
+    conn = http.client.HTTPSConnection("chatgpt.com", context=ctx, timeout=180)
+    conn.request("POST", "/backend-api/codex/responses", body=payload, headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream"
+    })
+    resp = conn.getresponse()
+
+    if resp.status != 200:
+        body = resp.read().decode("utf-8", errors="replace")
+        conn.close()
+        return {"success": False, "error": f"HTTP {resp.status}: {body[:500]}"}
+
+    chunks = []
+    while True:
+        chunk = resp.read(65536)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    conn.close()
+
+    data = b"".join(chunks).decode("utf-8", errors="replace")
+
+    # Extract base64 PNG
+    matches = re.findall(r'(iVBOR[A-Za-z0-9+/=]{1000,})', data)
+    if not matches:
+        return {"success": False, "error": "No image data in response"}
+
+    img = base64.b64decode(matches[0])
+    with open(output_path, "wb") as f:
+        f.write(img)
+
+    # Extract revised_prompt
+    revised = ""
+    m = re.search(r'"revised_prompt"\s*:\s*"([^"]*)"', data)
+    if m:
+        revised = m.group(1)
+
+    # Extract usage
+    usage = {}
+    m = re.search(r'"usage"\s*:\s*(\{[^}]+\})', data)
+    if m:
+        try:
+            usage = json.loads(m.group(1))
+        except:
+            pass
+
+    return {
+        "success": True,
+        "path": output_path,
+        "size": len(img),
+        "revised_prompt": revised,
+        "usage": usage
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Generate images via Codex API")
+    parser.add_argument("prompt", help="Image generation prompt")
+    parser.add_argument("--token", help="ChatGPT access token (or set CODEX_IMAGE_TOKEN env)")
+    parser.add_argument("--token-file", help="File containing the access token")
+    parser.add_argument("--output", "-o", default="codex_image.png", help="Output file path")
+    parser.add_argument("--model", default="gpt-5.4", help="Model (default: gpt-5.4)")
+    parser.add_argument("--effort", default="low", choices=["low", "medium", "high"], help="Reasoning effort")
+    args = parser.parse_args()
+
+    # Token resolution order:
+    # 1. --token argument
+    # 2. CODEX_IMAGE_TOKEN env var
+    # 3. --token-file argument
+    # 4. ~/.chatgpt_auth.json cache
+    # 5. Auto login flow via get_auth.py (opens browser, waits up to 5 min)
+    token = args.token or os.environ.get("CODEX_IMAGE_TOKEN")
+    if not token and args.token_file:
+        with open(args.token_file) as f:
+            token = f.read().strip()
+    if not token:
+        # Try cache
+        if os.path.exists(AUTH_CACHE):
+            try:
+                with open(AUTH_CACHE) as f:
+                    cached = json.load(f)
+                cached_at = cached.get("_cached_at", 0)
+                if time.time() - cached_at <= 8 * 3600:
+                    token = cached.get("accessToken", "")
+                    if token:
+                        print("[auth] Using cached token.", file=sys.stderr)
+            except Exception:
+                pass
+    if not token:
+        print("[auth] No token found — starting auto login flow...", file=sys.stderr)
+        try:
+            token = get_token_auto()
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"Generating image...", flush=True)
+    result = generate_image(token, args.prompt, args.output, args.model, args.effort)
+
+    # If oauth/auth error, invalidate cache and retry once with a fresh token
+    if not result["success"] and is_oauth_error(result):
+        print(f"[auth] OAuth error detected: {result['error']}", file=sys.stderr)
+        print("[auth] Invalidating cached token, trying to refresh from session...", file=sys.stderr)
+
+        # Remove stale cache
+        if os.path.exists(AUTH_CACHE):
+            os.remove(AUTH_CACHE)
+
+        # First try silently refreshing from browser session (no login page)
+        try:
+            token = get_token_auto(no_login=True)
+            print("[auth] Session refresh succeeded.", file=sys.stderr)
+        except RuntimeError as e:
+            if "not_logged_in" in str(e):
+                # Session also expired — open login page once and wait
+                print("[auth] Session expired. Opening login page for re-authentication (last attempt)...", file=sys.stderr)
+                try:
+                    token = get_token_auto(no_login=False)
+                except Exception as e2:
+                    print(json.dumps({"success": False, "error": f"Auth retry failed: {e2}. Please log in to ChatGPT and try again."}), file=sys.stderr)
+                    sys.exit(1)
+            else:
+                print(json.dumps({"success": False, "error": f"Auth retry failed: {e}"}), file=sys.stderr)
+                sys.exit(1)
+
+        print("[auth] Retrying image generation with new token...", file=sys.stderr)
+        print(f"Generating image...", flush=True)
+        result = generate_image(token, args.prompt, args.output, args.model, args.effort)
+
+        if not result["success"]:
+            print(json.dumps({
+                "success": False,
+                "error": f"Failed after auth retry: {result['error']}. Please check your ChatGPT login and try again."
+            }, indent=2), file=sys.stderr)
+            sys.exit(1)
+
+    if result["success"]:
+        print(json.dumps({
+            "success": True,
+            "path": result["path"],
+            "size": result["size"],
+            "revised_prompt": result["revised_prompt"]
+        }, indent=2))
+    else:
+        print(json.dumps({"success": False, "error": result["error"]}, indent=2), file=sys.stderr)
+        sys.exit(1)

--- a/codex-image/scripts/codex_image.py
+++ b/codex-image/scripts/codex_image.py
@@ -10,7 +10,12 @@ AUTH_CACHE = os.path.expanduser("~/.chatgpt_auth.json")
 
 def get_token_auto(no_login=False) -> str:
     """Get ChatGPT access token via get_auth.py (auto login flow).
-    
+
+    get_auth.py intentionally does NOT print the token to stdout (to avoid
+    leaking credentials into logs or conversation context). Instead, it writes
+    the token to AUTH_CACHE (~/.chatgpt_auth.json, chmod 600) and we read it
+    from there after the subprocess exits successfully.
+
     Args:
         no_login: If True, only check session/cache, don't open login page.
     """
@@ -19,7 +24,7 @@ def get_token_auto(no_login=False) -> str:
     if no_login:
         cmd.append("--no-login")
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=360)
-    # Print auth progress to stderr
+    # Print auth progress to stderr (contains no token values)
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
     stdout = result.stdout.strip()
@@ -28,7 +33,16 @@ def get_token_auto(no_login=False) -> str:
     data = json.loads(stdout)
     if not data.get("success"):
         raise RuntimeError(data.get("error", "Auth failed"))
-    return data["accessToken"]
+    # Read token from cache file — never from stdout
+    try:
+        with open(AUTH_CACHE) as f:
+            cached = json.load(f)
+        token = cached.get("accessToken", "")
+        if not token:
+            raise RuntimeError("Cache file exists but accessToken is empty.")
+        return token
+    except Exception as e:
+        raise RuntimeError(f"Failed to read token from cache after auth: {e}")
 
 def is_oauth_error(result: dict) -> bool:
     """Check if the error is an OAuth/auth related error."""

--- a/codex-image/scripts/get_auth.py
+++ b/codex-image/scripts/get_auth.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+ChatGPT Auth Token Fetcher
+Fetches the accessToken from https://chatgpt.com/api/auth/session via minis-browser-use.
+- If already cached in ~/.chatgpt_auth.json, returns it directly.
+- If not, opens chatgpt.com login page and polls every 30s (up to 5 min) in a new tab.
+- Saves the token to ~/.chatgpt_auth.json on success.
+"""
+import json, os, sys, time, subprocess
+
+AUTH_CACHE = os.path.expanduser("~/.chatgpt_auth.json")
+SESSION_URL = "https://chatgpt.com/api/auth/session"
+LOGIN_URL = "https://chatgpt.com/auth/login"
+MAX_WAIT = 300   # 5 minutes
+POLL_INTERVAL = 10
+
+
+def browser(action: str, **kwargs) -> dict:
+    """Run a minis-browser-use action and return parsed JSON output."""
+    # Build CLI args from action + kwargs
+    cmd = ["minis-browser-use", action]
+    tab_id = kwargs.pop("tab_id", None)
+    for k, v in kwargs.items():
+        cmd.append(f"--{k.replace('_', '-')}")
+        cmd.append(str(v))
+    if tab_id is not None:
+        cmd += ["--tab-id", str(tab_id)]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        stdout = result.stdout.strip()
+        if stdout:
+            try:
+                return json.loads(stdout)
+            except Exception:
+                return {"text": stdout}
+        return {"error": result.stderr.strip()}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def fetch_session_json(tab_id=None) -> dict | None:
+    """Navigate to the session URL in a tab and try to parse JSON."""
+    nav_kwargs = {}
+    if tab_id is not None:
+        nav_kwargs["tab_id"] = tab_id
+    browser("navigate", url=SESSION_URL, **nav_kwargs)
+
+    # Wait for DOM to settle
+    browser("wait_for_dom_stable", timeout=8000, **nav_kwargs)
+
+    # Get page text
+    text_result = browser("get_text", **nav_kwargs)
+
+    text = ""
+    if isinstance(text_result, dict):
+        data_field = text_result.get("data", {})
+        if isinstance(data_field, dict):
+            text = data_field.get("text", "") or data_field.get("content", "")
+        text = text or text_result.get("text", "") or text_result.get("content", "")
+    if not text:
+        return None
+
+    # Try to parse JSON
+    try:
+        data = json.loads(text.strip())
+        if isinstance(data, dict) and data.get("accessToken"):
+            return data
+    except Exception:
+        pass
+
+    # Also try extracting JSON from page source
+    import re
+    m = re.search(r'\{.*"accessToken"\s*:\s*"[^"]+".*\}', text, re.DOTALL)
+    if m:
+        try:
+            data = json.loads(m.group(0))
+            if data.get("accessToken"):
+                return data
+        except Exception:
+            pass
+
+    return None
+
+
+def save_cache(data: dict):
+    data["_cached_at"] = int(time.time())
+    with open(AUTH_CACHE, "w") as f:
+        json.dump(data, f, indent=2)
+    os.chmod(AUTH_CACHE, 0o600)
+
+
+def load_cache() -> dict | None:
+    if not os.path.exists(AUTH_CACHE):
+        return None
+    try:
+        with open(AUTH_CACHE) as f:
+            data = json.load(f)
+        token = data.get("accessToken", "")
+        if not token:
+            return None
+        # Treat cache as valid for 8 hours
+        cached_at = data.get("_cached_at", 0)
+        if time.time() - cached_at > 8 * 3600:
+            print("[auth] Cached token expired (>8h), re-fetching...", file=sys.stderr)
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-login", action="store_true",
+                        help="Only check session, do not open login page. Exit with error if not logged in.")
+    args = parser.parse_args()
+
+    # 1. Check cache first
+    cached = load_cache()
+    if cached:
+        print("[auth] Using cached token.", file=sys.stderr)
+        print(json.dumps({"success": True, "accessToken": cached["accessToken"], "source": "cache"}))
+        return
+
+    # 2. Try fetching session directly (user may already be logged in)
+    print("[auth] Checking existing ChatGPT session...", file=sys.stderr)
+    data = fetch_session_json()
+    if data and data.get("accessToken"):
+        save_cache(data)
+        print("[auth] Got token from existing session.", file=sys.stderr)
+        print(json.dumps({"success": True, "accessToken": data["accessToken"], "source": "session"}))
+        return
+
+    # 3. If --no-login, bail out immediately without opening login page
+    if args.no_login:
+        print("[auth] Not logged in (--no-login mode, skipping login page).", file=sys.stderr)
+        print(json.dumps({"success": False, "error": "not_logged_in"}))
+        sys.exit(1)
+
+    # 4. Open login page in foreground via minis-open (shows to user)
+    print("[auth] Not logged in. Opening ChatGPT login page...", file=sys.stderr)
+    subprocess.run(["minis-open", LOGIN_URL])
+    print("[auth] 请在弹出的页面中完成 ChatGPT 登录，登录后脚本将自动继续...", file=sys.stderr)
+    print(f"[auth] 将每 {POLL_INTERVAL}s 检查一次，最多等待 {MAX_WAIT}s。", file=sys.stderr)
+
+    deadline = time.time() + MAX_WAIT
+    poll_tab_id = None
+
+    while time.time() < deadline:
+        time.sleep(POLL_INTERVAL)
+        remaining = int(deadline - time.time())
+        print(f"[auth] Polling session... ({remaining}s remaining)", file=sys.stderr)
+
+        # Open a new tab to check session (avoids interrupting login tab)
+        if poll_tab_id is None:
+            new_tab_result = browser("new_tab")
+            if isinstance(new_tab_result, dict):
+                data_field = new_tab_result.get("data", new_tab_result)
+                poll_tab_id = data_field.get("tab_id") if isinstance(data_field, dict) else None
+
+        data = fetch_session_json(tab_id=poll_tab_id)
+        if data and data.get("accessToken"):
+            # Close the poll tab
+            if poll_tab_id is not None:
+                browser("close_tab", tab_id=poll_tab_id)
+            save_cache(data)
+            print("[auth] Login detected! Token saved.", file=sys.stderr)
+            print(json.dumps({"success": True, "accessToken": data["accessToken"], "source": "login"}))
+            return
+
+    print("[auth] Timed out waiting for login.", file=sys.stderr)
+    print(json.dumps({"success": False, "error": "Timed out waiting for ChatGPT login (5 min)"}))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/codex-image/scripts/get_auth.py
+++ b/codex-image/scripts/get_auth.py
@@ -83,9 +83,13 @@ def fetch_session_json(tab_id=None) -> dict | None:
 
 
 def save_cache(data: dict):
-    data["_cached_at"] = int(time.time())
+    """Only cache the token and timestamp — discard PII fields (email, user_id, etc.)."""
+    cache = {
+        "accessToken": data["accessToken"],
+        "_cached_at": int(time.time()),
+    }
     with open(AUTH_CACHE, "w") as f:
-        json.dump(data, f, indent=2)
+        json.dump(cache, f)
     os.chmod(AUTH_CACHE, 0o600)
 
 
@@ -119,7 +123,8 @@ def main():
     cached = load_cache()
     if cached:
         print("[auth] Using cached token.", file=sys.stderr)
-        print(json.dumps({"success": True, "accessToken": cached["accessToken"], "source": "cache"}))
+        # Token is NOT printed to stdout — callers must read from AUTH_CACHE directly
+        print(json.dumps({"success": True, "source": "cache"}))
         return
 
     # 2. Try fetching session directly (user may already be logged in)
@@ -128,7 +133,8 @@ def main():
     if data and data.get("accessToken"):
         save_cache(data)
         print("[auth] Got token from existing session.", file=sys.stderr)
-        print(json.dumps({"success": True, "accessToken": data["accessToken"], "source": "session"}))
+        # Token is NOT printed to stdout — callers must read from AUTH_CACHE directly
+        print(json.dumps({"success": True, "source": "session"}))
         return
 
     # 3. If --no-login, bail out immediately without opening login page
@@ -165,7 +171,8 @@ def main():
                 browser("close_tab", tab_id=poll_tab_id)
             save_cache(data)
             print("[auth] Login detected! Token saved.", file=sys.stderr)
-            print(json.dumps({"success": True, "accessToken": data["accessToken"], "source": "login"}))
+            # Token is NOT printed to stdout — callers must read from AUTH_CACHE directly
+            print(json.dumps({"success": True, "source": "login"}))
             return
 
     print("[auth] Timed out waiting for login.", file=sys.stderr)


### PR DESCRIPTION
## codex-image

Generate images using OpenAI's `gpt-image-2` via the ChatGPT internal Codex API.

> 💡 Contributed by @Sanite_Ava — thanks for sharing this skill!

### Features
- **Zero manual setup** — auto-fetches ChatGPT session token via browser; if not logged in, opens the login page and polls until authenticated
- **Token never leaks** — token is stored only in `~/.chatgpt_auth.json` (chmod 600, token + timestamp only); never printed to stdout, logs, or conversation context
- **Auto-refresh** — detects OAuth errors and silently refreshes the session token; falls back to re-login if session has expired
- Supports `low / medium / high` reasoning effort
- Cache valid for 8 hours

### Security
- `get_auth.py` stdout outputs only `{"success": true, "source": "cache|session|login"}` — no token value
- Cache file stores only `accessToken` + `_cached_at`; PII fields (email, user_id) from the session JSON are discarded
- `codex_image.py` reads the token from the cache file internally, never from subprocess stdout

### Usage
```bash
python3 scripts/codex_image.py "a futuristic city at night" --output city.png --effort low
```