### PR TITLE
feat: doubao-tts support API Key auth and usage reporting

### DIFF
--- a/doubao-tts/SKILL.md
+++ b/doubao-tts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doubao-tts
-version: 2.0.0
+version: 2.1.0
 description: 使用豆包语音合成（Volcengine TTS）将文本转为语音文件。当用户提到"豆包TTS"、"豆包语音合成"、"doubao tts"、"火山引擎TTS"、"volcengine tts"、"语音合成"、"文字转语音"、"TTS"、"生成音频"、"朗读文字"，或任何需要调用豆包/火山引擎语音合成 API 的场景，必须触发本技能。
 ---
 
@@ -8,33 +8,42 @@ description: 使用豆包语音合成（Volcengine TTS）将文本转为语音�
 
 使用火山引擎豆包语音合成 **V3 HTTP SSE 单向流式接口**将文本转为音频文件。
 
-## 获取 AppID 和 Token
+## 获取 API Key（推荐，新版控制台）
 
 1. 登录 [火山引擎控制台](https://console.volcengine.com/speech/app)
 2. 进入 **豆包语音 → 语音合成大模型 → 应用管理**
-3. 创建应用（或使用已有应用），点击应用名称进入详情
-4. 在应用详情页底部可看到：
-   - **APP ID** → 对应 `DOUBAO_TTS_APPID`
-   - **Access Token** → 对应 `DOUBAO_TTS_TOKEN`
+3. 创建应用（或使用已有应用）
+4. 在 [API Key 管理](https://console.volcengine.com/speech/new/setting/apikeys?projectName=default) 页面获取 API Key → 对应 `DOUBAO_TTS_API_KEY`
 
-> 若尚未开通服务，需先在 [语音合成大模型](https://console.volcengine.com/speech/service/10) 页面开通后才能创建应用。
+> 若尚未开通服务，需先在 [语音合成大模型](https://console.volcengine.com/speech/service/10) 页面开通。
+
+### 旧版控制台（AppID + Token）
+
+旧版控制台应用详情页底部可获取：
+- **APP ID** → `DOUBAO_TTS_APPID`
+- **Access Token** → `DOUBAO_TTS_TOKEN`
 
 ## 环境变量
 
-| 变量名 | 说明 |
-|---|---|
-| `DOUBAO_TTS_APPID` | 控制台申请的 AppID（即 `X-Api-App-Id`） |
-| `DOUBAO_TTS_TOKEN` | Access Token（即 `X-Api-Access-Key`） |
-| `DOUBAO_TTS_RESOURCE_ID` | 资源 ID，留空由服务端自动匹配，或指定 `seed-tts-2.0` 等 |
+| 变量名 | 说明 | 推荐 |
+|---|---|---|
+| `DOUBAO_TTS_API_KEY` | API Key（新版控制台，`X-Api-Key`） | ✅ |
+| `DOUBAO_TTS_APPID` | AppID（旧版控制台，`X-Api-App-Id`） | |
+| `DOUBAO_TTS_TOKEN` | Access Token（旧版控制台，`X-Api-Access-Key`） | |
+| `DOUBAO_TTS_RESOURCE_ID` | 资源 ID，留空默认 `seed-tts-2.0` | |
 
 检查是否已配置：
 ```sh
-[ -n "$DOUBAO_TTS_APPID" ] && echo "set" || echo "not set"
-[ -n "$DOUBAO_TTS_TOKEN" ] && echo "set" || echo "not set"
+[ -n "$DOUBAO_TTS_API_KEY" ] && echo "API_KEY: set" || echo "API_KEY: not set"
+[ -n "$DOUBAO_TTS_APPID" ] && echo "APPID: set" || echo "APPID: not set"
+[ -n "$DOUBAO_TTS_TOKEN" ] && echo "TOKEN: set" || echo "TOKEN: not set"
 ```
 
-未配置时告知用户设置：
-[Set DOUBAO_TTS_APPID](minis://settings/environments?create_key=DOUBAO_TTS_APPID&create_value=) | [Set DOUBAO_TTS_TOKEN](minis://settings/environments?create_key=DOUBAO_TTS_TOKEN&create_value=) | [Set DOUBAO_TTS_RESOURCE_ID](minis://settings/environments?create_key=DOUBAO_TTS_RESOURCE_ID&create_value=seed-tts-1.0)
+未配置时告知用户设置（优先使用 API Key）：
+[Set DOUBAO_TTS_API_KEY](minis://settings/environments?create_key=DOUBAO_TTS_API_KEY&create_value=) | [Set DOUBAO_TTS_RESOURCE_ID](minis://settings/environments?create_key=DOUBAO_TTS_RESOURCE_ID&create_value=seed-tts-2.0)
+
+旧版控制台（AppID + Token）：
+[Set DOUBAO_TTS_APPID](minis://settings/environments?create_key=DOUBAO_TTS_APPID&create_value=) | [Set DOUBAO_TTS_TOKEN](minis://settings/environments?create_key=DOUBAO_TTS_TOKEN&create_value=)
 
 ## 使用方式
 
@@ -66,8 +75,11 @@ uv run --script --cache-dir /root/.cache/uv \
 ## API 说明
 
 - **接口**：`https://openspeech.bytedance.com/api/v3/tts/unidirectional/sse`（SSE 流式）
-- **鉴权**：Header `X-Api-App-Id` + `X-Api-Access-Key`（即 AppID + Token，**非** API Key）
+- **鉴权**（二选一）：
+  - 新版控制台：Header `X-Api-Key`（API Key）
+  - 旧版控制台：Header `X-Api-App-Id` + `X-Api-Access-Key`（AppID + Token）
 - **Resource ID**：指定调用的模型版本（见下表）
+- **用量返回**：脚本默认携带 `X-Control-Require-Usage-Tokens-Return: text_words`，合成结束时返回计费字符数（`text_words`）
 
 | Resource ID | 说明 |
 |---|---|
@@ -81,7 +93,10 @@ uv run --script --cache-dir /root/.cache/uv \
 |---|---|
 | `--text` | 要合成的文本（必填） |
 | `--output` | 输出文件路径（必填） |
-| `--speaker` | 音色，默认 `BV700_streaming`（灿灿） |
+| `--api-key` | API Key（新版控制台，优先于 APPID/TOKEN） |
+| `--appid` | AppID（旧版控制台） |
+| `--token` | Access Token（旧版控制台） |
+| `--speaker` | 音色，默认 `zh_female_shuangkuaisisi_uranus_bigtts`（爽快思思 2.0） |
 | `--encoding` | 格式：`mp3`/`pcm`/`ogg_opus`，默认 `mp3` |
 | `--speech-rate` | 语速 [-50, 100]，0 为默认，100 为 2 倍速 |
 | `--loudness` | 音量 [-50, 100]，0 为默认 |
@@ -100,13 +115,13 @@ uv run --script --cache-dir /root/.cache/uv \
 | `zh_female_shuangkuaisisi_uranus_bigtts` | 爽快思思 2.0 ⭐默认 | 通用 |
 | `zh_female_cancan_uranus_bigtts` | 知性灿灿 2.0 | 角色扮演 |
 | `zh_female_tianmeixiaoyuan_uranus_bigtts` | 甜美小源 2.0 | 通用 |
-| `zh_female_vv_uranus_bigtts` | Vivi 2.0 | 通用，支持中/日/印尼/西语 |
+| `zh_female_vv_uranus_bigtts` | Vivi 2.0 | 通用，中/日/印尼/墨西哥西语，方言川陕东北 |
 | `zh_female_xiaohe_uranus_bigtts` | 小何 2.0 | 通用 |
 | `zh_male_m191_uranus_bigtts` | 云舟 2.0 | 通用 |
 | `zh_male_taocheng_uranus_bigtts` | 小天 2.0 | 通用 |
 | `zh_female_kefunvsheng_uranus_bigtts` | 暖阳女声 2.0 | 客服 |
-| `en_female_dacey_uranus_bigtts` | Dacey | 美式英语 |
-| `en_male_tim_uranus_bigtts` | Tim | 美式英语 |
+| `en_female_dacey_uranus_bigtts` | Dacey | 多语种（英） |
+| `en_male_tim_uranus_bigtts` | Tim | 多语种（英） |
 
 ### 豆包语音合成模型 1.0（`seed-tts-1.0`，需改 `--resource-id`）
 
@@ -126,6 +141,6 @@ uv run --script --cache-dir /root/.cache/uv \
 
 ## 完整工作流
 
-1. 检查环境变量是否配置（APPID + TOKEN）
+1. 检查环境变量是否配置（优先 `DOUBAO_TTS_API_KEY`，其次 `DOUBAO_TTS_APPID` + `DOUBAO_TTS_TOKEN`）
 2. 调用 `tts.py` 脚本生成音频文件到 `/var/minis/workspace/`
 3. 以 `minis://workspace/xxx.mp3` 链接形式返回给用户，可直接点击播放

--- a/doubao-tts/scripts/tts.py
+++ b/doubao-tts/scripts/tts.py
@@ -7,7 +7,7 @@
 Doubao TTS - 豆包语音合成脚本（V3 HTTP SSE 单向流式接口）
 文档：https://www.volcengine.com/docs/6561/1598757
 接口：https://openspeech.bytedance.com/api/v3/tts/unidirectional/sse
-鉴权：X-Api-App-Id + X-Api-Access-Key Header（即 AppID + Token）
+鉴权：新版控制台使用 X-Api-Key（API Key）；旧版控制台使用 X-Api-App-Id + X-Api-Access-Key
 """
 
 import argparse
@@ -22,11 +22,28 @@ import urllib.error
 API_URL = "https://openspeech.bytedance.com/api/v3/tts/unidirectional/sse"
 
 
+def resolve_auth(api_key: str, appid: str, token: str) -> tuple[dict, str]:
+    """解析鉴权凭证：返回 (鉴权 headers, 模式描述)。凭证缺失则报错退出。
+
+    优先级：API Key（新版控制台）> AppID + Token（旧版控制台）。
+    """
+    if api_key:
+        return {"X-Api-Key": api_key}, "API Key (新版控制台)"
+    if appid and token:
+        return (
+            {"X-Api-App-Id": appid, "X-Api-Access-Key": token},
+            "AppID + Token (旧版控制台)",
+        )
+    print("[ERROR] 未设置凭证。请通过以下任一方式提供：", file=sys.stderr)
+    print("  - --api-key 参数 或 DOUBAO_TTS_API_KEY 环境变量（推荐，新版控制台）", file=sys.stderr)
+    print("  - --appid + --token 参数 或 DOUBAO_TTS_APPID + DOUBAO_TTS_TOKEN（旧版控制台）", file=sys.stderr)
+    sys.exit(1)
+
+
 def synthesize(
     text: str,
     output_path: str,
-    appid: str,
-    token: str,
+    auth_headers: dict,
     resource_id: str = "seed-tts-2.0",
     speaker: str = "zh_female_shuangkuaisisi_uranus_bigtts",
     fmt: str = "mp3",
@@ -62,11 +79,13 @@ def synthesize(
     }
 
     headers = {
-        "X-Api-App-Id": appid,
-        "X-Api-Access-Key": token,
         "X-Api-Resource-Id": resource_id or "seed-tts-2.0",
         "X-Api-Request-Id": req_id,
+        # 请求服务端在结束帧返回用量数据（计费字符数 text_words），否则默认不返回
+        "X-Control-Require-Usage-Tokens-Return": "text_words",
         "Content-Type": "application/json",
+        # 鉴权 header：X-Api-Key 或 X-Api-App-Id + X-Api-Access-Key，由 resolve_auth 决定
+        **auth_headers,
     }
 
     data = json.dumps(payload).encode("utf-8")
@@ -145,6 +164,11 @@ def _handle_error(code: int, msg: str):
         print("[HINT] 音色未授权，请在控制台购买或使用免费音色。", file=sys.stderr)
     elif "exceed max limit" in msg:
         print("[HINT] 文本长度超限，请缩短文本。", file=sys.stderr)
+    elif code == 55000000:
+        # 服务端通用错误：高频原因是音色与 Resource ID 代次不匹配
+        # （2.0 音色须配 seed-tts-2.0，1.0 音色须配 seed-tts-1.0），也可能是服务端临时异常
+        print("[HINT] 服务端错误。请检查音色与 Resource ID 是否匹配"
+              "（2.0 音色配 seed-tts-2.0，1.0 音色配 seed-tts-1.0），或稍后重试。", file=sys.stderr)
     sys.exit(1)
 
 
@@ -153,14 +177,17 @@ def main():
         description="豆包语音合成 CLI（火山引擎 V3 HTTP SSE 单向流式接口）",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-示例：
+示例（新版控制台，使用 API Key）：
   uv run --script --cache-dir /root/.cache/uv tts.py --text "你好世界" --output /tmp/hello.mp3
   uv run --script --cache-dir /root/.cache/uv tts.py --text "今天天气真好" --speaker zh_female_cancan_uranus_bigtts --output /tmp/out.mp3
-  uv run --script --cache-dir /root/.cache/uv tts.py --text "Hello!" --speaker en_female_dacey_uranus_bigtts --output /tmp/en.mp3
+
+示例（旧版控制台，使用 AppID + Token）：
+  uv run --script --cache-dir /root/.cache/uv tts.py --text "你好世界" --appid 123 --token xxx --output /tmp/hello.mp3
 
 环境变量（优先级低于命令行参数）：
-  DOUBAO_TTS_APPID       AppID（X-Api-App-Id）
-  DOUBAO_TTS_TOKEN       Access Token（X-Api-Access-Key）
+  DOUBAO_TTS_API_KEY     API Key（新版控制台，推荐）
+  DOUBAO_TTS_APPID       AppID（旧版控制台，X-Api-App-Id）
+  DOUBAO_TTS_TOKEN       Access Token（旧版控制台，X-Api-Access-Key）
   DOUBAO_TTS_RESOURCE_ID Resource ID（留空默认用 seed-tts-2.0）
 
 Resource ID 说明：
@@ -174,10 +201,12 @@ Resource ID 说明：
     )
     parser.add_argument("--text", required=True, help="要合成的文本")
     parser.add_argument("--output", required=True, help="输出音频文件路径（如 /tmp/out.mp3）")
-    parser.add_argument("--appid", default=None, help="AppID（优先于环境变量）")
-    parser.add_argument("--token", default=None, help="Access Token（优先于环境变量）")
+    parser.add_argument("--api-key", default=None,
+                        help="API Key（新版控制台，优先于 APPID/TOKEN）")
+    parser.add_argument("--appid", default=None, help="AppID（旧版控制台，优先于环境变量）")
+    parser.add_argument("--token", default=None, help="Access Token（旧版控制台，优先于环境变量）")
     parser.add_argument("--resource-id", default=None,
-                        help="Resource ID（默认 seed-tts-1.0）")
+                        help="Resource ID（默认 seed-tts-2.0）")
     parser.add_argument("--speaker", default="zh_female_shuangkuaisisi_uranus_bigtts",
                         help="音色 speaker（默认 zh_female_shuangkuaisisi_uranus_bigtts 爽快思思 2.0）")
     parser.add_argument("--encoding", default="mp3",
@@ -201,24 +230,19 @@ Resource ID 说明：
     args = parser.parse_args()
 
     # 读取凭证（命令行 > 环境变量）
+    api_key = args.api_key or os.environ.get("DOUBAO_TTS_API_KEY", "")
     appid = args.appid or os.environ.get("DOUBAO_TTS_APPID", "")
     token = args.token or os.environ.get("DOUBAO_TTS_TOKEN", "")
     resource_id = args.resource_id or os.environ.get("DOUBAO_TTS_RESOURCE_ID", "")
 
-    if not appid:
-        print("[ERROR] 未设置 AppID。请通过 --appid 参数或 DOUBAO_TTS_APPID 环境变量提供。", file=sys.stderr)
-        sys.exit(1)
-    if not token:
-        print("[ERROR] 未设置 Token。请通过 --token 参数或 DOUBAO_TTS_TOKEN 环境变量提供。", file=sys.stderr)
-        sys.exit(1)
+    auth_headers, auth_mode = resolve_auth(api_key, appid, token)
 
-    print(f"[INFO] 合成中... speaker={args.speaker} format={args.encoding} speech_rate={args.speech_rate}", file=sys.stderr)
+    print(f"[INFO] 合成中... speaker={args.speaker} format={args.encoding} speech_rate={args.speech_rate} auth={auth_mode}", file=sys.stderr)
 
     result = synthesize(
         text=args.text,
         output_path=args.output,
-        appid=appid,
-        token=token,
+        auth_headers=auth_headers,
         resource_id=resource_id,
         speaker=args.speaker,
         fmt=args.encoding,


### PR DESCRIPTION
## doubao-tts Skill 更新

为豆包 TTS skill 新增**新版控制台 API Key 鉴权**，并完善用量返回与错误提示。向后兼容，旧版 AppID + Token 仍可用。

### 主要变更

- 🔑 **新增 API Key 鉴权**：支持新版控制台 `X-Api-Key`，优先级高于旧版；旧版 `X-Api-App-Id` + `X-Api-Access-Key` 继续兼容
- 📊 **返回计费字符数**：携带 `X-Control-Require-Usage-Tokens-Return: text_words`，合成结束输出实际计费字符数
- 💡 **新增错误码 55000000 提示**：高频原因是音色与 Resource ID 代次不匹配（2.0 音色配 `seed-tts-2.0`，1.0 配 `seed-tts-1.0`）
- ♻️ **重构**：抽出 `resolve_auth` 统一鉴权优先级判断，`synthesize` 改收 `auth_headers`
- 📝 **文档**：修正默认 `resource_id`，补充环境变量检查与旧版凭证快捷设置链接，version 2.0.0 → 2.1.0

### 环境变量

| 变量 | 说明 | 推荐 |
|---|---|---|
| `DOUBAO_TTS_API_KEY` | API Key（新版控制台，`X-Api-Key`） | ✅ |
| `DOUBAO_TTS_APPID` | AppID（旧版控制台，`X-Api-App-Id`） | |
| `DOUBAO_TTS_TOKEN` | Access Token（旧版控制台，`X-Api-Access-Key`） | |
| `DOUBAO_TTS_RESOURCE_ID` | 资源 ID，留空默认 `seed-tts-2.0` | |

### 快速使用

```sh
uv run --script --cache-dir /root/.cache/uv \
  /var/minis/skills/doubao-tts/scripts/tts.py \
  --text "你好，欢迎使用豆包语音合成" \
  --output /var/minis/workspace/output.mp3
```
