### PR TITLE
feat: add health-sleep-analysis skill

### DIFF
--- a/health-sleep-analysis/SKILL.md
+++ b/health-sleep-analysis/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: health-sleep-analysis
+description: Analyze sleep health data from Apple HealthKit, including sleep stages (Deep/REM/Core/Awake), blood oxygen saturation (SpO2) during sleep, sleep duration trends, bedtime patterns, resting heart rate, and HRV. Use this skill whenever the user asks about sleep quality, sleep analysis, blood oxygen during sleep, sleep stages breakdown, sleep trends over time, heart rate, HRV, or any health data analysis involving sleep or cardiac health. Triggers on: "sleep analysis", "blood oxygen", "sleep quality", "deep sleep", "REM sleep", "resting heart rate", "HRV", "心脏健康", "睡眠分析", "睡眠质量", "血氧", "深睡眠", "静息心率", "心率变异" and similar in any language.
+---
+
+# Sleep Health Analysis Skill
+
+Fetch sleep, SpO2, heart rate, and HRV data from Apple HealthKit, analyze it, and produce visual reports.
+
+## Language Rules (IMPORTANT)
+
+> **Detect the language of the user's message and apply it consistently throughout the entire response:**
+>
+> - **Written analysis, conclusions, health advice** → user's language
+> - **Chart/image text labels, titles, axes, legend, insight cards, footer** → user's language
+> - **Code, script internals, variable names** → English (always)
+> - **When rendering SVG charts**: pass a `--lang` argument to the rendering scripts; the scripts will localize all on-chart text automatically
+>
+> Supported `--lang` values: `zh` (Chinese, default), `en` (English), `ja` (Japanese)  
+> If the user writes in another language, fall back to `en` for chart text and reply in their language.
+
+---
+
+## Pre-built Scripts (call directly, no rewriting needed)
+
+| Script | Purpose |
+|---|---|
+| `sleep_report_data.py` | Extract 7-day report JSON from raw HealthKit data |
+| `sleep_report_librsvg.py` | Render 7-day weekly report card → SVG + PNG via `rsvg-convert` |
+| `sleep_month_trend_librsvg.py` | Render 30-day monthly trend → SVG + PNG via `rsvg-convert` |
+| `sleep_halfyear.py` | Long-term trend (30+ days), matplotlib charts |
+| `cardiac_analysis.py` | Cardiac health: RHR, HRV, SpO2, max HR |
+
+---
+
+## Quick Start
+
+### Step 1 — Install dependencies
+
+```bash
+apk add rsvg-convert font-noto-cjk -q
+python3 -c "import matplotlib, numpy" 2>/dev/null || apk add py3-matplotlib py3-numpy -q
+```
+
+### Step 2 — Fetch data (write to /tmp to avoid workspace sync delay)
+
+```bash
+# 7-day weekly report
+apple-healthkit sleep --days 8 --compact -q > /tmp/sleep_raw.json
+apple-healthkit blood-oxygen --days 8 --limit 2000 --compact -q > /tmp/spo2_raw.json
+
+# 30-day monthly trend
+apple-healthkit sleep --days 31 --compact -q > /tmp/sleep_raw.json
+apple-healthkit blood-oxygen --days 31 --limit 5000 --compact -q > /tmp/spo2_raw.json
+```
+
+**Important:** Always write raw data to `/tmp/` first (not `/var/minis/workspace/`). The workspace directory has an iSH ↔ iOS sync delay that causes stale reads. Copy to workspace only after scripts finish.
+
+### Step 3 — Run the appropriate script
+
+```bash
+# ── 7-day weekly report card ──────────────────────────────────
+python3 /var/minis/skills/health-sleep-analysis/sleep_report_data.py \
+    --sleep /tmp/sleep_raw.json --spo2 /tmp/spo2_raw.json \
+    --out /tmp/sleep_report_7d.json
+
+python3 /var/minis/skills/health-sleep-analysis/sleep_report_librsvg.py \
+    --data /tmp/sleep_report_7d.json \
+    --out-prefix /tmp/sleep_report_7d \
+    --lang zh                          # zh | en | ja
+
+# ── 30-day monthly trend ──────────────────────────────────────
+python3 /var/minis/skills/health-sleep-analysis/sleep_month_trend_librsvg.py \
+    --days 30 \
+    --sleep /tmp/sleep_raw.json --spo2 /tmp/spo2_raw.json \
+    --out-prefix /tmp/sleep_month_trend \
+    --lang zh                          # zh | en | ja
+
+# ── Half-year trend (26 weeks, weekly aggregation) ────────────
+apple-healthkit sleep --days 186 --compact -q > /tmp/sleep_raw.json
+apple-healthkit blood-oxygen --days 186 --limit 10000 --compact -q > /tmp/spo2_raw.json
+python3 /var/minis/skills/health-sleep-analysis/sleep_longterm_librsvg.py \
+    --period halfyear \
+    --sleep /tmp/sleep_raw.json --spo2 /tmp/spo2_raw.json \
+    --out-prefix /tmp/sleep_halfyear \
+    --lang zh                          # zh | en | ja
+
+# ── Full-year trend (12 months, monthly aggregation) ──────────
+apple-healthkit sleep --days 366 --compact -q > /tmp/sleep_raw.json
+apple-healthkit blood-oxygen --days 366 --limit 10000 --compact -q > /tmp/spo2_raw.json
+python3 /var/minis/skills/health-sleep-analysis/sleep_longterm_librsvg.py \
+    --period year \
+    --sleep /tmp/sleep_raw.json --spo2 /tmp/spo2_raw.json \
+    --out-prefix /tmp/sleep_year \
+    --lang zh
+
+# ── Long-term trend (matplotlib, 30+ days) ───────────────────
+DAYS=185
+cd /var/minis/workspace
+apple-healthkit sleep --days $((DAYS+1)) --compact -q > sleep_raw.json
+apple-healthkit blood-oxygen --days $((DAYS+1)) --limit 10000 --compact -q > spo2_raw.json
+python3 /var/minis/skills/health-sleep-analysis/sleep_halfyear.py
+# 输出: sleep_halfyear.png（当前目录）
+
+# ── Cardiac health ────────────────────────────────────────────
+apple-healthkit heart-rate --days 30 --limit 5000 --compact -q > /tmp/hr_raw.json
+apple-healthkit hrv --days 30 --limit 500 --compact -q > /tmp/hrv_raw.json
+python3 /var/minis/skills/health-sleep-analysis/cardiac_analysis.py
+```
+
+### Step 4 — Copy output and display
+
+```bash
+cp /tmp/sleep_report_7d.png /var/minis/workspace/sleep_report_7d.png
+cp /tmp/sleep_month_trend.png /var/minis/workspace/sleep_month_trend.png
+```
+
+Display in chat with Markdown inline images. Follow up with a written analysis in the user's language.
+
+---
+
+## Localization Reference
+
+When rendering SVG charts, scripts accept `--lang <code>`. The following strings must be translated per language:
+
+| Key | zh | en | ja |
+|---|---|---|---|
+| report_title_7d | 最近一周睡眠周报 | Weekly Sleep Report | 週間睡眠レポート |
+| report_title_30d | 最近一个月睡眠趋势 | Monthly Sleep Trend | 月間睡眠トレンド |
+| subtitle_suffix | 夜有效记录 | nights recorded | 夜の有効記録 |
+| avg_sleep | 平均睡眠 | Avg Sleep | 平均睡眠 |
+| good_days | 达标天数 | Goal Days | 達成日数 |
+| deep_avg | 深睡均值 | Avg Deep | 深睡眠平均 |
+| min_spo2 | 最低血氧 | Min SpO2 | 最低血中酸素 |
+| stage_trend | 睡眠阶段趋势 | Sleep Stage Trend | 睡眠ステージ推移 |
+| key_insights | 关键洞察 | Key Insights | 重要インサイト |
+| daily_detail | 每日明细 | Daily Detail | 日別明細 |
+| deep | 深睡 | Deep | 深睡眠 |
+| core | 浅睡 | Core | コア |
+| awake | 清醒 | Awake | 覚醒 |
+| bedtime | 入睡 | Bedtime | 就寝 |
+| min_o2 | 最低氧 | Min O₂ | 最低酸素 |
+| spo2_trend_title | 睡眠期最低血氧 | Nightly Min SpO2 | 夜間最低血中酸素 |
+| weekly_summary | 周汇总 | Weekly Summary | 週間サマリー |
+| monthly_conclusion | 月度结论 | Monthly Summary | 月間まとめ |
+| insight_duration | 主问题：睡眠时长不足 | Issue: Sleep Too Short | 問題：睡眠時間不足 |
+| insight_bedtime | 作息偏晚 | Late Bedtime | 就寝時刻が遅い |
+| insight_spo2 | 血氧均值正常，低点需观察 | SpO2 avg OK, low dips noted | 血中酸素平均は正常、低下に注意 |
+| recommend_7h | 推荐 7h | Goal 7h | 目標 7h |
+| data_source | 数据来源：Apple HealthKit · 仅供健康趋势参考 | Source: Apple HealthKit · For reference only | データ：Apple HealthKit · 参考用のみ |
+| generated | 生成时间 | Generated | 生成日時 |
+| sleep_intelligence | Sleep Intelligence | Sleep Intelligence | Sleep Intelligence |
+
+---
+
+## Script Argument Reference
+
+### sleep_report_data.py
+
+```
+--sleep   path to sleep_raw.json   (default: /var/minis/workspace/sleep_raw.json)
+--spo2    path to spo2_raw.json    (default: /var/minis/workspace/spo2_raw.json)
+--out     output JSON path         (default: /var/minis/workspace/sleep_report_7d.json)
+```
+
+### sleep_report_librsvg.py
+
+```
+--data        input JSON from sleep_report_data.py
+--out-prefix  SVG/PNG output prefix   (default: /var/minis/workspace/sleep_report_7d_librsvg)
+--lang        zh | en | ja            (default: zh)
+--width       canvas width px         (default: 1280)
+--height      canvas height px        (default: 1760)
+```
+
+### sleep_month_trend_librsvg.py
+
+```
+--days        number of nights to include  (default: 30)
+--sleep       path to sleep_raw.json
+--spo2        path to spo2_raw.json
+--out-prefix  SVG/PNG output prefix        (default: /var/minis/workspace/sleep_month_trend)
+--lang        zh | en | ja                 (default: zh)
+```
+
+---
+
+## Data Processing
+
+### Night attribution rule
+
+Records between 00:00–13:59 belong to the **previous calendar day** (same sleep session):
+
+```python
+def sleep_date(dt):
+    return (dt - timedelta(days=1)).date() if dt.hour < 14 else dt.date()
+```
+
+### Sleep stage mapping
+
+| HealthKit value | Stage |
+|---|---|
+| `asleepDeep` | Deep |
+| `asleepREM` | REM |
+| `asleepCore` | Core (light) |
+| `awake` | Awake |
+| `inBed` | In-bed (excluded) |
+
+### HealthKit JSON field names
+
+Raw samples use `start` / `end` (not `startDate` / `endDate`). Always check both:
+
+```python
+ss = s.get('startDate') or s.get('start')
+ee = s.get('endDate')   or s.get('end')
+```
+
+### Workspace sync delay
+
+Writing large files directly to `/var/minis/workspace/` can result in iSH reading a stale cached version. Always:
+1. Write data and outputs to `/tmp/`
+2. Run scripts with `/tmp/` paths
+3. `cp` final PNGs to `/var/minis/workspace/` for display
+
+---
+
+## Health Standards
+
+### Sleep duration
+| Range | Rating |
+|---|---|
+| ≥ 7h | ✅ Sufficient |
+| 6–7h | ⚠️ Slightly short |
+| < 6h | ❌ Insufficient (adults need 7–9h) |
+
+### Sleep stages
+| Stage | Healthy % | Function |
+|---|---|---|
+| Deep | ≥ 13% | Physical recovery, immunity, memory |
+| REM | 20–25% | Emotion regulation, cognition |
+| Core | 45–55% | Transitional |
+
+### SpO2
+| Range | Rating |
+|---|---|
+| ≥ 95% | ✅ Normal |
+| 90–94% | ⚠️ Low, monitor |
+| < 90% | ❌ Dangerous, seek medical advice |
+
+> Frequent drops below 95% (>20% of readings) or any reading below 90% warrants evaluation for **obstructive sleep apnea (OSA)**, especially with snoring, daytime sleepiness, or morning headaches.
+
+### Resting Heart Rate (RHR)
+| Range | Rating |
+|---|---|
+| < 40 bpm | ❌ Too low, consult doctor |
+| 40–60 bpm | ✅ Excellent (athlete level) |
+| 60–80 bpm | ✅ Normal |
+| 80–100 bpm | ⚠️ Elevated |
+| > 100 bpm | ❌ Tachycardia, consult doctor |
+
+Estimate RHR from raw heart rate data (lowest 25% of daily readings):
+
+```python
+vals = sorted(by_day[date])
+rhr = mean(vals[:max(1, len(vals)//4)])
+```
+
+### HRV (SDNN)
+| Range | Rating |
+|---|---|
+| ≥ 50 ms | ✅ Good |
+| 30–50 ms | ⚠️ Fair |
+| < 30 ms | ❌ Low autonomic function |
+
+---
+
+## Common Issues
+
+**Q: Only a few SpO2 readings?**  
+A: Add `--limit`, use 2000 for short-term, 10000 for long-term.
+
+**Q: Chinese/Japanese characters show as boxes?**  
+A: Run `apk add font-noto-cjk` first.
+
+**Q: Missing data for some nights?**  
+A: Apple Watch likely not worn; nights with < 1h total are auto-filtered.
+
+**Q: Chart still shows stale data after re-running?**  
+A: Write outputs to `/tmp/` and use `--sleep /tmp/... --spo2 /tmp/...` arguments. Copy PNG to workspace only for display.
+
+**Q: 30-day chart shows only 6–7 bars?**  
+A: The workspace JSON is stale. Fetch fresh data to `/tmp/` and pass `/tmp/` paths explicitly to the script.

