### PR TITLE
Fix codex-image auth login stdout passthrough

### DIFF
--- a/codex-image/scripts/codex_image.py
+++ b/codex-image/scripts/codex_image.py
@@ -23,17 +23,18 @@ def get_token_auto(no_login=False) -> str:
     cmd = [sys.executable, script]
     if no_login:
         cmd.append("--no-login")
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=360)
-    # Print auth progress to stderr (contains no token values)
+    # T172: do NOT capture stdout. get_auth.py emits OSC 1337 markers (via
+    # `minis-open <login_url>`) that the host ChatViewModel must see in order
+    # to pop the WebView login sheet. capture_output=True swallows those
+    # markers so the user never sees the login page and the script polls
+    # uselessly for 5 minutes. Pass stdout through; success signal comes
+    # from process exit code + presence of the auth cache file.
+    result = subprocess.run(cmd, stderr=subprocess.PIPE, text=True, timeout=360)
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
-    stdout = result.stdout.strip()
-    if not stdout:
-        raise RuntimeError(f"get_auth.py returned no output. stderr: {result.stderr[:300]}")
-    data = json.loads(stdout)
-    if not data.get("success"):
-        raise RuntimeError(data.get("error", "Auth failed"))
-    # Read token from cache file — never from stdout
+    if result.returncode != 0:
+        raise RuntimeError(f"get_auth.py exited rc={result.returncode}. stderr: {result.stderr[:300]}")
+    # Read token from cache file — get_auth.py writes it on success
     try:
         with open(AUTH_CACHE) as f:
             cached = json.load(f)
@@ -41,6 +42,8 @@ def get_token_auto(no_login=False) -> str:
         if not token:
             raise RuntimeError("Cache file exists but accessToken is empty.")
         return token
+    except FileNotFoundError:
+        raise RuntimeError("get_auth.py exited 0 but no cache file was written")
     except Exception as e:
         raise RuntimeError(f"Failed to read token from cache after auth: {e}")
 

--- a/codex-image/scripts/codex_image_edit.py
+++ b/codex-image/scripts/codex_image_edit.py
@@ -16,11 +16,14 @@ def get_token():
                 return c['accessToken']
         except Exception:
             pass
-    r = subprocess.run([sys.executable, os.path.join(SCRIPT_DIR, 'get_auth.py')], capture_output=True, text=True, timeout=360)
+    # T172: stdout pass-through so OSC 1337 markers from minis-open reach
+    # the host ChatViewModel and the login WebView pops up. capture_output
+    # would swallow them and the script would poll fruitlessly for 5 min.
+    r = subprocess.run([sys.executable, os.path.join(SCRIPT_DIR, 'get_auth.py')], stderr=subprocess.PIPE, text=True, timeout=360)
     if r.stderr:
         print(r.stderr, end='', file=sys.stderr)
     if r.returncode != 0:
-        raise SystemExit(r.stdout + r.stderr)
+        raise SystemExit(r.stderr or 'get_auth.py failed')
     with open(AUTH_CACHE) as f:
         return json.load(f)['accessToken']
 


### PR DESCRIPTION
## Summary
- Let get_auth.py stdout pass through in codex-image scripts so Minis host can receive minis-open / OSC 1337 login markers
- Stop parsing auth success from captured stdout; validate by subprocess exit code and auth cache contents
- Apply the same fix to image edit auth flow

## Why
The previous fix was merged into feat/codex-image-start-auth after that branch had already been merged to main, so main still contains the old capture_output=True behavior. This PR targets main directly.

When stdout is captured, the ChatGPT login WebView trigger emitted by minis-open is swallowed by the parent process. The user never sees the login page and the script can poll until timeout. Passing stdout through allows the host to open the login flow, after which the token cache is read normally.

## Tested
- Ran codex_image.py locally from the installed skill
- ChatGPT login opened successfully
- Generated an image successfully