### PR TITLE
Add image-to-image support for codex-image

### DIFF
--- a/codex-image/SKILL.md
+++ b/codex-image/SKILL.md
@@ -26,6 +26,8 @@ Generate images via `chatgpt.com/backend-api/codex/responses` using the `image_g
 
 ## Usage
 
+### Text-to-image
+
 ```bash
 python3 scripts/codex_image.py "a cute rabbit on a light background" \
   --output rabbit.png \
@@ -33,16 +35,29 @@ python3 scripts/codex_image.py "a cute rabbit on a light background" \
   --effort low
 ```
 
+### Image-to-image / reference image
+
+```bash
+python3 scripts/codex_image_edit.py "turn this person into a cinematic iOS AI assistant portrait" \
+  --image reference.jpg \
+  --output portrait.png \
+  --model gpt-5.4 \
+  --effort low
+```
+
+`codex_image_edit.py` encodes the local reference image as a base64 data URL and sends it as multimodal input (`input_text` + `input_image`) to the same Codex responses endpoint, then asks the `image_generation` tool to create a new image from the reference.
+
 ### Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `prompt` | (required) | Image description |
-| `--output` | `codex_image.png` | Output file path |
+| `prompt` | (required) | Image description or edit instruction |
+| `--image` | (edit only, required) | Local reference image path for image-to-image generation |
+| `--output` | `codex_image.png` / `codex_image_edit.png` | Output file path |
 | `--model` | `gpt-5.4` | Codex model |
 | `--effort` | `low` | Reasoning effort: low/medium/high |
-| `--token` | - | Access token directly (skips auto auth) |
-| `--token-file` | - | File containing token (skips auto auth) |
+| `--token` | - | Access token directly (skips auto auth; text-to-image script only) |
+| `--token-file` | - | File containing token (skips auto auth; text-to-image script only) |
 
 ### Output
 

--- a/codex-image/scripts/codex_image_edit.py
+++ b/codex-image/scripts/codex_image_edit.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Experimental image-to-image generation via ChatGPT Codex responses image_generation tool."""
+import argparse, base64, http.client, json, mimetypes, os, re, ssl, subprocess, sys, time
+
+AUTH_CACHE = os.path.expanduser('~/.chatgpt_auth.json')
+SCRIPT_DIR = os.path.dirname(__file__)
+
+
+def get_token():
+    if os.path.exists(AUTH_CACHE):
+        try:
+            with open(AUTH_CACHE) as f:
+                c = json.load(f)
+            if time.time() - c.get('_cached_at', 0) <= 8 * 3600 and c.get('accessToken'):
+                print('[auth] Using cached token.', file=sys.stderr)
+                return c['accessToken']
+        except Exception:
+            pass
+    r = subprocess.run([sys.executable, os.path.join(SCRIPT_DIR, 'get_auth.py')], capture_output=True, text=True, timeout=360)
+    if r.stderr:
+        print(r.stderr, end='', file=sys.stderr)
+    if r.returncode != 0:
+        raise SystemExit(r.stdout + r.stderr)
+    with open(AUTH_CACHE) as f:
+        return json.load(f)['accessToken']
+
+
+def data_url(path):
+    mt = mimetypes.guess_type(path)[0] or 'image/png'
+    with open(path, 'rb') as f:
+        b64 = base64.b64encode(f.read()).decode('ascii')
+    return 'data:%s;base64,%s' % (mt, b64)
+
+
+def call_api(token, prompt, image_path, output, model, effort, schema):
+    img = data_url(image_path)
+    if schema == 'responses_multimodal':
+        content = [
+            {'type': 'input_text', 'text': 'Use the image generation tool to create a new image based on the reference image. Preserve the main person identity/style when relevant. Request: ' + prompt},
+            {'type': 'input_image', 'image_url': img}
+        ]
+        input_obj = [{'role': 'user', 'content': content}]
+    elif schema == 'chatgpt_multimodal':
+        content = [
+            {'type': 'text', 'text': 'Use the image generation tool to create a new image based on the reference image. Preserve the main person identity/style when relevant. Request: ' + prompt},
+            {'type': 'image_url', 'image_url': {'url': img}}
+        ]
+        input_obj = [{'role': 'user', 'content': content}]
+    else:
+        raise ValueError(schema)
+
+    payload = json.dumps({
+        'model': model,
+        'instructions': 'You are a helpful assistant. Use tools when available.',
+        'input': input_obj,
+        'store': False,
+        'tools': [{'type': 'image_generation'}],
+        'reasoning': {'effort': effort},
+        'include': [],
+        'tool_choice': 'auto',
+        'parallel_tool_calls': True,
+        'stream': True
+    })
+    conn = http.client.HTTPSConnection('chatgpt.com', context=ssl.create_default_context(), timeout=240)
+    conn.request('POST', '/backend-api/codex/responses', body=payload, headers={
+        'Authorization': 'Bearer ' + token,
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream'
+    })
+    resp = conn.getresponse()
+    raw = resp.read().decode('utf-8', errors='replace')
+    status = resp.status
+    conn.close()
+    if status != 200:
+        return {'success': False, 'error': 'HTTP %s: %s' % (status, raw[:1000])}
+    matches = re.findall(r'(iVBOR[A-Za-z0-9+/=]{1000,})', raw)
+    if not matches:
+        return {'success': False, 'error': 'No image data in response', 'raw_excerpt': raw[:1500]}
+    img_bytes = base64.b64decode(matches[0])
+    with open(output, 'wb') as f:
+        f.write(img_bytes)
+    revised = ''
+    m = re.search(r'"revised_prompt"\s*:\s*"([^"]*)"', raw)
+    if m:
+        revised = m.group(1)
+    return {'success': True, 'path': output, 'size': len(img_bytes), 'revised_prompt': revised, 'schema': schema}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('prompt')
+    ap.add_argument('--image', required=True)
+    ap.add_argument('-o', '--output', default='codex_image_edit.png')
+    ap.add_argument('--model', default='gpt-5.4')
+    ap.add_argument('--effort', default='low', choices=['low','medium','high'])
+    ap.add_argument('--schema', default='responses_multimodal', choices=['responses_multimodal','chatgpt_multimodal'])
+    args = ap.parse_args()
+    token = get_token()
+    print('Generating image from reference...', flush=True)
+    res = call_api(token, args.prompt, args.image, args.output, args.model, args.effort, args.schema)
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+    if not res.get('success'):
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds experimental image-to-image support to the `codex-image` skill.

## Changes

- Add `scripts/codex_image_edit.py`
- Support `--image` reference input
- Encode local reference images as base64 data URLs
- Send multimodal input with `input_text` + `input_image` to the Codex responses endpoint
- Reuse the existing ChatGPT auth cache / auto-login flow
- Save generated PNG output to `--output`
- Document text-to-image and image-to-image usage in `SKILL.md`

## Test

Tested on Minis iOS / iSH:

```bash
python3 scripts/codex_image_edit.py \
  "Create a cinematic portrait of this same woman as an iOS AI assistant..." \
  --image /var/minis/shared/3hao-ref-1.jpg \
  --output /var/minis/attachments/sanhao_img2img_test.png \
  --model gpt-5.4 \
  --effort low
```

Result:

```json
{
  "success": true,
  "path": "/var/minis/attachments/sanhao_img2img_test.png",
  "size": 2067149,
  "schema": "responses_multimodal"
}
```

## Notes

This uses the same unofficial ChatGPT backend endpoint as the existing `codex-image` script. Availability may change.