--- a/health-sleep-analysis/sleep_halfyear.py
+++ b/health-sleep-analysis/sleep_halfyear.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""
+sleep_halfyear.py — 半年 / 长期睡眠趋势可视化
+用法: cd /path/to/workdir && python3 sleep_halfyear.py
+输入: sleep_raw.json, spo2_raw.json（当前目录）
+输出: sleep_halfyear.png（当前目录）
+"""
+
+import json
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+import matplotlib.dates as mdates
+from matplotlib.patches import FancyBboxPatch
+from matplotlib.gridspec import GridSpec
+from datetime import datetime, timedelta, date
+from collections import defaultdict
+import os, sys
+
+# ── 字体 ──────────────────────────────────────────────────────
+def setup_font():
+    cjk_paths = [
+        '/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc',
+        '/usr/share/fonts/noto-cjk/NotoSansCJKsc-Regular.otf',
+        '/usr/share/fonts/noto/NotoSansCJK-Regular.ttc',
+    ]
+    for p in cjk_paths:
+        if os.path.exists(p):
+            fm.fontManager.addfont(p)
+            prop = fm.FontProperties(fname=p)
+            plt.rcParams['font.family'] = prop.get_name()
+            return
+    plt.rcParams['font.family'] = 'sans-serif'
+
+setup_font()
+plt.rcParams.update({'font.size': 10, 'axes.unicode_minus': False})
+
+# ── 常量 ──────────────────────────────────────────────────────
+STAGE_META = {
+    'asleepDeep': {'label': '深睡眠', 'color': '#2D6A9F'},
+    'asleepREM':  {'label': 'REM',    'color': '#6A5ACD'},
+    'asleepCore': {'label': '浅睡眠', 'color': '#5BA4CF'},
+    'awake':      {'label': '清醒',   'color': '#F4A261'},
+}
+STAGE_ORDER = ['asleepDeep', 'asleepREM', 'asleepCore', 'awake']
+
+# ── 日期归属（凌晨0-14点归前一天）─────────────────────────────
+def sleep_date(dt: datetime) -> date:
+    if dt.hour < 14:
+        return (dt - timedelta(days=1)).date()
+    return dt.date()
+
+def parse_dt(s):
+    return datetime.strptime(s[:19], '%Y-%m-%dT%H:%M:%S')
+
+# ── 加载睡眠数据 ───────────────────────────────────────────────
+def load_sleep(path):
+    data = json.load(open(path))
+    samples = data.get('samples', data) if isinstance(data, dict) else data
+    by_day = defaultdict(lambda: defaultdict(float))
+    bed_times = defaultdict(list)
+    wake_times = defaultdict(list)
+    for s in samples:
+        v = s.get('value', '')
+        if v == 'inBed':
+            continue
+        start = parse_dt(s.get('startDate', s.get('start', '')))
+        end   = parse_dt(s.get('endDate', s.get('end', '')))
+        dur   = (end - start).total_seconds() / 3600
+        if dur <= 0:
+            continue
+        day = sleep_date(start)
+        if v in STAGE_META:
+            by_day[day][v] += dur
+        # 入睡/起床时间（只记非awake）
+        if v != 'awake':
+            bed_times[day].append(start)
+            wake_times[day].append(end)
+    return by_day, bed_times, wake_times
+
+# ── 加载血氧数据 ───────────────────────────────────────────────
+def load_spo2(path):
+    data = json.load(open(path))
+    samples = data.get('samples', data) if isinstance(data, dict) else data
+    by_day = defaultdict(list)
+    for s in samples:
+        try:
+            dt = parse_dt(s.get('startDate', s.get('date', '')))
+        except:
+            continue
+        val = s.get('percentage', s.get('value', None))
+        if val is None:
+            continue
+        val = float(val)
+        if val > 1:
+            val = val  # already %
+        else:
+            val = val * 100
+        if val < 70 or val > 100:
+            continue
+        day = sleep_date(dt)
+        by_day[day].append(val)
+    return by_day
+
+# ── 时间轴辅助（以22:00为基准）────────────────────────────────
+BASE_H = 22
+def to_axis(h):
+    return (h - BASE_H) % 24
+def axis_fmt(v, pos=None):
+    h = int((BASE_H + v) % 24)
+    return f'{h:02d}:00'
+
+# ── 7日滚动均值 ────────────────────────────────────────────────
+def rolling_mean(vals, w=7):
+    out = []
+    for i in range(len(vals)):
+        sl = [v for v in vals[max(0, i-w+1):i+1] if v is not None]
+        out.append(np.mean(sl) if sl else None)
+    return out
+
+# ── 月度汇总 ───────────────────────────────────────────────────
+def monthly_summary(days, by_day, spo2_by_day):
+    from collections import OrderedDict
+    months = OrderedDict()
+    for d in days:
+        key = (d.year, d.month)
+        if key not in months:
+            months[key] = {'days': [], 'spo2': []}
+        months[key]['days'].append(d)
+        if d in spo2_by_day and spo2_by_day[d]:
+            months[key]['spo2'].extend(spo2_by_day[d])
+    return months
+
+# ══════════════════════════════════════════════════════════════
+# 主程序
+# ══════════════════════════════════════════════════════════════
+SLEEP_PATH = 'sleep_raw.json'
+SPO2_PATH  = 'spo2_raw.json'
+OUT_PATH   = 'sleep_halfyear.png'
+
+by_day, bed_times, wake_times = load_sleep(SLEEP_PATH)
+spo2_by_day = load_spo2(SPO2_PATH)
+
+# 过滤：总睡眠 >= 1h 的天
+valid_days = sorted([
+    d for d, stages in by_day.items()
+    if sum(stages.values()) >= 1.0
+])
+
+if not valid_days:
+    print("没有有效睡眠数据", file=sys.stderr)
+    sys.exit(1)
+
+print(f"有效睡眠天数: {len(valid_days)} 天")
+print(f"日期范围: {valid_days[0]} ~ {valid_days[-1]}")
+
+# 取最近 185 天
+if len(valid_days) > 185:
+    valid_days = valid_days[-185:]
+
+days = valid_days
+xs = [datetime(d.year, d.month, d.day) for d in days]
+
+# ── 各阶段时长序列 ──────────────────────────────────────────
+stage_vals = {k: [by_day[d].get(k, 0) for d in days] for k in STAGE_ORDER}
+total_sleep = [sum(by_day[d].get(k, 0) for k in ['asleepDeep','asleepREM','asleepCore']) for d in days]
+
+# ── 血氧序列 ──────────────────────────────────────────────────
+spo2_mean = [np.mean(spo2_by_day[d]) if spo2_by_day.get(d) else None for d in days]
+spo2_min  = [min(spo2_by_day[d]) if spo2_by_day.get(d) else None for d in days]
+spo2_mean_roll = rolling_mean(spo2_mean)
+total_roll = rolling_mean(total_sleep)
+
+# ── 入睡/起床时间 ─────────────────────────────────────────────
+bed_h, wake_h = [], []
+for d in days:
+    if bed_times[d]:
+        bh = min(bed_times[d]).hour + min(bed_times[d]).minute/60
+        bed_h.append(to_axis(bh))
+    else:
+        bed_h.append(None)
+    if wake_times[d]:
+        wh = max(wake_times[d]).hour + max(wake_times[d]).minute/60
+        wake_h.append(to_axis(wh))
+    else:
+        wake_h.append(None)
+
+bed_roll  = rolling_mean(bed_h)
+wake_roll = rolling_mean(wake_h)
+
+# ── 月度汇总 ──────────────────────────────────────────────────
+months = monthly_summary(days, by_day, spo2_by_day)
+
+# ══════════════════════════════════════════════════════════════
+# 绘图
+# ══════════════════════════════════════════════════════════════
+BG = '#0F1117'
+GRID_C = '#2A2D3A'
+TEXT_C = '#E0E0E0'
+ACCENT = '#4FC3F7'
+
+fig = plt.figure(figsize=(18, 22), facecolor=BG)
+gs = GridSpec(4, 2, figure=fig,
+              hspace=0.42, wspace=0.25,
+              left=0.06, right=0.97, top=0.95, bottom=0.04)
+
+ax1 = fig.add_subplot(gs[0, :])   # 睡眠堆叠柱
+ax2 = fig.add_subplot(gs[1, :])   # 血氧趋势
+ax3 = fig.add_subplot(gs[2, :])   # 入睡/起床时间
+ax4 = fig.add_subplot(gs[3, 0])   # 月度平均
+ax5 = fig.add_subplot(gs[3, 1])   # 月度血氧箱线
+
+def style_ax(ax, title):
+    ax.set_facecolor('#181B27')
+    ax.tick_params(colors=TEXT_C, labelsize=9)
+    ax.set_title(title, color=TEXT_C, fontsize=12, fontweight='bold', pad=8)
+    ax.spines[:].set_color(GRID_C)
+    ax.yaxis.label.set_color(TEXT_C)
+    ax.xaxis.label.set_color(TEXT_C)
+    ax.grid(axis='y', color=GRID_C, linewidth=0.6, linestyle='--')
+
+# ── 标题 ──────────────────────────────────────────────────────
+fig.text(0.5, 0.975, '睡眠趋势分析报告', ha='center', va='top',
+         color='white', fontsize=18, fontweight='bold')
+fig.text(0.5, 0.962, f'{days[0].strftime("%Y.%m.%d")} — {days[-1].strftime("%Y.%m.%d")}  |  共 {len(days)} 天',
+         ha='center', va='top', color='#888888', fontsize=11)
+
+# ────────────────────────────────────────────────────────────
+# 图1：每日睡眠堆叠柱 + 7日均线
+# ────────────────────────────────────────────────────────────
+style_ax(ax1, '每日睡眠时长（小时）')
+bottom = np.zeros(len(days))
+for k in STAGE_ORDER:
+    vals = np.array(stage_vals[k])
+    ax1.bar(xs, vals, bottom=bottom, color=STAGE_META[k]['color'],
+            label=STAGE_META[k]['label'], width=0.8, alpha=0.85)
+    bottom += vals
+
+# 7日滚动均线
+roll_xs = [x for x, v in zip(xs, total_roll) if v is not None]
+roll_ys = [v for v in total_roll if v is not None]
+ax1.plot(roll_xs, roll_ys, color='#FFD700', linewidth=2, label='7日均线', zorder=5)
+ax1.axhline(7, color='#FF6B6B', linewidth=1.2, linestyle='--', alpha=0.8, label='推荐7小时')
+
+ax1.set_ylabel('小时')
+ax1.legend(loc='upper left', framealpha=0.3, labelcolor=TEXT_C,
+           facecolor='#1E2130', edgecolor=GRID_C, ncol=6, fontsize=9)
+ax1.xaxis.set_major_formatter(mdates.DateFormatter('%m/%d'))
+ax1.xaxis.set_major_locator(mdates.WeekdayLocator(interval=2))
+ax1.set_xlim(xs[0] - timedelta(days=1), xs[-1] + timedelta(days=1))
+ax1.set_ylim(0, 12)
+ax1.tick_params(axis='x', rotation=30)
+
+# 均值标注
+avg_total = np.mean([v for v in total_sleep if v > 0])
+ax1.text(0.99, 0.95, f'均值 {avg_total:.1f}h', transform=ax1.transAxes,
+         ha='right', va='top', color='#FFD700', fontsize=10, fontweight='bold')
+
+# ────────────────────────────────────────────────────────────
+# 图2：血氧趋势
+# ────────────────────────────────────────────────────────────
+style_ax(ax2, '睡眠期血氧饱和度（SpO₂）')
+spo2_xs = [x for x, v in zip(xs, spo2_mean) if v is not None]
+spo2_ys = [v for v in spo2_mean if v is not None]
+spo2_min_xs = [x for x, v in zip(xs, spo2_min) if v is not None]
+spo2_min_ys = [v for v in spo2_min if v is not None]
+
+if spo2_xs:
+    ax2.fill_between(spo2_xs, spo2_ys, alpha=0.25, color='#4FC3F7')
+    ax2.plot(spo2_xs, spo2_ys, color='#4FC3F7', linewidth=1.5, label='均值', zorder=4)
+    ax2.scatter(spo2_min_xs, spo2_min_ys, color='#FF8A65', s=18, alpha=0.7, label='最低值', zorder=5)
+
+    # 7日均线
+    roll2_xs = [x for x, v in zip(spo2_xs, rolling_mean(spo2_ys)) if v is not None]
+    roll2_ys = [v for v in rolling_mean(spo2_ys) if v is not None]
+    ax2.plot(roll2_xs, roll2_ys, color='#FFD700', linewidth=2, label='7日均线', zorder=6)
+
+    # 标注低于90的点
+    for x, y in zip(spo2_min_xs, spo2_min_ys):
+        if y < 90:
+            ax2.annotate(f'{y:.0f}%', (x, y), textcoords='offset points',
+                         xytext=(0, -14), color='#FF5252', fontsize=8)
+
+ax2.axhline(95, color='#FF6B6B', linewidth=1, linestyle='--', alpha=0.7, label='95%警戒线')
+ax2.set_ylabel('SpO₂ (%)')
+ax2.set_ylim(88, 101)
+ax2.legend(loc='lower left', framealpha=0.3, labelcolor=TEXT_C,
+           facecolor='#1E2130', edgecolor=GRID_C, ncol=4, fontsize=9)
+ax2.xaxis.set_major_formatter(mdates.DateFormatter('%m/%d'))
+ax2.xaxis.set_major_locator(mdates.WeekdayLocator(interval=2))
+ax2.set_xlim(xs[0] - timedelta(days=1), xs[-1] + timedelta(days=1))
+ax2.tick_params(axis='x', rotation=30)
+
+if spo2_ys:
+    ax2.text(0.99, 0.05, f'均值 {np.mean(spo2_ys):.1f}%', transform=ax2.transAxes,
+             ha='right', va='bottom', color='#4FC3F7', fontsize=10, fontweight='bold')
+
+# ────────────────────────────────────────────────────────────
+# 图3：入睡 / 起床时间
+# ────────────────────────────────────────────────────────────
+style_ax(ax3, '入睡 & 起床时间')
+bed_xs  = [x for x, v in zip(xs, bed_h)  if v is not None]
+bed_ys  = [v for v in bed_h  if v is not None]
+wake_xs = [x for x, v in zip(xs, wake_h) if v is not None]
+wake_ys = [v for v in wake_h if v is not None]
+
+if bed_xs:
+    ax3.scatter(bed_xs, bed_ys, color='#AB47BC', s=22, alpha=0.6, label='入睡', zorder=4)
+    roll_b = rolling_mean(bed_ys)
+    roll_bx = [x for x, v in zip(bed_xs, roll_b) if v is not None]
+    roll_by = [v for v in roll_b if v is not None]
+    ax3.plot(roll_bx, roll_by, color='#CE93D8', linewidth=2, label='入睡7日均', zorder=5)
+
+if wake_xs:
+    ax3.scatter(wake_xs, wake_ys, color='#26A69A', s=22, alpha=0.6, label='起床', zorder=4)
+    roll_w = rolling_mean(wake_ys)
+    roll_wx = [x for x, v in zip(wake_xs, roll_w) if v is not None]
+    roll_wy = [v for v in roll_w if v is not None]
+    ax3.plot(roll_wx, roll_wy, color='#4DB6AC', linewidth=2, label='起床7日均', zorder=5)
+
+# 01:00 警戒线 (to_axis(1) = (1-22)%24 = 3)
+ax3.axhline(to_axis(1), color='#FF6B6B', linewidth=1, linestyle='--', alpha=0.7, label='01:00警戒')
+
+ax3.yaxis.set_major_formatter(matplotlib.ticker.FuncFormatter(axis_fmt))
+ax3.yaxis.set_major_locator(matplotlib.ticker.MultipleLocator(2))
+ax3.set_ylabel('时间')
+ax3.legend(loc='upper left', framealpha=0.3, labelcolor=TEXT_C,
+           facecolor='#1E2130', edgecolor=GRID_C, ncol=5, fontsize=9)
+ax3.xaxis.set_major_formatter(mdates.DateFormatter('%m/%d'))
+ax3.xaxis.set_major_locator(mdates.WeekdayLocator(interval=2))
+ax3.set_xlim(xs[0] - timedelta(days=1), xs[-1] + timedelta(days=1))
+ax3.tick_params(axis='x', rotation=30)
+
+# ────────────────────────────────────────────────────────────
+# 图4：月度平均睡眠堆叠柱
+# ────────────────────────────────────────────────────────────
+style_ax(ax4, '月度平均睡眠时长')
+month_labels, month_deep, month_rem, month_core, month_total = [], [], [], [], []
+for (yr, mo), info in months.items():
+    label = f"{yr}/{mo:02d}"
+    mdays = [d for d in info['days'] if sum(by_day[d].values()) >= 1]
+    if not mdays:
+        continue
+    month_labels.append(label)
+    month_deep.append(np.mean([by_day[d].get('asleepDeep', 0) for d in mdays]))
+    month_rem.append(np.mean([by_day[d].get('asleepREM', 0) for d in mdays]))
+    month_core.append(np.mean([by_day[d].get('asleepCore', 0) for d in mdays]))
+    t = np.mean([sum(by_day[d].get(k,0) for k in ['asleepDeep','asleepREM','asleepCore']) for d in mdays])
+    month_total.append(t)
+
+mx = np.arange(len(month_labels))
+b0 = np.zeros(len(month_labels))
+for k, color_k in [('asleepDeep', '#2D6A9F'), ('asleepREM', '#6A5ACD'), ('asleepCore', '#5BA4CF')]:
+    vals = [np.mean([by_day[d].get(k, 0) for d in months[tuple(int(p) for p in lbl.split('/'))]['days']
+                     if sum(by_day[d].values()) >= 1])
+            for lbl in month_labels]
+    ax4.bar(mx, vals, bottom=b0, color=color_k, alpha=0.85)
+    b0 += np.array(vals)
+
+ax4.set_xticks(mx)
+ax4.set_xticklabels(month_labels, rotation=30, color=TEXT_C, fontsize=9)
+ax4.set_ylabel('小时')
+ax4.axhline(7, color='#FF6B6B', linewidth=1.2, linestyle='--', alpha=0.8)
+ax4.set_ylim(0, 10)
+
+for i, (t, lbl) in enumerate(zip(month_total, month_labels)):
+    reach = sum(1 for d in months[tuple(int(p) for p in lbl.split('/'))]['days']
+                if sum(by_day[d].get(k,0) for k in ['asleepDeep','asleepREM','asleepCore']) >= 7) 
+    total_n = len([d for d in months[tuple(int(p) for p in lbl.split('/'))]['days']
+                   if sum(by_day[d].values()) >= 1])
+    pct = reach/total_n*100 if total_n else 0
+    ax4.text(i, t + 0.1, f'{pct:.0f}%', ha='center', va='bottom',
+             color='#FFD700', fontsize=8)
+
+# ────────────────────────────────────────────────────────────
+# 图5：月度血氧箱线图
+# ────────────────────────────────────────────────────────────
+style_ax(ax5, '月度睡眠期血氧（SpO₂）')
+box_data, box_labels = [], []
+for (yr, mo), info in months.items():
+    if info['spo2']:
+        box_data.append(info['spo2'])
+        box_labels.append(f"{yr}/{mo:02d}")
+
+if box_data:
+    bp = ax5.boxplot(box_data, patch_artist=True, labels=box_labels,
+                     medianprops={'color': '#FFD700', 'linewidth': 2},
+                     boxprops={'facecolor': '#1E4D7B', 'alpha': 0.8, 'edgecolor': '#4FC3F7'},
+                     whiskerprops={'color': '#888888'},
+                     capprops={'color': '#888888'},
+                     flierprops={'marker': 'o', 'color': '#FF8A65', 'markersize': 4, 'alpha': 0.6})
+    ax5.axhline(95, color='#FF6B6B', linewidth=1, linestyle='--', alpha=0.7)
+    ax5.set_ylim(88, 101)
+    ax5.set_ylabel('SpO₂ (%)')
+    ax5.tick_params(axis='x', rotation=30)
+    for label in ax5.get_xticklabels():
+        label.set_color(TEXT_C)
+
+# ── 底部统计摘要 ──────────────────────────────────────────────
+avg_deep = np.mean([by_day[d].get('asleepDeep', 0) for d in days])
+avg_rem  = np.mean([by_day[d].get('asleepREM', 0) for d in days])
+avg_core = np.mean([by_day[d].get('asleepCore', 0) for d in days])
+avg_awake = np.mean([by_day[d].get('awake', 0) for d in days])
+reach7 = sum(1 for v in total_sleep if v >= 7)
+spo2_vals = [v for vl in spo2_by_day.values() for v in vl]
+spo2_low95 = sum(1 for v in spo2_vals if v < 95)
+
+summary = (
+    f"均值  总睡眠 {avg_total:.1f}h  |  深睡眠 {avg_deep:.1f}h ({avg_deep/avg_total*100:.0f}%)  "
+    f"|  REM {avg_rem:.1f}h ({avg_rem/avg_total*100:.0f}%)  |  浅睡眠 {avg_core:.1f}h  "
+    f"|  达标率(≥7h) {reach7}/{len(days)} ({reach7/len(days)*100:.0f}%)"
+    + (f"  |  血氧均值 {np.mean(spo2_vals):.1f}%  低于95%次数 {spo2_low95}" if spo2_vals else "")
+)
+fig.text(0.5, 0.015, summary, ha='center', va='bottom',
+         color='#AAAAAA', fontsize=9)
+
+plt.savefig(OUT_PATH, dpi=150, bbox_inches='tight', facecolor=BG)
+print(f"\n图表已保存: {OUT_PATH}")
+
+# ── 终端摘要 ──────────────────────────────────────────────────
+print("\n════════ 总体统计 ════════")
+print(f"分析天数: {len(days)} 天 ({days[0]} ~ {days[-1]})")
+print(f"平均睡眠: {avg_total:.2f}h / 夜")
+print(f"  深睡眠: {avg_deep:.2f}h ({avg_deep/avg_total*100:.1f}%)")
+print(f"  REM:    {avg_rem:.2f}h ({avg_rem/avg_total*100:.1f}%)")
+print(f"  浅睡眠: {avg_core:.2f}h ({avg_core/avg_total*100:.1f}%)")
+print(f"  清醒:   {avg_awake:.2f}h")
+print(f"≥7h达标: {reach7}/{len(days)} 天 ({reach7/len(days)*100:.1f}%)")
+if spo2_vals:
+    print(f"血氧均值: {np.mean(spo2_vals):.1f}%  最低: {min(spo2_vals):.1f}%")
+    print(f"低于95%: {spo2_low95} 次")
+
+print("\n════════ 月度汇总 ════════")
+print(f"{'月份':<10} {'天数':>6} {'均睡眠':>8} {'深睡%':>8} {'REM%':>7} {'≥7h%':>7} {'血氧均':>8}")
+print("─" * 60)
+for (yr, mo), info in months.items():
+    mdays = [d for d in info['days'] if sum(by_day[d].values()) >= 1]
+    if not mdays:
+        continue
+    mt = np.mean([sum(by_day[d].get(k,0) for k in ['asleepDeep','asleepREM','asleepCore']) for d in mdays])
+    md = np.mean([by_day[d].get('asleepDeep', 0) for d in mdays])
+    mr = np.mean([by_day[d].get('asleepREM', 0) for d in mdays])
+    r7 = sum(1 for d in mdays if sum(by_day[d].get(k,0) for k in ['asleepDeep','asleepREM','asleepCore']) >= 7)
+    sp = f"{np.mean(info['spo2']):.1f}%" if info['spo2'] else 'N/A'
+    print(f"{yr}/{mo:02d}     {len(mdays):>5}    {mt:>6.2f}h  {md/mt*100:>6.1f}%  {mr/mt*100:>5.1f}%  {r7/len(mdays)*100:>5.1f}%    {sp:>6}")

--- a/health-sleep-analysis/sleep_longterm_librsvg.py
+++ b/health-sleep-analysis/sleep_longterm_librsvg.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Half-year (26 weeks) or full-year (12 months) sleep trend.
+Design language matches sleep_report_librsvg.py.
+"""
+import argparse, json, html, subprocess
+from pathlib import Path
+from datetime import datetime, timedelta, date
+from collections import defaultdict
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--period',     default='halfyear', choices=['halfyear','year'])
+parser.add_argument('--sleep',      default='/var/minis/workspace/sleep_raw.json')
+parser.add_argument('--spo2',       default='/var/minis/workspace/spo2_raw.json')
+parser.add_argument('--out-prefix', default='/var/minis/workspace/sleep_longterm')
+parser.add_argument('--lang',       default='zh', choices=['zh','en','ja'])
+args = parser.parse_args()
+
+DAYS = 185 if args.period == 'halfyear' else 370
+
+STR = {
+    'zh': dict(
+        title_half='最近半年睡眠趋势', title_year='最近一年睡眠趋势',
+        sub_half='26周聚合', sub_year='12个月聚合',
+        suffix='夜有效记录', source='Apple Health 睡眠阶段 / 血氧',
+        avg_sleep='平均睡眠', good_rate='达标率', deep_avg='深睡均值', min_spo2='最低血氧',
+        note_sleep='月均睡眠时长', note_good='≥7h 占比', note_deep='深睡恢复', note_spo2='睡眠期最低点',
+        stage_title='睡眠阶段趋势', recommend='目标 7h',
+        deep='深睡', core='浅睡', awake='清醒',
+        spo2_title='血氧趋势（最低值）', warn_line='95%',
+        avg_lbl='均值', min_lbl='最低',
+        bed_title='入睡时间趋势', warn_01='01:00',
+        sum_title='汇总', goal_lbl='达标', spo2_lbl='SpO2',
+        conclusion='结论', generated='生成时间',
+        data_source='数据来源：Apple HealthKit · 仅供健康趋势参考',
+    ),
+    'en': dict(
+        title_half='6-Month Sleep Trend', title_year='1-Year Sleep Trend',
+        sub_half='26-week aggregation', sub_year='12-month aggregation',
+        suffix='nights', source='Apple Health Sleep Stages / SpO2',
+        avg_sleep='Avg Sleep', good_rate='Goal Rate', deep_avg='Avg Deep', min_spo2='Min SpO2',
+        note_sleep='Monthly avg', note_good='≥7h rate', note_deep='Deep recovery', note_spo2='Sleep SpO2 low',
+        stage_title='Sleep Stage Trend', recommend='Goal 7h',
+        deep='Deep', core='Core', awake='Awake',
+        spo2_title='SpO2 Trend (min)', warn_line='95%',
+        avg_lbl='avg', min_lbl='min',
+        bed_title='Bedtime Trend', warn_01='01:00',
+        sum_title='Summary', goal_lbl='Goal', spo2_lbl='SpO2',
+        conclusion='Summary', generated='Generated',
+        data_source='Source: Apple HealthKit · For reference only',
+    ),
+    'ja': dict(
+        title_half='直近半年の睡眠トレンド', title_year='直近1年の睡眠トレンド',
+        sub_half='26週集計', sub_year='12ヶ月集計',
+        suffix='夜', source='Apple Health 睡眠ステージ / 血中酸素',
+        avg_sleep='平均睡眠', good_rate='達成率', deep_avg='深睡眠平均', min_spo2='最低血中酸素',
+        note_sleep='月間平均', note_good='≥7h 達成率', note_deep='深睡眠回復', note_spo2='睡眠中最低値',
+        stage_title='睡眠ステージ推移', recommend='目標 7h',
+        deep='深睡眠', core='コア', awake='覚醒',
+        spo2_title='血中酸素推移（最低値）', warn_line='95%',
+        avg_lbl='平均', min_lbl='最低',
+        bed_title='就寝時刻推移', warn_01='01:00',
+        sum_title='サマリー', goal_lbl='達成', spo2_lbl='SpO2',
+        conclusion='まとめ', generated='生成日時',
+        data_source='データ：Apple HealthKit · 参考用のみ',
+    ),
+}
+T = STR[args.lang]
+TITLE    = T['title_half'] if args.period == 'halfyear' else T['title_year']
+SUBTITLE = T['sub_half']   if args.period == 'halfyear' else T['sub_year']
+
+COL = {
+    'text':'#f8fafc','muted':'#94a3b8','blue':'#60a5fa','cyan':'#22d3ee',
+    'violet':'#a78bfa','amber':'#fbbf24','red':'#fb7185','green':'#34d399',
+    'deep':'#2563eb','core':'#22c1c3','rem':'#a78bfa','awake':'#fb923c',
+}
+
+def esc(x): return html.escape(str(x))
+def txt(x,y,s,size=22,color=None,weight=400,anchor='start'):
+    return (f'<text x="{x}" y="{y}" font-size="{size}" fill="{color or COL["text"]}"'
+            f' font-weight="{weight}" text-anchor="{anchor}">{esc(s)}</text>')
+def rct(x,y,w,h,r,fill,stroke='#ffffff22'):
+    return f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{r}" fill="{fill}" stroke="{stroke}"/>'
+def tspan_unit(x,y,val,unit,vsize,vcolor,usize,ucolor,weight=850):
+    return (f'<text x="{x}" y="{y}" font-size="{vsize}" fill="{vcolor}" font-weight="{weight}">'
+            f'{esc(val)}<tspan font-size="{usize}" fill="{ucolor}" dx="6">{esc(unit)}</tspan></text>')
+def line(x1,y1,x2,y2,color='#ffffff25',sw=1,dash=''):
+    da = f' stroke-dasharray="{dash}"' if dash else ''
+    return f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{sw}"{da}/>'
+
+ICON_PATHS = {
+    'moon':     '<path d="M12 3a6.6 6.6 0 0 0 8.8 8.8A9 9 0 1 1 12 3Z"/>',
+    'clock':    '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+    'bars':     '<path d="M3 3v18h18"/><path d="M7 16V9M12 16V5M17 16v-3"/>',
+    'droplet':  '<path d="M12 2.5S5.5 9.4 5.5 14A6.5 6.5 0 0 0 18.5 14C18.5 9.4 12 2.5 12 2.5Z"/>',
+    'activity': '<path d="M22 12h-4l-3 8L9 4l-3 8H2"/>',
+    'sparkles': '<path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3Z"/>',
+    'calendar': '<rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/>',
+}
+def icon(name,x,y,size=28,color='currentColor',sw=2.2):
+    return (f'<svg x="{x}" y="{y}" width="{size}" height="{size}" viewBox="0 0 24 24" '
+            f'fill="none" stroke="{color}" stroke-width="{sw}" '
+            f'stroke-linecap="round" stroke-linejoin="round">{ICON_PATHS[name]}</svg>')
+
+def val_color(v): return COL['green'] if v>=7 else (COL['amber'] if v>=6 else COL['red'])
+def pct_color(p): return COL['green'] if p>=0.7 else (COL['amber'] if p>=0.5 else COL['red'])
+
+# ── Parse data ────────────────────────────────────────────────────────────────
+def parse_dt(s): return datetime.strptime(s[:19], '%Y-%m-%dT%H:%M:%S')
+def sleep_date(dt): return (dt-timedelta(days=1)).date() if dt.hour<14 else dt.date()
+def hm(dt): return dt.hour+dt.minute/60
+
+STAGE_MAP = {'asleepDeep':'Deep','asleepREM':'REM','asleepCore':'Core','awake':'Awake','inBed':None}
+
+samples    = json.load(open(args.sleep)).get('samples',[])
+spo2_samps = json.load(open(args.spo2)).get('samples',[])
+
+nights = defaultdict(lambda: defaultdict(float))
+bed_h  = {}
+for s in samples:
+    raw = s.get('stage') or s.get('value') or s.get('sleepStage','')
+    stg = STAGE_MAP.get(raw)
+    ss  = s.get('startDate') or s.get('start')
+    ee  = s.get('endDate')   or s.get('end')
+    if not ss or not ee: continue
+    a=parse_dt(ss); b=parse_dt(ee); n=sleep_date(a)
+    if stg: nights[n][stg] += (b-a).total_seconds()/3600
+    af=hm(a); af=af+24 if af<14 else af
+    bed_h[n]=min(bed_h.get(n,af),af)
+
+spo2_by = defaultdict(list)
+for s in spo2_samps:
+    v=s.get('percentage') or s.get('value')
+    if isinstance(v,(int,float)) and v>50:
+        spo2_by[sleep_date(parse_dt(s['date']))].append(float(v))
+
+valid = sorted([d for d in nights if sum(nights[d].values())>1])[-DAYS:]
+if not valid: raise SystemExit('No sleep data.')
+
+# ── Bucket aggregation ────────────────────────────────────────────────────────
+USE_WEEKS = (args.period=='halfyear')
+def bucket_key(d):
+    if USE_WEEKS:
+        iso=d.isocalendar(); return f'{iso[0]}-W{iso[1]:02d}'
+    return d.strftime('%Y-%m')
+
+def bucket_label(key):
+    if USE_WEEKS:
+        y,w=int(key[:4]),int(key[6:])
+        mon=date.fromisocalendar(y,w,1)
+        return f'{mon.month}/{mon.day}'
+    y,m=int(key[:4]),int(key[5:])
+    return {'zh':f'{m}月','en':['','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][m],'ja':f'{m}月'}[args.lang]
+
+bkt_days=defaultdict(list)
+for d in valid: bkt_days[bucket_key(d)].append(d)
+bkt_keys=sorted(bkt_days.keys())
+
+def _avg(xs): return sum(xs)/len(xs) if xs else 0
+
+buckets=[]
+for key in bkt_keys:
+    ds=bkt_days[key]
+    totals=[sum(nights[d].values()) for d in ds]
+    sp_min=[min(spo2_by[d]) for d in ds if spo2_by.get(d)]
+    beds=[bed_h[d] for d in ds if d in bed_h]
+    buckets.append(dict(
+        key=key, label=bucket_label(key), n=len(ds),
+        avg_total=_avg(totals),
+        avg_deep =_avg([nights[d].get('Deep',0) for d in ds]),
+        avg_core =_avg([nights[d].get('Core',0) for d in ds]),
+        avg_rem  =_avg([nights[d].get('REM',0)  for d in ds]),
+        avg_awake=_avg([nights[d].get('Awake',0) for d in ds]),
+        good_rate=sum(1 for t in totals if t>=7)/len(totals) if totals else 0,
+        spo2_min =min(sp_min) if sp_min else None,
+        spo2_avg =_avg(sp_min) if sp_min else None,
+        avg_bed  =_avg(beds) if beds else None,
+    ))
+
+nb=len(buckets)
+g_avg  =_avg([b['avg_total'] for b in buckets])
+g_deep =_avg([b['avg_deep']  for b in buckets])
+g_rate =_avg([b['good_rate'] for b in buckets])
+g_spmin=min((b['spo2_min'] for b in buckets if b['spo2_min'] is not None),default=None)
+range_lbl=f"{valid[0].strftime('%Y/%m/%d')} – {valid[-1].strftime('%Y/%m/%d')}"
+
+# ── Layout ────────────────────────────────────────────────────────────────────
+W=1280; PAD=54; CW=W-PAD*2; GAP=24
+
+METRIC_H =174
+STAGE_H  =500   # panel card height; bars confined inside with chartClip
+SPO2_H   =340
+BED_H    =320
+ROW_H    =62
+rows_per_col=(nb+1)//2
+SUM_H    =rows_per_col*ROW_H+110
+CONCL_H  =108
+FOOTER_H =60
+
+y_hdr    =170
+y_metrics=y_hdr+10
+y_stage  =y_metrics+METRIC_H+GAP
+y_spo2   =y_stage +STAGE_H +GAP
+y_bed    =y_spo2  +SPO2_H  +GAP
+y_sum    =y_bed   +BED_H   +GAP
+y_concl  =y_sum   +SUM_H   +GAP
+y_footer =y_concl +CONCL_H +GAP
+TOTAL_H  =y_footer+FOOTER_H+50
+
+# ── SVG ───────────────────────────────────────────────────────────────────────
+svg=[]
+svg.append(f'''<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{TOTAL_H}" viewBox="0 0 {W} {TOTAL_H}">
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#07111f"/><stop offset=".55" stop-color="#0b1020"/><stop offset="1" stop-color="#111827"/>
+  </linearGradient>
+  <linearGradient id="cardGrad" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#ffffff" stop-opacity=".105"/><stop offset="1" stop-color="#ffffff" stop-opacity=".035"/>
+  </linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0" stop-color="#38bdf8" stop-opacity=".5"/><stop offset="1" stop-color="#38bdf8" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowPurple" cx="50%" cy="50%" r="50%">
+    <stop offset="0" stop-color="#a78bfa" stop-opacity=".4"/><stop offset="1" stop-color="#a78bfa" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="shadow"><feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#000" flood-opacity=".3"/></filter>
+  <style><![CDATA[text{{font-family:'Noto Sans CJK SC','Noto Sans CJK','PingFang SC',Arial,sans-serif;text-rendering:geometricPrecision}}]]></style>
+</defs>
+<rect width="100%" height="100%" fill="url(#bg)"/>
+<circle cx="1150" cy="220" r="300" fill="url(#glowBlue)"/>
+<circle cx="80"   cy="{TOTAL_H-200}" r="280" fill="url(#glowPurple)"/>
+<g filter="url(#shadow)">
+''')
+
+# Header
+svg.append(txt(PAD,108,TITLE,54,COL['text'],850))
+svg.append(txt(PAD,152,f'{range_lbl} · {len(valid)} {T["suffix"]} · {SUBTITLE} · {T["source"]}',22,COL['muted']))
+svg.append(rct(920,60,306,56,28,'#ffffff12','#ffffff25'))
+svg.append(icon('sparkles',940,76,26,'#dbeafe'))
+svg.append(txt(976,97,'Sleep Intelligence',20,'#dbeafe',550))
+
+# Metric cards
+MCW,MCH,MGAP=272,METRIC_H,18
+METRICS=[
+    ('moon',    T['avg_sleep'],f'{g_avg:.1f}',           'h', T['note_sleep'],val_color(g_avg),  val_color(g_avg)),
+    ('activity',T['good_rate'],f'{g_rate*100:.0f}',      '%', T['note_good'], pct_color(g_rate), pct_color(g_rate)),
+    ('clock',   T['deep_avg'], f'{g_deep:.1f}',          'h', T['note_deep'], COL['violet'],     COL['violet']),
+    ('droplet', T['min_spo2'], f'{g_spmin:.1f}' if g_spmin else '—','%',T['note_spo2'],COL['red'],COL['red']),
+]
+for i,(ic,title,val,unit,note,color,vc) in enumerate(METRICS):
+    mx,my=PAD+i*(MCW+MGAP),y_metrics
+    svg.append(rct(mx,my,MCW,MCH,26,'url(#cardGrad)','#ffffff24'))
+    svg.append(txt(mx+22,my+40,title,19,COL['muted'],500))
+    svg.append(f'<rect x="{mx+MCW-66}" y="{my+18}" width="50" height="50" rx="16" fill="{color}" opacity=".16"/>')
+    svg.append(icon(ic,mx+MCW-56,my+27,26,color))
+    svg.append(tspan_unit(mx+22,my+108,val,unit,46,vc,22,COL['muted']))
+    svg.append(txt(mx+22,my+142,note,16,COL['muted']))
+
+# ── Panel 1: Stage trend ──────────────────────────────────────────────────────
+svg.append(rct(PAD,y_stage,CW,STAGE_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('bars',PAD+30,y_stage+28,30,COL['cyan']))
+svg.append(txt(PAD+74,y_stage+52,T['stage_title'],28,COL['text'],760))
+
+LEGEND=[( T['deep'],'deep'),(T['core'],'core'),('REM','rem'),(T['awake'],'awake')]
+for i,(lbl,key) in enumerate(LEGEND):
+    gx=PAD+380+i*195
+    svg.append(f'<circle cx="{gx}" cy="{y_stage+44}" r="7" fill="{COL[key]}"/>')
+    svg.append(txt(gx+16,y_stage+51,lbl,18,'#dbeafe',650))
+
+# Chart area inside panel — reserve 56px at bottom for rotated labels
+CHART_PAD_TOP=80; CHART_PAD_BOT=56
+cx=PAD+60; cy=y_stage+CHART_PAD_TOP
+chart_w=CW-120
+chart_h=STAGE_H-CHART_PAD_TOP-CHART_PAD_BOT
+
+# chartClip: hard boundary — bars CANNOT overflow top or sides
+svg.append(f'<clipPath id="chartClip">'
+           f'<rect x="{cx}" y="{cy}" width="{chart_w}" height="{chart_h}"/>'
+           f'</clipPath>')
+
+svg.append(line(cx,cy+chart_h,cx+chart_w,cy+chart_h))  # baseline
+target_y=cy+chart_h-7/9*chart_h
+svg.append(line(cx,target_y,cx+chart_w,target_y,COL['green'],2,'8 6'))
+svg.append(txt(cx+chart_w-72,target_y-10,T['recommend'],16,'#86efac',500))
+
+bar_gap=5
+bw=max(6,(chart_w-(nb-1)*bar_gap)/nb)
+
+# All bars inside chartClip group
+svg.append('<g clip-path="url(#chartClip)">')
+for i,b in enumerate(buckets):
+    bx=cx+i*(bw+bar_gap); by=cy+chart_h
+    for key,col in [('avg_deep',COL['deep']),('avg_core',COL['core']),('avg_rem',COL['rem']),('avg_awake',COL['awake'])]:
+        hh=b[key]/9*chart_h
+        by-=hh
+        svg.append(f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bw:.1f}" height="{hh:.1f}" rx="3" fill="{col}" opacity=".93"/>')
+svg.append('</g>')
+
+# Date labels outside chartClip (below baseline), rotated -45°
+for i,b in enumerate(buckets):
+    lx=cx+i*(bw+bar_gap)+bw/2
+    ly=cy+chart_h+14
+    svg.append(f'<text x="{lx:.1f}" y="{ly:.1f}" font-size="12" fill="{COL["muted"]}"'
+               f' text-anchor="end" transform="rotate(-45 {lx:.1f} {ly:.1f})">{esc(b["label"])}</text>')
+
+# ── Panel 2: SpO2 ─────────────────────────────────────────────────────────────
+svg.append(rct(PAD,y_spo2,CW,SPO2_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('droplet',PAD+30,y_spo2+28,30,COL['blue']))
+svg.append(txt(PAD+74,y_spo2+52,T['spo2_title'],28,COL['text'],760))
+
+ax=cx; ay=y_spo2+88; aw=chart_w; ah=SPO2_H-130
+# clipPath for SpO2 chart area — prevents bars/circles from escaping panel
+svg.append(f'<clipPath id="spo2Clip"><rect x="{ax}" y="{ay}" width="{aw}" height="{ah}"/></clipPath>')
+svg.append(line(ax,ay+ah,ax+aw,ay+ah))
+svg.append(line(ax,ay,ax,ay+ah,'#ffffff18'))
+for pct in [90,95,100]:
+    gy=ay+ah-(pct-85)/15*ah
+    svg.append(line(ax,gy,ax+aw,gy,'#ffffff15',1,'5 4'))
+    svg.append(txt(ax-8,gy+5,str(pct),14,COL['muted'],400,'end'))
+svg.append(line(ax,ay+ah-(95-85)/15*ah,ax+aw,ay+ah-(95-85)/15*ah,COL['amber'],1.5,'7 5'))
+svg.append(txt(ax+aw+8,ay+ah-(95-85)/15*ah+5,T['warn_line'],13,COL['amber']))
+
+# x positions: evenly distribute across full chart width
+pts=[]
+step = aw/max(1,nb-1) if nb>1 else 0
+for i,b in enumerate(buckets):
+    if b['spo2_min'] is None: continue
+    bx=ax+i*step; by2=ay+ah-(b['spo2_min']-85)/15*ah
+    bh2=ay+ah-by2; col=COL['red'] if b['spo2_min']<90 else COL['blue']
+    pts.append((bx,by2,b,col))
+
+svg.append('<g clip-path="url(#spo2Clip)">')
+for bx,by2,b,col in pts:
+    bh2=ay+ah-by2
+    svg.append(f'<rect x="{bx-bw/2:.1f}" y="{by2:.1f}" width="{bw:.1f}" height="{bh2:.1f}" rx="3" fill="{col}" opacity=".3"/>')
+for (x1,y1,_,__),(x2,y2,_,__) in zip(pts,pts[1:]):
+    svg.append(line(x1,y1,x2,y2,COL['blue'],2.5))
+for bx,by2,b,col in pts:
+    svg.append(f'<circle cx="{bx:.1f}" cy="{by2:.1f}" r="5" fill="{col}"/>')
+svg.append('</g>')
+
+spo2_avgs=[b['spo2_avg'] for b in buckets if b['spo2_avg']]
+sp_stat=(f'{T["avg_lbl"]} {_avg(spo2_avgs):.1f}%  ·  {T["min_lbl"]} {g_spmin:.1f}%' if g_spmin else '')
+svg.append(txt(ax,ay+ah+28,sp_stat,18,COL['muted']))
+
+# ── Panel 3: Bedtime ──────────────────────────────────────────────────────────
+svg.append(rct(PAD,y_bed,CW,BED_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('clock',PAD+30,y_bed+28,30,COL['violet']))
+svg.append(txt(PAD+74,y_bed+52,T['bed_title'],28,COL['text'],760))
+
+bax=cx; bay=y_bed+88; baw=chart_w; bah=BED_H-130
+BASE=22
+def to_ax(h): return (h-BASE)%24
+def ax_fmt(v): return f'{int((BASE+v)%24):02d}:00'
+
+svg.append(line(bax,bay+bah,bax+baw,bay+bah))
+svg.append(line(bax,bay,bax,bay+bah,'#ffffff18'))
+for tick in range(0,13,2):
+    ty2=bay+tick/12*bah
+    svg.append(line(bax,ty2,bax+baw,ty2,'#ffffff12',1,'4 4'))
+    svg.append(txt(bax-8,ty2+5,ax_fmt(tick),13,COL['muted'],400,'end'))
+warn_v=to_ax(1)/12*bah
+svg.append(line(bax,bay+warn_v,bax+baw,bay+warn_v,COL['red'],1.5,'7 5'))
+svg.append(txt(bax+baw+8,bay+warn_v+5,T['warn_01'],13,COL['red']))
+
+bed_pts=[]
+for i,b in enumerate(buckets):
+    if b['avg_bed'] is None: continue
+    bh_n=b['avg_bed']%24; v=to_ax(bh_n)/12*bah
+    px2=bax+i*(baw/max(1,nb-1)); py2=bay+v
+    bed_pts.append((px2,py2,b))
+for (x1,y1,_),(x2,y2,_) in zip(bed_pts,bed_pts[1:]):
+    svg.append(line(x1,y1,x2,y2,COL['violet'],2.5))
+for px2,py2,b in bed_pts:
+    svg.append(f'<circle cx="{px2:.1f}" cy="{py2:.1f}" r="5" fill="{COL["violet"]}"/>')
+
+# ── Panel 4: Summary table ────────────────────────────────────────────────────
+svg.append(rct(PAD,y_sum,CW,SUM_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('calendar',PAD+30,y_sum+28,30,COL['amber']))
+svg.append(txt(PAD+74,y_sum+52,T['sum_title'],28,COL['text'],760))
+
+half_cw=(CW-20)//2
+for i,b in enumerate(buckets):
+    col_idx=i//rows_per_col; row_idx=i%rows_per_col
+    rx=PAD+col_idx*(half_cw+20); ry=y_sum+80+row_idx*ROW_H
+    svg.append(rct(rx,ry,half_cw,ROW_H-8,18,'#0f172acc','#ffffff18'))
+    svg.append(txt(rx+14,ry+ROW_H-20,b['label'],17,COL['text'],700))
+    svg.append(txt(rx+110,ry+ROW_H-20,f"{b['avg_total']:.1f}h",17,val_color(b['avg_total']),700))
+    svg.append(txt(rx+210,ry+ROW_H-20,f"{b['good_rate']*100:.0f}% {T['goal_lbl']}",15,pct_color(b['good_rate']),500))
+    svg.append(txt(rx+360,ry+ROW_H-20,
+                   f"{T['spo2_lbl']} {b['spo2_min']:.0f}%" if b['spo2_min'] else '',
+                   15,COL['red'] if b['spo2_min'] and b['spo2_min']<90 else COL['muted'],400))
+
+# ── Conclusion ────────────────────────────────────────────────────────────────
+svg.append(rct(PAD,y_concl,CW,CONCL_H,30,'#0f172acc','#ffffff1e'))
+spo2_ok=g_spmin is None or g_spmin>=90
+conc={'zh':f"均值 {g_avg:.1f}h · 达标率 {g_rate*100:.0f}% · 深睡均值 {g_deep:.1f}h"+('· 血氧低点正常' if spo2_ok else f' · 血氧最低 {g_spmin:.1f}% ⚠'),
+      'en':f"{g_avg:.1f}h avg · {g_rate*100:.0f}% goal · Deep {g_deep:.1f}h"+(' · SpO2 OK' if spo2_ok else f' · SpO2 min {g_spmin:.1f}% ⚠'),
+      'ja':f"平均 {g_avg:.1f}h · 達成率 {g_rate*100:.0f}% · 深睡眠 {g_deep:.1f}h"+('· SpO2 正常' if spo2_ok else f' · 最低 {g_spmin:.1f}% ⚠')}[args.lang]
+svg.append(txt(PAD+22,y_concl+44,T['conclusion'],26,COL['text'],800))
+svg.append(txt(PAD+22,y_concl+82,conc,20,'#cbd5e1'))
+
+# ── Footer ────────────────────────────────────────────────────────────────────
+svg.append(rct(PAD,y_footer,310,40,20,'#ffffff0a','#ffffff18'))
+svg.append(txt(PAD+18,y_footer+26,f"{T['generated']}: {date.today()}",16,COL['muted']))
+svg.append(txt(W-PAD,y_footer+26,T['data_source'],16,COL['muted'],400,'end'))
+svg.append('</g></svg>')
+
+svg_path=Path(args.out_prefix+'.svg')
+png_path=Path(args.out_prefix+'.png')
+svg_path.write_text('\n'.join(svg))
+subprocess.run(['rsvg-convert',str(svg_path),'-w',str(W),'-o',str(png_path)],check=True)
+print(png_path)

--- a/health-sleep-analysis/sleep_month_trend_librsvg.py
+++ b/health-sleep-analysis/sleep_month_trend_librsvg.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""30-day monthly sleep trend rendered via rsvg-convert.
+Design language matches sleep_report_librsvg.py.
+
+Usage:
+  python3 sleep_month_trend_librsvg.py --days 30 --lang zh \\
+      --sleep /tmp/sleep_raw.json --spo2 /tmp/spo2_raw.json \\
+      --out-prefix /tmp/sleep_month_trend
+"""
+import argparse, json, html, subprocess
+from pathlib import Path
+from datetime import datetime, timedelta, date
+from collections import defaultdict
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+parser = argparse.ArgumentParser()
+parser.add_argument('--days',       type=int, default=30)
+parser.add_argument('--sleep',      default='/var/minis/workspace/sleep_raw.json')
+parser.add_argument('--spo2',       default='/var/minis/workspace/spo2_raw.json')
+parser.add_argument('--out-prefix', default='/var/minis/workspace/sleep_month_trend')
+parser.add_argument('--lang',       default='zh', choices=['zh','en','ja'])
+args = parser.parse_args()
+
+# ── Localisation ──────────────────────────────────────────────────────────────
+STR = {
+    'zh': dict(
+        title='最近一个月睡眠趋势', suffix='夜有效记录', source='Apple Health 睡眠阶段 / 血氧',
+        avg_sleep='平均睡眠', good_days='达标天数', deep_avg='深睡均值', min_spo2='最低血氧',
+        note_sleep='月均睡眠时长', note_good='≥7h 的夜数', note_deep='深睡恢复', note_spo2='睡眠期最低点',
+        stage_title='睡眠阶段趋势', recommend='推荐 7h',
+        deep='深睡', core='浅睡', awake='清醒',
+        spo2_title='血氧趋势', warn_line='95% 警戒',
+        avg_lbl='均值', min_lbl='最低',
+        week_title='周汇总', goal_lbl='达标',
+        conclusion_title='月度结论',
+        short='本月睡眠时长偏短', ok='本月睡眠时长基本达标',
+        spo2_bad='；出现低于90%的血氧低点，建议持续观察',
+        spo2_ok='；血氧低点未见明显危险信号',
+        generated='生成时间',
+        data_source='数据来源：Apple HealthKit · 仅供健康趋势参考',
+    ),
+    'en': dict(
+        title='Monthly Sleep Trend', suffix='nights recorded', source='Apple Health Sleep Stages / SpO2',
+        avg_sleep='Avg Sleep', good_days='Goal Days', deep_avg='Avg Deep', min_spo2='Min SpO2',
+        note_sleep='Monthly avg', note_good='≥7h nights', note_deep='Deep recovery', note_spo2='Sleep SpO2 low',
+        stage_title='Sleep Stage Trend', recommend='Goal 7h',
+        deep='Deep', core='Core', awake='Awake',
+        spo2_title='SpO2 Trend', warn_line='95% alert',
+        avg_lbl='avg', min_lbl='min',
+        week_title='Weekly Summary', goal_lbl='Goal',
+        conclusion_title='Monthly Summary',
+        short='Sleep duration below goal this month', ok='Sleep duration on target this month',
+        spo2_bad='; SpO2 dropped below 90%, monitor closely',
+        spo2_ok='; no dangerous SpO2 lows detected',
+        generated='Generated',
+        data_source='Source: Apple HealthKit · For reference only',
+    ),
+    'ja': dict(
+        title='月間睡眠トレンド', suffix='夜の有効記録', source='Apple Health 睡眠ステージ / 血中酸素',
+        avg_sleep='平均睡眠', good_days='達成日数', deep_avg='深睡眠平均', min_spo2='最低血中酸素',
+        note_sleep='月間平均', note_good='≥7h の夜数', note_deep='深睡眠回復', note_spo2='睡眠中最低値',
+        stage_title='睡眠ステージ推移', recommend='目標 7h',
+        deep='深睡眠', core='コア', awake='覚醒',
+        spo2_title='血中酸素推移', warn_line='95% 警戒',
+        avg_lbl='平均', min_lbl='最低',
+        week_title='週間サマリー', goal_lbl='達成',
+        conclusion_title='月間まとめ',
+        short='今月の睡眠時間は目標未達', ok='今月の睡眠時間は概ね達成',
+        spo2_bad='；90%未満の低下あり、継続観察を推奨',
+        spo2_ok='；危険な血中酸素低下は見られない',
+        generated='生成日時',
+        data_source='データ：Apple HealthKit · 参考用のみ',
+    ),
+}
+T = STR[args.lang]
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+COL = {
+    'text':'#f8fafc','muted':'#94a3b8','blue':'#60a5fa','cyan':'#22d3ee',
+    'violet':'#a78bfa','amber':'#fbbf24','red':'#fb7185','green':'#34d399',
+    'deep':'#2563eb','core':'#22c1c3','rem':'#a78bfa','awake':'#fb923c',
+}
+
+# ── SVG helpers ───────────────────────────────────────────────────────────────
+def esc(x): return html.escape(str(x))
+def txt(x,y,s,size=22,color=None,weight=400,anchor='start'):
+    return (f'<text x="{x}" y="{y}" font-size="{size}" fill="{color or COL["text"]}"'
+            f' font-weight="{weight}" text-anchor="{anchor}">{esc(s)}</text>')
+def rct(x,y,w,h,r,fill,stroke='#ffffff22'):
+    return f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{r}" fill="{fill}" stroke="{stroke}"/>'
+def tspan_unit(x,y,val,unit,vsize,vcolor,usize,ucolor,weight=850):
+    return (f'<text x="{x}" y="{y}" font-size="{vsize}" fill="{vcolor}" font-weight="{weight}">'
+            f'{esc(val)}<tspan font-size="{usize}" fill="{ucolor}" dx="6">{esc(unit)}</tspan></text>')
+def line(x1,y1,x2,y2,color='#ffffff25',sw=1,dash=''):
+    da=f' stroke-dasharray="{dash}"' if dash else ''
+    return f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{sw}"{da}/>'
+
+ICON_PATHS = {
+    'moon':     '<path d="M12 3a6.6 6.6 0 0 0 8.8 8.8A9 9 0 1 1 12 3Z"/>',
+    'clock':    '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+    'bars':     '<path d="M3 3v18h18"/><path d="M7 16V9M12 16V5M17 16v-3"/>',
+    'droplet':  '<path d="M12 2.5S5.5 9.4 5.5 14A6.5 6.5 0 0 0 18.5 14C18.5 9.4 12 2.5 12 2.5Z"/>',
+    'activity': '<path d="M22 12h-4l-3 8L9 4l-3 8H2"/>',
+    'sparkles': '<path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3Z"/>',
+}
+def icon(name,x,y,size=28,color='currentColor',sw=2.2):
+    return (f'<svg x="{x}" y="{y}" width="{size}" height="{size}" viewBox="0 0 24 24" '
+            f'fill="none" stroke="{color}" stroke-width="{sw}" '
+            f'stroke-linecap="round" stroke-linejoin="round">{ICON_PATHS[name]}</svg>')
+
+def val_color(v): return COL['green'] if v>=7 else (COL['amber'] if v>=6 else COL['red'])
+
+# ── Parse data ────────────────────────────────────────────────────────────────
+def parse_dt(s): return datetime.strptime(s[:19], '%Y-%m-%dT%H:%M:%S')
+def sleep_date(dt): return (dt-timedelta(days=1)).date() if dt.hour<14 else dt.date()
+def hm(dt): return dt.hour+dt.minute/60
+
+STAGE_MAP = {'asleepDeep':'Deep','asleepREM':'REM','asleepCore':'Core','awake':'Awake','inBed':None}
+
+sleep_raw  = json.load(open(args.sleep))
+spo2_raw   = json.load(open(args.spo2))
+samples    = sleep_raw.get('samples', sleep_raw)
+spo2_samps = spo2_raw.get('samples', spo2_raw)
+
+nights = defaultdict(lambda: defaultdict(float))
+bed_h  = {}; wake_h = {}
+
+for s in samples:
+    raw = s.get('stage') or s.get('value') or s.get('sleepStage','')
+    stg = STAGE_MAP.get(raw)
+    ss  = s.get('startDate') or s.get('start')
+    ee  = s.get('endDate')   or s.get('end')
+    if not ss or not ee: continue
+    a=parse_dt(ss); b=parse_dt(ee); n=sleep_date(a)
+    dur=(b-a).total_seconds()/3600
+    if stg: nights[n][stg]+=dur
+    af=hm(a); af=af+24 if af<14 else af
+    bf=hm(b); bf=bf+24 if bf<14 else bf
+    bed_h[n] =min(bed_h.get(n,af),af)
+    wake_h[n]=max(wake_h.get(n,bf),bf)
+
+spo2_by = defaultdict(list)
+for s in spo2_samps:
+    v=s.get('percentage') or s.get('value')
+    if isinstance(v,(int,float)) and v>50:
+        spo2_by[sleep_date(parse_dt(s['date']))].append(float(v))
+
+valid = sorted([d for d in nights if sum(nights[d].values())>1])[-args.days:]
+if not valid: raise SystemExit('No sleep data.')
+
+rows=[]
+for d in valid:
+    st=nights[d]; total=sum(st.values()); sp=spo2_by.get(d,[])
+    rows.append(dict(
+        date=d, label=d.strftime('%m/%d'),
+        total=total,
+        deep=st.get('Deep',0), core=st.get('Core',0),
+        rem=st.get('REM',0),   awake=st.get('Awake',0),
+        spo2_mean=sum(sp)/len(sp) if sp else None,
+        spo2_min =min(sp) if sp else None,
+        bed =bed_h.get(d),
+    ))
+
+def _avg(xs): return sum(xs)/len(xs) if xs else 0
+avg_total = _avg([r['total'] for r in rows])
+avg_deep  = _avg([r['deep']  for r in rows])
+avg_rem   = _avg([r['rem']   for r in rows])
+spmins    = [r['spo2_min']  for r in rows if r['spo2_min']  is not None]
+spmeans   = [r['spo2_mean'] for r in rows if r['spo2_mean'] is not None]
+good      = sum(1 for r in rows if r['total']>=7)
+range_lbl = f"{rows[0]['label']}–{rows[-1]['label']}"
+
+# weekly buckets for summary
+weeks=[]
+for i in range(0,len(rows),7):
+    chunk=rows[i:i+7]
+    weeks.append((chunk[0]['label']+'–'+chunk[-1]['label'],
+                  _avg([r['total'] for r in chunk]),
+                  sum(1 for r in chunk if r['total']>=7)))
+
+# ── Layout ────────────────────────────────────────────────────────────────────
+W=1280; PAD=54; CW=W-PAD*2; GAP=24
+nb=len(rows)
+
+METRIC_H  =174
+STAGE_H   =520   # taller to accommodate rotated labels on 30 bars
+SPO2_H    =330
+WEEK_H    =len(weeks)*72+100
+CONCL_H   =120
+FOOTER_H  =60
+
+y_metrics =170
+y_stage   =y_metrics+METRIC_H+GAP
+y_spo2    =y_stage +STAGE_H +GAP
+y_week    =y_spo2  +SPO2_H  +GAP
+y_concl   =y_week  +WEEK_H  +GAP
+y_footer  =y_concl +CONCL_H +GAP
+TOTAL_H   =y_footer+FOOTER_H+50
+
+svg=[]
+svg.append(f'''<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{TOTAL_H}" viewBox="0 0 {W} {TOTAL_H}">
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#07111f"/><stop offset=".55" stop-color="#0b1020"/><stop offset="1" stop-color="#111827"/>
+  </linearGradient>
+  <linearGradient id="cardGrad" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#ffffff" stop-opacity=".105"/><stop offset="1" stop-color="#ffffff" stop-opacity=".035"/>
+  </linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0" stop-color="#38bdf8" stop-opacity=".5"/><stop offset="1" stop-color="#38bdf8" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowPurple" cx="50%" cy="50%" r="50%">
+    <stop offset="0" stop-color="#a78bfa" stop-opacity=".4"/><stop offset="1" stop-color="#a78bfa" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="shadow"><feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#000" flood-opacity=".3"/></filter>
+  <style><![CDATA[text{{font-family:'Noto Sans CJK SC','Noto Sans CJK','PingFang SC',Arial,sans-serif;text-rendering:geometricPrecision}}]]></style>
+</defs>
+<rect width="100%" height="100%" fill="url(#bg)"/>
+<circle cx="1150" cy="200" r="300" fill="url(#glowBlue)"/>
+<circle cx="80"   cy="{TOTAL_H-200}" r="280" fill="url(#glowPurple)"/>
+<g filter="url(#shadow)">
+''')
+
+# Header
+svg.append(txt(PAD,108,T['title'],54,COL['text'],850))
+svg.append(txt(PAD,152,f'{range_lbl} · {len(rows)} {T["suffix"]} · {T["source"]}',22,COL['muted']))
+svg.append(rct(920,60,306,56,28,'#ffffff12','#ffffff25'))
+svg.append(icon('sparkles',940,76,26,'#dbeafe'))
+svg.append(txt(976,97,'Sleep Intelligence',20,'#dbeafe',550))
+
+# Metric cards
+MCW,MCH,MGAP=272,METRIC_H,18
+METRICS=[
+    ('moon',    T['avg_sleep'],f'{avg_total:.1f}','h', T['note_sleep'],val_color(avg_total),val_color(avg_total)),
+    ('clock',   T['good_days'],str(good),         '',  f"{len(rows)} {T['note_good']}",COL['green'],COL['green']),
+    ('activity',T['deep_avg'], f'{avg_deep:.1f}', 'h', T['note_deep'], COL['violet'],   COL['violet']),
+    ('droplet', T['min_spo2'], f'{min(spmins):.1f}' if spmins else '—','%',T['note_spo2'],COL['red'],COL['red']),
+]
+for i,(ic,title,val,unit,note,color,vc) in enumerate(METRICS):
+    mx,my=PAD+i*(MCW+MGAP),y_metrics
+    svg.append(rct(mx,my,MCW,MCH,26,'url(#cardGrad)','#ffffff24'))
+    svg.append(txt(mx+22,my+40,title,19,COL['muted'],500))
+    svg.append(f'<rect x="{mx+MCW-66}" y="{my+18}" width="50" height="50" rx="16" fill="{color}" opacity=".16"/>')
+    svg.append(icon(ic,mx+MCW-56,my+27,26,color))
+    svg.append(tspan_unit(mx+22,my+108,val,unit,46,vc,22,COL['muted']))
+    svg.append(txt(mx+22,my+142,note,16,COL['muted']))
+
+# ── Panel 1: Stage trend ──────────────────────────────────────────────────────
+svg.append(rct(PAD,y_stage,CW,STAGE_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('bars',PAD+30,y_stage+28,30,COL['cyan']))
+svg.append(txt(PAD+74,y_stage+52,T['stage_title'],28,COL['text'],760))
+
+LEGEND=[(T['deep'],'deep'),(T['core'],'core'),('REM','rem'),(T['awake'],'awake')]
+for i,(lbl,key) in enumerate(LEGEND):
+    gx=PAD+380+i*195
+    svg.append(f'<circle cx="{gx}" cy="{y_stage+44}" r="7" fill="{COL[key]}"/>')
+    svg.append(txt(gx+16,y_stage+51,lbl,18,'#dbeafe',650))
+
+CHART_PAD_TOP=80; CHART_PAD_BOT=70   # 70px for rotated labels
+cx=PAD+60; cy=y_stage+CHART_PAD_TOP
+chart_w=CW-120; chart_h=STAGE_H-CHART_PAD_TOP-CHART_PAD_BOT
+
+# Global clip — prevents overflow in all directions
+svg.append(f'<clipPath id="stageClip"><rect x="{cx}" y="{cy}" width="{chart_w}" height="{chart_h}"/></clipPath>')
+
+svg.append(line(cx,cy+chart_h,cx+chart_w,cy+chart_h))
+target_y=cy+chart_h-7/9*chart_h
+svg.append(line(cx,target_y,cx+chart_w,target_y,COL['green'],2,'8 6'))
+svg.append(txt(cx+chart_w-72,target_y-10,T['recommend'],16,'#86efac',500))
+
+bar_gap=4
+bw=max(6,(chart_w-(nb-1)*bar_gap)/nb)
+
+svg.append('<g clip-path="url(#stageClip)">')
+for i,r in enumerate(rows):
+    bx=cx+i*(bw+bar_gap); by=cy+chart_h
+    for key,col in [('deep',COL['deep']),('core',COL['core']),('rem',COL['rem']),('awake',COL['awake'])]:
+        hh=r[key]/9*chart_h; by-=hh
+        svg.append(f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bw:.1f}" height="{hh:.1f}" rx="2" fill="{col}" opacity=".93"/>')
+svg.append('</g>')
+
+# Rotated date labels — outside stageClip, below baseline
+for i,r in enumerate(rows):
+    lx=cx+i*(bw+bar_gap)+bw/2; ly=cy+chart_h+14
+    svg.append(f'<text x="{lx:.1f}" y="{ly:.1f}" font-size="11" fill="{COL["muted"]}"'
+               f' text-anchor="end" transform="rotate(-45 {lx:.1f} {ly:.1f})">{esc(r["label"][3:])}</text>')
+
+# ── Panel 2: SpO2 trend ───────────────────────────────────────────────────────
+svg.append(rct(PAD,y_spo2,CW,SPO2_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('droplet',PAD+30,y_spo2+28,30,COL['blue']))
+svg.append(txt(PAD+74,y_spo2+52,T['spo2_title'],28,COL['text'],760))
+
+ax=cx; ay=y_spo2+88; aw=chart_w; ah=SPO2_H-130
+# clipPath for SpO2 chart area
+svg.append(f'<clipPath id="spo2Clip"><rect x="{ax}" y="{ay}" width="{aw}" height="{ah}"/></clipPath>')
+svg.append(line(ax,ay+ah,ax+aw,ay+ah))
+svg.append(line(ax,ay,ax,ay+ah,'#ffffff18'))
+for pct in [90,95,100]:
+    gy=ay+ah-(pct-85)/15*ah
+    svg.append(line(ax,gy,ax+aw,gy,'#ffffff15',1,'5 4'))
+    svg.append(txt(ax-8,gy+5,str(pct),14,COL['muted'],400,'end'))
+svg.append(line(ax,ay+ah-(95-85)/15*ah,ax+aw,ay+ah-(95-85)/15*ah,COL['amber'],1.5,'7 5'))
+svg.append(txt(ax+aw+8,ay+ah-(95-85)/15*ah+5,T['warn_line'],13,COL['amber']))
+
+# min SpO2 line — clipped to chart bounds
+pts=[]
+step=aw/max(1,nb-1) if nb>1 else 0
+for i,r in enumerate(rows):
+    if r['spo2_min'] is None: continue
+    bx=ax+i*step; by2=ay+ah-(r['spo2_min']-85)/15*ah
+    col=COL['red'] if r['spo2_min']<90 else COL['blue']
+    pts.append((bx,by2,r,col))
+svg.append('<g clip-path="url(#spo2Clip)">')
+for (x1,y1,_,__),(x2,y2,_,__) in zip(pts,pts[1:]):
+    svg.append(line(x1,y1,x2,y2,COL['blue'],2.5))
+for bx,by2,r,col in pts:
+    svg.append(f'<circle cx="{bx:.1f}" cy="{by2:.1f}" r="5" fill="{col}"/>')
+svg.append('</g>')
+
+sp_stat=f'{T["avg_lbl"]} {_avg(spmeans):.1f}%  ·  {T["min_lbl"]} {min(spmins):.1f}%' if spmins else ''
+svg.append(txt(ax,ay+ah+28,sp_stat,18,COL['muted']))
+
+# ── Panel 3: Weekly summary ───────────────────────────────────────────────────
+svg.append(rct(PAD,y_week,CW,WEEK_H,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('activity',PAD+30,y_week+28,30,COL['violet']))
+svg.append(txt(PAD+74,y_week+52,T['week_title'],28,COL['text'],760))
+
+for i,(lab,av,gd) in enumerate(weeks):
+    ry=y_week+80+i*72
+    svg.append(rct(PAD+20,ry,CW-40,60,20,'#0f172acc','#ffffff18'))
+    svg.append(txt(PAD+40,ry+37,lab,20,COL['text'],700))
+    svg.append(txt(PAD+40+340,ry+37,f'{av:.1f}h',20,val_color(av),760))
+    svg.append(txt(PAD+40+460,ry+37,f'{gd} {T["goal_lbl"]}',18,COL['green'] if gd>=5 else COL['amber'],500))
+
+# ── Conclusion banner ─────────────────────────────────────────────────────────
+svg.append(rct(PAD,y_concl,CW,CONCL_H,30,'#0f172acc','#ffffff1e'))
+summary = T['ok'] if avg_total>=7 else T['short']
+spo2_note = T['spo2_bad'] if spmins and min(spmins)<90 else T['spo2_ok']
+conc = f'{summary}：{T["avg_lbl"]} {avg_total:.1f}h，{good}/{len(rows)} {T["note_good"]}。深睡 {avg_deep:.1f}h，REM {avg_rem:.1f}h{spo2_note}。' if args.lang=='zh' else \
+       f'{summary}: avg {avg_total:.1f}h, {good}/{len(rows)} {T["note_good"]}, Deep {avg_deep:.1f}h, REM {avg_rem:.1f}h{spo2_note}.' if args.lang=='en' else \
+       f'{summary}：平均 {avg_total:.1f}h、{good}/{len(rows)} {T["note_good"]}。深睡眠 {avg_deep:.1f}h、REM {avg_rem:.1f}h{spo2_note}。'
+svg.append(txt(PAD+22,y_concl+46,T['conclusion_title'],26,COL['text'],800))
+svg.append(txt(PAD+22,y_concl+86,conc,19,'#cbd5e1'))
+
+# ── Footer ────────────────────────────────────────────────────────────────────
+svg.append(rct(PAD,y_footer,310,40,20,'#ffffff0a','#ffffff18'))
+svg.append(txt(PAD+18,y_footer+26,f"{T['generated']}: {date.today()}",16,COL['muted']))
+svg.append(txt(W-PAD,y_footer+26,T['data_source'],16,COL['muted'],400,'end'))
+svg.append('</g></svg>')
+
+svg_path=Path(args.out_prefix+'.svg')
+png_path=Path(args.out_prefix+'.png')
+svg_path.write_text('\n'.join(svg))
+subprocess.run(['rsvg-convert',str(svg_path),'-w',str(W),'-o',str(png_path)],check=True)
+print(png_path)

--- a/health-sleep-analysis/sleep_report_data.py
+++ b/health-sleep-analysis/sleep_report_data.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import json, math, argparse
+from datetime import datetime, timedelta, date
+from collections import defaultdict
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--sleep', default='/var/minis/workspace/sleep_raw.json')
+parser.add_argument('--spo2',  default='/var/minis/workspace/spo2_raw.json')
+parser.add_argument('--out',   default='/var/minis/workspace/sleep_report_7d.json')
+args = parser.parse_args()
+
+sleep_data=json.load(open(args.sleep))
+spo2_data=json.load(open(args.spo2))
+samples=sleep_data.get('samples', sleep_data)
+spo2_samples=spo2_data.get('samples', spo2_data)
+STAGE_MAP={'asleepDeep':'Deep','asleepREM':'REM','asleepCore':'Core','awake':'Awake','inBed':None}
+
+def parse_dt(s): return datetime.strptime(s[:19], '%Y-%m-%dT%H:%M:%S')
+def sleep_date(dt): return (dt-timedelta(days=1)).date() if dt.hour<14 else dt.date()
+def hm_float(dt): return dt.hour+dt.minute/60
+
+def fmt_h(v):
+    if v is None or math.isnan(v): return '—'
+    h=int(v); m=int(round((v-h)*60))
+    if m==60: h+=1; m=0
+    return f'{h%24:02d}:{m:02d}'
+
+nights=defaultdict(lambda: defaultdict(float)); bed={}; wake={}; segments=defaultdict(list)
+for s in samples:
+    raw=s.get('stage') or s.get('value') or s.get('sleepStage','')
+    stage=STAGE_MAP.get(raw)
+    st=s.get('startDate') or s.get('start'); en=s.get('endDate') or s.get('end')
+    if not st or not en: continue
+    a=parse_dt(st); b=parse_dt(en); n=sleep_date(a); dur=(b-a).total_seconds()/3600
+    if stage: nights[n][stage]+=dur; segments[n].append({'stage':stage,'start':a.isoformat(),'end':b.isoformat(),'hours':dur})
+    af=hm_float(a); af=af+24 if af<14 else af
+    bf=hm_float(b); bf=bf+24 if bf<14 else bf
+    bed[n]=min(bed.get(n,af),af); wake[n]=max(wake.get(n,bf),bf)
+
+spo2=defaultdict(list)
+for s in spo2_samples:
+    dt=parse_dt(s['date']); val=s.get('percentage') or s.get('value')
+    if isinstance(val,(int,float)) and val>50: spo2[sleep_date(dt)].append(float(val))
+
+valid=sorted([d for d in nights if sum(nights[d].values())>1])[-7:]
+rows=[]
+for d in valid:
+    st=nights[d]; total=sum(st.values()); sp=spo2.get(d,[])
+    rows.append({
+        'date':str(d),'label':d.strftime('%m/%d'),'weekday':'一二三四五六日'[d.weekday()],
+        'total':round(total,2),'deep':round(st.get('Deep',0),2),'rem':round(st.get('REM',0),2),'core':round(st.get('Core',0),2),'awake':round(st.get('Awake',0),2),
+        'deep_pct':round(st.get('Deep',0)/total*100,1) if total else 0,
+        'rem_pct':round(st.get('REM',0)/total*100,1) if total else 0,
+        'spo2_mean':round(float(np.mean(sp)),1) if sp else None,
+        'spo2_min':round(float(min(sp)),1) if sp else None,
+        'bed':fmt_h(bed.get(d,0)%24) if d in bed else '—',
+        'wake':fmt_h(wake.get(d,0)%24) if d in wake else '—'
+    })
+summary={
+    'days':len(rows),
+    'avg_total':round(float(np.mean([r['total'] for r in rows])),1) if rows else 0,
+    'avg_deep':round(float(np.mean([r['deep'] for r in rows])),1) if rows else 0,
+    'avg_rem':round(float(np.mean([r['rem'] for r in rows])),1) if rows else 0,
+    'avg_spo2':round(float(np.mean([r['spo2_mean'] for r in rows if r['spo2_mean']])),1) if any(r['spo2_mean'] for r in rows) else None,
+    'min_spo2':round(float(min([r['spo2_min'] for r in rows if r['spo2_min']])),1) if any(r['spo2_min'] for r in rows) else None,
+    'good_days':sum(1 for r in rows if r['total']>=7),
+    'range': (rows[0]['label']+'–'+rows[-1]['label']) if rows else ''
+}
+json.dump({'summary':summary,'rows':rows}, open(args.out,'w'), ensure_ascii=False, indent=2)
+print(args.out)

--- a/health-sleep-analysis/sleep_report_librsvg.py
+++ b/health-sleep-analysis/sleep_report_librsvg.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+import json, subprocess, html, argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--data',       default='/var/minis/workspace/sleep_report_7d.json')
+parser.add_argument('--out-prefix', default='/var/minis/workspace/sleep_report_7d_librsvg')
+parser.add_argument('--lang',       default='zh', choices=['zh','en','ja'])
+parser.add_argument('--width',  type=int, default=1280)
+parser.add_argument('--height', type=int, default=1760)
+args = parser.parse_args()
+
+STRINGS = {
+    'zh': dict(title='最近一周睡眠周报', suffix='夜有效记录', source_suffix='Apple Health 睡眠阶段 / 血氧',
+               avg_sleep='平均睡眠', good_days='达标天数', deep_avg='深睡均值', min_spo2='最低血氧',
+               stage_trend='睡眠阶段趋势', recommend='推荐 7h', key_insights='关键洞察', daily_detail='每日明细',
+               deep='深睡', core='浅睡', awake='清醒', bedtime='入睡', min_o2='最低氧',
+               spo2_section='睡眠期最低血氧', generated='生成时间',
+               data_source='数据来源：Apple HealthKit · 仅供健康趋势参考',
+               note_duration='低于推荐 7h，优先补时长', note_good='夜有效记录', note_deep='深睡略偏少，恢复不足', note_spo2='建议持续观察',
+               ins_duration_t='主问题：睡眠时长不足', ins_bedtime_t='作息偏晚', ins_spo2_t='血氧均值正常，低点需观察',
+               ins_bedtime_b_tpl='平均入睡 {bed}，建议先提前到 00:30 前。'),
+    'en': dict(title='Weekly Sleep Report', suffix='nights recorded', source_suffix='Apple Health Sleep Stages / SpO2',
+               avg_sleep='Avg Sleep', good_days='Goal Days', deep_avg='Avg Deep', min_spo2='Min SpO2',
+               stage_trend='Sleep Stage Trend', recommend='Goal 7h', key_insights='Key Insights', daily_detail='Daily Detail',
+               deep='Deep', core='Core', awake='Awake', bedtime='Bedtime', min_o2='Min O2',
+               spo2_section='Nightly Min SpO2', generated='Generated',
+               data_source='Source: Apple HealthKit · For reference only',
+               note_duration='Below 7h goal, prioritize sleep', note_good='nights recorded', note_deep='Low deep sleep', note_spo2='Monitor closely',
+               ins_duration_t='Issue: Sleep Too Short', ins_bedtime_t='Late Bedtime', ins_spo2_t='SpO2 avg OK, low dips noted',
+               ins_bedtime_b_tpl='Avg bedtime {bed}. Aim for before 00:30.'),
+    'ja': dict(title='週間睡眠レポート', suffix='夜の有効記録', source_suffix='Apple Health 睡眠ステージ / 血中酸素',
+               avg_sleep='平均睡眠', good_days='達成日数', deep_avg='深睡眠平均', min_spo2='最低血中酸素',
+               stage_trend='睡眠ステージ推移', recommend='目標 7h', key_insights='重要インサイト', daily_detail='日別明細',
+               deep='深睡眠', core='コア', awake='覚醒', bedtime='就寝', min_o2='最低O2',
+               spo2_section='夜間最低血中酸素', generated='生成日時',
+               data_source='データ：Apple HealthKit · 参考用のみ',
+               note_duration='7h未満、まず睡眠時間を確保', note_good='夜の有効記録', note_deep='深睡眠が少ない', note_spo2='継続観察を推奨',
+               ins_duration_t='問題：睡眠時間不足', ins_bedtime_t='就寝時刻が遅い', ins_spo2_t='血中酸素平均は正常、低下に注意',
+               ins_bedtime_b_tpl='平均就寝 {bed}。00:30前を目標に。'),
+}
+T = STRINGS[args.lang]
+
+data = json.loads(Path(args.data).read_text())
+S, R = data['summary'], data['rows']
+W, H = args.width, args.height
+
+# Compute average bedtime from actual data for the insight card
+def _avg_bed():
+    beds = [r['bed'] for r in R if r.get('bed') and r['bed'] != '—']
+    if not beds: return '—'
+    # parse HH:MM, convert to float hours adjusted for cross-midnight
+    def to_h(s):
+        h, m = int(s[:2]), int(s[3:])
+        f = h + m/60
+        return f + 24 if f < 14 else f
+    avg = sum(to_h(b) for b in beds) / len(beds)
+    h = int(avg % 24); m = int((avg % 1) * 60)
+    return f'{h:02d}:{m:02d}'
+
+avg_bed_str = _avg_bed()
+T_bedtime_b = T['ins_bedtime_b_tpl'].format(bed=avg_bed_str)
+
+SVG_PATH = Path(args.out_prefix + '.svg')
+PNG_PATH = Path(args.out_prefix + '.png')
+
+COL = {
+    'bg0':'#07111f','bg1':'#0b1020','card':'#111827','card2':'#0f172a','line':'#26324a',
+    'text':'#f8fafc','muted':'#94a3b8','blue':'#60a5fa','cyan':'#22d3ee','violet':'#a78bfa',
+    'amber':'#fbbf24','red':'#fb7185','green':'#34d399','deep':'#2563eb','core':'#22c1c3','rem':'#a78bfa','awake':'#fb923c'
+}
+
+def esc(x): return html.escape(str(x))
+def icon(name, x, y, size=28, color='currentColor', sw=2.3):
+    paths = {
+        'moon': '<path d="M12 3a6.6 6.6 0 0 0 8.8 8.8A9 9 0 1 1 12 3Z"/>',
+        'clock': '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+        'heart': '<path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 0 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8Z"/>',
+        'droplet': '<path d="M12 2.5S5.5 9.4 5.5 14A6.5 6.5 0 0 0 18.5 14C18.5 9.4 12 2.5 12 2.5Z"/>',
+        'alert': '<path d="M10.3 3.9 1.9 18a2 2 0 0 0 1.7 3h16.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/><path d="M12 9v4M12 17h.01"/>',
+        'bars': '<path d="M3 3v18h18"/><path d="M7 16V9M12 16V5M17 16v-3"/>',
+        'activity': '<path d="M22 12h-4l-3 8L9 4l-3 8H2"/>',
+        'sparkles': '<path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3Z"/><path d="M19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8L19 15Z"/>'
+    }
+    return f'<svg x="{x}" y="{y}" width="{size}" height="{size}" viewBox="0 0 24 24" fill="none" stroke="{color}" stroke-width="{sw}" stroke-linecap="round" stroke-linejoin="round">{paths[name]}</svg>'
+
+def total_cls(v):
+    return COL['green'] if v >= 7 else (COL['amber'] if v >= 6 else COL['red'])
+
+def rounded_rect(x,y,w,h,r,fill,stroke='#ffffff22',opacity=1):
+    return f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{r}" fill="{fill}" stroke="{stroke}" opacity="{opacity}"/>'
+
+def text(x,y,content,size=24,color=None,weight=400,anchor='start',opacity=1):
+    return f'<text x="{x}" y="{y}" font-size="{size}" fill="{color or COL["text"]}" font-weight="{weight}" text-anchor="{anchor}" opacity="{opacity}">{esc(content)}</text>'
+
+def metric_card(x,y,w,h,icon_name,title,value,unit,note,color,value_color=None):
+    s=[]
+    s.append(rounded_rect(x,y,w,h,28,'url(#cardGrad)','#ffffff24'))
+    s.append(text(x+24,y+42,title,20,COL['muted'],500))
+    s.append(f'<rect x="{x+w-76}" y="{y+22}" width="54" height="54" rx="17" fill="{color}" opacity=".16"/>')
+    s.append(icon(icon_name,x+w-63,y+35,28,color))
+    # librsvg 对不同字体的数字宽度估算不稳定，使用单个 <text> + tspan 避免单位错位
+    s.append(
+        f'<text x="{x+24}" y="{y+116}" font-size="50" fill="{value_color or color}" font-weight="850">'
+        f'{esc(value)}<tspan font-size="24" fill="{COL["muted"]}" font-weight="650" dx="8">{esc(unit)}</tspan></text>'
+    )
+    s.append(text(x+24,y+152,note,18,COL['muted'],400))
+    return '\n'.join(s)
+
+svg=[]
+svg.append(f'''<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}">
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#07111f"/><stop offset=".55" stop-color="#0b1020"/><stop offset="1" stop-color="#111827"/></linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="#38bdf8" stop-opacity=".55"/><stop offset="1" stop-color="#38bdf8" stop-opacity="0"/></radialGradient>
+  <radialGradient id="glowPurple" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="#a78bfa" stop-opacity=".45"/><stop offset="1" stop-color="#a78bfa" stop-opacity="0"/></radialGradient>
+  <linearGradient id="cardGrad" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff" stop-opacity=".105"/><stop offset="1" stop-color="#ffffff" stop-opacity=".035"/></linearGradient>
+  <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity=".34"/></filter>
+  <style><![CDATA[
+    text{{font-family:'Noto Sans CJK SC','Noto Sans CJK SC Regular','Noto Sans CJK','PingFang SC',Arial,sans-serif;text-rendering:geometricPrecision}}
+  ]]></style>
+</defs>
+<rect width="100%" height="100%" fill="url(#bg)"/>
+<circle cx="1190" cy="180" r="270" fill="url(#glowBlue)"/>
+<circle cx="0" cy="1540" r="260" fill="url(#glowPurple)"/>
+<g filter="url(#shadow)">
+''')
+# header
+svg.append(text(54,108,T['title'],58,COL['text'],850))
+svg.append(text(56,152,f"{S['range']} · {S['days']} {T['suffix']} · {T['source_suffix']}",25,COL['muted'],400))
+svg.append(rounded_rect(950,62,270,60,30,'#ffffff12','#ffffff25'))
+svg.append(icon('sparkles',972,78,28,'#dbeafe'))
+svg.append(text(1016,101,'Sleep Intelligence',22,'#dbeafe',550))
+
+# metrics
+mx,my,gap,cw,ch=54,210,20,280,174
+cards=[
+    ('moon', T['avg_sleep'],  S['avg_total'], 'h', T['note_duration'], COL['blue'],   total_cls(S['avg_total'])),
+    ('clock',T['good_days'],  S['good_days'], '',  f"{S['days']} {T['note_good']}",   COL['green'],  COL['green']),
+    ('heart',T['deep_avg'],   S['avg_deep'],  'h', T['note_deep'],     COL['violet'], COL['violet']),
+    ('droplet',T['min_spo2'], S['min_spo2'],  '%', T['note_spo2'],     COL['red'],    COL['red']),
+]
+for i,c in enumerate(cards): svg.append(metric_card(mx+i*(cw+gap),my,cw,ch,*c))
+
+# main stage panel
+px,py,pw,ph=54,420,1172,520
+svg.append(rounded_rect(px,py,pw,ph,36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('bars',px+30,py+29,31,COL['cyan']))
+svg.append(text(px+76,py+55,T['stage_trend'],30,COL['text'],760))
+chart_x,chart_y,chart_w,chart_h=px+40,py+112,pw-80,320
+svg.append(f'<line x1="{chart_x}" y1="{chart_y+chart_h}" x2="{chart_x+chart_w}" y2="{chart_y+chart_h}" stroke="#ffffff24"/>')
+target_y=chart_y+chart_h-7/8*chart_h
+svg.append(f'<line x1="{chart_x}" y1="{target_y}" x2="{chart_x+chart_w}" y2="{target_y}" stroke="{COL['green']}" stroke-width="2" stroke-dasharray="8 8" opacity=".75"/>')
+svg.append(text(chart_x+chart_w-82,target_y-12,T['recommend'],18,'#86efac',500))
+bar_w=82; step=chart_w/len(R)
+for i,r in enumerate(R):
+    cx=chart_x+i*step+step/2-bar_w/2
+    svg.append(f'<clipPath id="clip{i}"><rect x="{cx}" y="{chart_y}" width="{bar_w}" height="{chart_h}" rx="26"/></clipPath>')
+    svg.append(f'<rect x="{cx}" y="{chart_y}" width="{bar_w}" height="{chart_h}" rx="26" fill="#0f172a" stroke="#ffffff18"/>')
+    y=chart_y+chart_h
+    for key,col in [('deep',COL['deep']),('core',COL['core']),('rem',COL['rem']),('awake',COL['awake'])]:
+        hh=r[key]/8*chart_h; y-=hh
+        svg.append(f'<rect clip-path="url(#clip{i})" x="{cx}" y="{y}" width="{bar_w}" height="{hh}" fill="{col}" opacity=".95"/>')
+    svg.append(text(cx+bar_w/2,chart_y+chart_h+38,f"{r['total']:.1f}h",21,total_cls(r['total']),780,'middle'))
+    svg.append(text(cx+bar_w/2,chart_y+chart_h+68,f"{r['label']} {r['weekday']}",18,COL['muted'],400,'middle'))
+legend_items=[('deep',COL['deep'],T['deep']),('core',COL['core'],T['core']),('rem',COL['rem'],'REM'),('awake',COL['awake'],T['awake'])]
+lx0,ly2=px+365,py+48
+for idx,(name,col,lbl) in enumerate(legend_items):
+    gx=lx0+idx*190
+    svg.append(f'<circle cx="{gx}" cy="{ly2}" r="7" fill="{col}"/>')
+    svg.append(text(gx+16,ly2+7,lbl,19,'#dbeafe',650))
+
+# lower panels
+for p in [(54,970,620,620),(698,970,528,620)]: svg.append(rounded_rect(*p[:4],36,'url(#cardGrad)','#ffffff24'))
+svg.append(icon('moon',84,1000,31,COL['blue'])); svg.append(text(130,1027,T['daily_detail'],30,COL['text'],760))
+row_y=1060
+for r in R:
+    svg.append(rounded_rect(84,row_y,560,70,22,'#0f172acc','#ffffff18'))
+    svg.append(text(104,row_y+31,r['label'],20,COL['text'],760))
+    svg.append(text(104,row_y+54,r['weekday'],15,COL['muted']))
+    bx,by,bw,bh=198,row_y+28,250,18
+    svg.append(f'<rect x="{bx}" y="{by}" width="{bw}" height="{bh}" rx="9" fill="#243047"/>')
+    svg.append(f'<rect x="{bx}" y="{by}" width="{min(bw,r['total']/7*bw)}" height="{bh}" rx="9" fill="url(#barFill)"/>')
+    svg.append(f'<defs><linearGradient id="barFill" x1="0" x2="1"><stop offset="0" stop-color="{COL['blue']}"/><stop offset=".55" stop-color="{COL['cyan']}"/><stop offset="1" stop-color="{COL['violet']}"/></linearGradient></defs>')
+    svg.append(text(472,row_y+31,r['bed'],19,'#dbeafe',550,'end'))
+    svg.append(text(472,row_y+53,T['bedtime'],14,COL['muted'],400,'end'))
+    spcol=COL['red'] if r['spo2_min']<90 else (COL['amber'] if r['spo2_min']<95 else COL['green'])
+    svg.append(text(620,row_y+31,str(r['spo2_min'])+'%',19,spcol,650,'end'))
+    svg.append(text(620,row_y+53,T['min_o2'],14,COL['muted'],400,'end'))
+    row_y+=84
+
+svg.append(icon('activity',728,1000,31,COL['violet'])); svg.append(text(774,1027,T['key_insights'],30,COL['text'],760))
+ins=[
+    ('alert', COL['red'],    T['ins_duration_t'], f"{T['avg_sleep']} {S['avg_total']}h. {T['note_duration']}."),
+    ('clock', COL['amber'],  T['ins_bedtime_t'],  T_bedtime_b),
+    ('droplet',COL['cyan'],  T['ins_spo2_t'],     f"avg {S['avg_spo2']}%, min {S['min_spo2']}%. {T['note_spo2']}."),
+]
+y=1060
+for ic,col,title,body in ins:
+    svg.append(rounded_rect(728,y,468,95,24,'#0f172acc','#ffffff18'))
+    svg.append(f'<rect x="{750}" y="{y+20}" width="48" height="48" rx="16" fill="{col}" opacity=".16"/>')
+    svg.append(icon(ic,761,y+30,25,col))
+    svg.append(text(816,y+38,title,21,COL['text'],760))
+    words=list(body); line=''; lines=[]
+    for ch in words:
+        line+=ch
+        if len(line)>=27: lines.append(line); line=''
+    if line: lines.append(line)
+    for j,ln in enumerate(lines[:2]): svg.append(text(816,y+65+j*18,ln,14,'#cbd5e1',400))
+    y+=111
+svg.append(text(728,1415,T['spo2_section'],20,'#cbd5e1',500))
+cx0,cy0,cw2,ch2=728,1448,468,88
+mini_step=cw2/len(R)
+for i,r in enumerate(R):
+    h=max(18,(r['spo2_min']-85)/15*ch2)
+    x=cx0+i*mini_step+20; y=cy0+ch2-h
+    col=COL['red'] if r['spo2_min']<90 else COL['blue']
+    svg.append(f'<rect x="{x}" y="{y}" width="42" height="{h}" rx="11" fill="{col}" opacity=".9"/>')
+    svg.append(text(x+21,y-10,str(r['spo2_min'])+'%',13,'#cbd5e1',500,'middle'))
+    svg.append(text(x+21,cy0+ch2+24,r['label'][3:],13,'#64748b',400,'middle'))
+
+from datetime import date as _date
+svg.append(rounded_rect(54,1698,340,42,21,'#ffffff0a','#ffffff18'))
+svg.append(text(76,1725,f"{T['generated']}: {_date.today()}",17,COL['muted']))
+svg.append(text(1226,1725,T['data_source'],17,COL['muted'],400,'end'))
+svg.append('</g></svg>')
+SVG_PATH.write_text('\n'.join(svg))
+subprocess.run(['rsvg-convert', str(SVG_PATH), '-w', str(W), '-h', str(H), '-o', str(PNG_PATH)], check=True)
+print(PNG_PATH)


### PR DESCRIPTION
## 睡眠健康分析 Skill

从 Apple HealthKit 读取睡眠、血氧、心率、HRV 数据，生成可视化健康报告。

### 功能

- **7 天周报卡片**：睡眠阶段（Deep/REM/Core/Awake）堆叠图 + 血氧趋势 + 每日明细，via rsvg-convert 渲染 SVG/PNG
- **30 天月度趋势**：睡眠时长趋势 + 阶段占比，via rsvg-convert
- **半年 / 全年长期趋势**：周聚合 / 月聚合折线图，via librsvg + matplotlib
- **心脏健康分析**：静息心率、HRV、最大心率、SpO2 综合评估

### 多语言支持

通过 `--lang zh|en|ja` 参数切换图表文字语言，回复语言自动跟随用户输入。

### 包含文件

| 文件 | 说明 |
|---|---|
| `SKILL.md` | 完整使用文档（快速开始 / 参数说明 / 健康标准） |
| `sleep_report_data.py` | 从原始 HealthKit JSON 提取 7 日报告数据 |
| `sleep_report_librsvg.py` | 渲染 7 日周报卡片 → SVG + PNG |
| `sleep_month_trend_librsvg.py` | 渲染 30 日月度趋势图 |
| `sleep_longterm_librsvg.py` | 渲染半年 / 全年长期趋势图 |
| `sleep_halfyear.py` | matplotlib 版长期趋势，cd 到工作目录运行 |