### PR TITLE
feat(quark-hub): v1.4 — background download with progress & pre-save dedup check

### DIFF
--- a/quark-hub/SKILL.md
+++ b/quark-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quark-hub
-version: 1.3.0
+version: 1.4.0
 description: 夸克网盘文件管理工具。支持登录、列目录、转存分享链接、下载文件、创建目录。登录改用 minis-browser-use 替代原项目的 Playwright。当用户提到「夸克网盘」「夸克下载」「夸克转存」「quark」「pan.quark.cn」时触发本技能。
 ---
 
@@ -24,7 +24,7 @@ description: 夸克网盘文件管理工具。支持登录、列目录、转存�
 | 包 | 来源 | 用途 |
 |---|---|---|
 | `aiohttp` | Alpine 原生 (`py3-aiohttp`) | 所有 async HTTP 请求 |
-| 标准库 | Python 内置 | asyncio / json / re / urllib 等 |
+| 标准库 | Python 内置 | asyncio / json / re / urllib / threading 等 |
 
 若 `aiohttp` 不可用：
 ```bash
@@ -39,9 +39,44 @@ apk add py3-aiohttp
 | `tree-share <url>` | 🔓 无需 | 递归展开分享链接完整文件树 |
 | `info` | 🔒 需要 | 查看账号信息和容量 |
 | `ls [fid]` | 🔒 需要 | 列出自己网盘目录（含 fid） |
-| `save <url> [fid]` | 🔒 需要 | 转存分享文件到网盘 |
-| `dl <url> [dir]` | 🔒 需要 | 下载自己分享的文件到本地 |
+| `save <url> [fid]` | 🔒 需要 | 转存分享文件到网盘（自动检查是否已存在） |
+| `dl <url> [dir]` | 🔒 需要 | 下载自己网盘的文件到本地（后台线程+进度） |
 | `mkdir <name> [fid]` | 🔒 需要 | 创建网盘目录 |
+
+## ⚡ 转存 + 下载最佳流程（Agent 必读）
+
+**下载他人分享文件时，按以下顺序执行，避免重复转存：**
+
+```
+1. tree-share <url>           # 看清楚分享里有什么
+2. ls [to_fid]                # 检查目标网盘目录是否已有同名内容
+3a. 已有 → 直接取 fid 下载    # 跳过转存，用现有 fid 调 api_get_download_urls
+3b. 没有 → save <url>         # 转存（内部也会自动检查，已有则跳过）
+4. ls [to_fid]                # 取得转存后文件的 fid
+5. dl（传 extra_fids）         # 后台线程下载，自动打印进度和1min均速
+```
+
+**关键：`save` 命令现在会自动检查目标目录是否已有同名文件，有则跳过转存。**
+但 agent 仍应在调用 `save` 前先 `ls` 确认，避免不必要的网络请求。
+
+## 下载注意事项
+
+- `dl` / `download_files_bg` 只能下载**自己网盘**内的文件（夸克接口限制）
+- 他人分享 → 先 `save` 转存 → 再 `ls` 取 fid → 再 `dl`
+- 下载使用**后台线程**，每 10 秒打印进度（已下/总大小/百分比/1min均速）
+- 下载 URL 指向阿里云 OSS，headers 不能带 `Content-Type`（已在代码中处理）
+- 字幕等文件可通过 `rename_map` 参数在下载时同步重命名（如与视频同名）
+
+## 代码级 API（供脚本 import 使用）
+
+```python
+from quark_hub import (
+    ensure_cookie,           # 获取/校验 Cookie，失效时 sys.exit(10)
+    api_get_download_urls,   # 传 fid 列表 → 返回含 download_url 的 dict 列表
+    download_files_bg,       # 后台线程下载，传 items=[{file_name, download_url, save_name?}]
+    api_list_all,            # 列出网盘目录
+)
+```
 
 ## 登录流程（agent 执行）
 
@@ -50,8 +85,6 @@ agent 按以下步骤完成登录：
 
 ### 步骤 1：给用户一个可点击的登录链接
 
-在 chat 中输出 Markdown 链接让用户点击打开夸克登录页：
-
 ```markdown
 请先登录夸克网盘：[点击登录夸克网盘](https://pan.quark.cn)
 登录完成后告诉我～
@@ -59,32 +92,14 @@ agent 按以下步骤完成登录：
 
 ### 步骤 2：用户确认登录后，提取 Cookie 并保存
 
-**关键：必须先 navigate 打开夸克页面刷新一次，让 WebView 与服务器交换最新 Cookie，然后再 get_cookies。**
-
-最简方式——直接调用封装好的脚本：
-
 ```bash
 sh /var/minis/skills/quark-hub/scripts/refresh_cookie.sh
 ```
-
-该脚本内部执行：navigate → sleep 3 → get_cookies → source env → 写入 `~/.quark_hub_cookie`。
 
 ### 步骤 3：验证登录成功
 
 ```bash
 python3 /var/minis/skills/quark-hub/quark_hub.py info
-```
-
-### 完整伪代码
-
-```
-1. 运行命令 → exit code 10？
-2. YES → 输出可点击链接：[点击登录夸克网盘](https://pan.quark.cn)
-3. 用户确认已登录 →
-     a. browser_use navigate https://pan.quark.cn （刷新 Cookie）
-     b. 等待几秒
-     c. browser_use get_cookies → 提取 env 文件路径 → source → 写文件
-4. 验证 info → 重新运行原命令
 ```
 
 ## 使用示例
@@ -93,14 +108,14 @@ python3 /var/minis/skills/quark-hub/quark_hub.py info
 S=/var/minis/skills/quark-hub/quark_hub.py
 
 # 🔓 无需登录
-python3 $S ls-share   "https://pan.quark.cn/s/6095134522b4"
-python3 $S tree-share "https://pan.quark.cn/s/6095134522b4"
+python3 $S ls-share   "https://pan.quark.cn/s/xxxxxxxx"
+python3 $S tree-share "https://pan.quark.cn/s/xxxxxxxx"
 
-# 🔒 需要登录（Cookie 有效时直接执行，无效时 exit 10）
+# 🔒 需要登录
 python3 $S info
 python3 $S ls
 python3 $S ls <fid>
-python3 $S save "https://pan.quark.cn/s/xxxxxxxx"
+python3 $S save "https://pan.quark.cn/s/xxxxxxxx"         # 自动检查已有 → 跳过或转存
 python3 $S save "https://pan.quark.cn/s/xxxxxxxx?pwd=1234" <目标fid>
 python3 $S dl   "https://pan.quark.cn/s/xxxxxxxx" /var/minis/workspace/
 python3 $S mkdir 我的电影
@@ -108,7 +123,5 @@ python3 $S mkdir 我的电影
 
 ## 注意事项
 
-- `dl` 只能下载**自己网盘**的文件（夸克接口限制），他人分享需先 `save` 转存
 - Cookie 有效期约 7–30 天，失效后重新登录即可
-- 下载 URL 指向阿里云 OSS，headers 中不能带 `Content-Type: application/json`（已在代码中处理）
 - 严禁用于非法用途，本工具仅调用夸克官方 API

--- a/quark-hub/quark_hub.py
+++ b/quark-hub/quark_hub.py
@@ -311,33 +311,157 @@ async def api_mkdir(cookie: str, name: str, pdir_fid: str = "0") -> str:
         raise RuntimeError(f"创建目录失败：{j.get('message')}")
     return j["data"]["fid"]
 
-async def download_file(url: str, save_path: Path, cookie: str) -> None:
+def download_file(url: str, save_path: Path, cookie: str) -> None:
     """
-    【需要登录】流式下载单个文件，带进度输出。
+    【需要登录】同步流式下载单个文件（适合在线程中调用）。
     下载 URL 指向阿里云 OSS，不能带 Content-Type（签名校验会失败）。
     """
+    import urllib.request as _ur
     dl_headers = {
         "User-Agent": UA_WEB,
         "Cookie": cookie,
         "Referer": QUARK_HOME + "/",
     }
     save_path.parent.mkdir(parents=True, exist_ok=True)
-    async with aiohttp.ClientSession() as s:
-        async with s.get(
-            url, headers=dl_headers,
-            timeout=aiohttp.ClientTimeout(total=300),
-            allow_redirects=True,
-        ) as r:
-            total = int(r.headers.get("Content-Length", 0))
-            done = 0
-            with open(save_path, "wb") as f:
-                async for chunk in r.content.iter_chunked(1024 * 256):
-                    f.write(chunk)
-                    done += len(chunk)
-                    if total:
-                        print(f"\r  {save_path.name}  {done/total*100:.1f}%",
-                              end="", flush=True)
+    req = _ur.Request(url, headers=dl_headers)
+    with _ur.urlopen(req, timeout=60) as resp:
+        total = int(resp.headers.get("Content-Length") or 0)
+        done = 0
+        with open(save_path, "wb") as f:
+            while True:
+                chunk = resp.read(512 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
+                done += len(chunk)
+                if total:
+                    print(f"\r  {save_path.name}  {done/total*100:.1f}%",
+                          end="", flush=True)
     print()
+
+
+# ── 后台多文件下载（线程 + 进度报告）────────────────────────────────────────
+
+import threading
+from collections import deque
+
+class _DLTask:
+    """单文件下载任务，记录进度和速度历史。"""
+    def __init__(self, name: str, save_path: Path, url: str, cookie: str):
+        self.name = name
+        self.save_path = save_path
+        self.url = url
+        self.cookie = cookie
+        self.total_size = 0
+        self.done_bytes = 0
+        self.finished = False
+        self.error: Optional[Exception] = None
+        # (timestamp, cumulative_bytes) 用于计算过去 1min 均速
+        self.speed_history: deque = deque()
+
+    def speed_1min(self) -> float:
+        now = time.time()
+        while self.speed_history and now - self.speed_history[0][0] > 60:
+            self.speed_history.popleft()
+        if len(self.speed_history) < 2:
+            return 0.0
+        t0, b0 = self.speed_history[0]
+        t1, b1 = self.speed_history[-1]
+        dt = t1 - t0
+        return (b1 - b0) / dt if dt > 0.1 else 0.0
+
+    def progress_line(self) -> str:
+        pct = f"{self.done_bytes / self.total_size * 100:.1f}%" if self.total_size else "??%"
+        done_s  = _fmt_size(self.done_bytes)
+        total_s = _fmt_size(self.total_size) if self.total_size else "?"
+        spd     = _fmt_size(self.speed_1min()) + "/s"
+        if self.finished:
+            status = "✅ 完成"
+        elif self.error:
+            status = f"❌ {self.error}"
+        else:
+            status = "⬇ 下载中"
+        return f"  [{status}] {self.name}  {done_s}/{total_s} ({pct})  1min均速: {spd}"
+
+def _run_dl_task(task: _DLTask) -> None:
+    """线程入口：流式下载并更新进度。"""
+    import urllib.request as _ur
+    dl_headers = {
+        "User-Agent": UA_WEB,
+        "Cookie": task.cookie,
+        "Referer": QUARK_HOME + "/",
+    }
+    try:
+        req = _ur.Request(task.url, headers=dl_headers)
+        task.save_path.parent.mkdir(parents=True, exist_ok=True)
+        with _ur.urlopen(req, timeout=60) as resp:
+            cl = resp.headers.get("Content-Length")
+            if cl:
+                task.total_size = int(cl)
+            with open(task.save_path, "wb") as f:
+                while True:
+                    chunk = resp.read(512 * 1024)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    task.done_bytes += len(chunk)
+                    now = time.time()
+                    task.speed_history.append((now, task.done_bytes))
+        task.finished = True
+    except Exception as e:
+        task.error = e
+
+async def download_files_bg(items: list[dict], save_dir: Path, cookie: str,
+                            report_interval: int = 10) -> None:
+    """
+    后台线程下载多个文件，每隔 report_interval 秒打印一次进度。
+
+    items 格式：[{"file_name": str, "download_url": str}, ...]
+    每项可选 "save_name" 覆盖保存文件名。
+    打印 download_url（截断到 80 字符）供调试。
+    """
+    save_dir.mkdir(parents=True, exist_ok=True)
+    tasks: list[_DLTask] = []
+
+    for item in items:
+        orig_name = item["file_name"]
+        save_name = item.get("save_name", orig_name)
+        url       = item["download_url"]
+        save_path = save_dir / save_name
+
+        print(f"\n📎 {orig_name}  →  {save_name}")
+        print(f"   URL: {url[:80]}...")
+
+        tasks.append(_DLTask(save_name, save_path, url, cookie))
+
+    print(f"\n🚀 启动 {len(tasks)} 个后台下载线程...\n")
+    threads = []
+    for t in tasks:
+        th = threading.Thread(target=_run_dl_task, args=(t,), daemon=True)
+        th.start()
+        threads.append(th)
+
+    start = time.time()
+    while True:
+        await asyncio.sleep(report_interval)
+        elapsed = time.time() - start
+        print(f"\n⏱ 已用时 {elapsed:.0f}s  [{time.strftime('%H:%M:%S')}]")
+        for t in tasks:
+            print(t.progress_line())
+        if all(t.finished or t.error for t in tasks):
+            break
+
+    for th in threads:
+        th.join(timeout=5)
+
+    print("\n" + "=" * 60)
+    print("📦 下载结果：")
+    for t in tasks:
+        if t.finished:
+            size = t.save_path.stat().st_size
+            print(f"  ✅ {t.save_path.name}  ({_fmt_size(size)})")
+        else:
+            print(f"  ❌ {t.name}  失败: {t.error}")
 
 
 # ── 命令实现 ──────────────────────────────────────────────────────────────────
@@ -395,21 +519,40 @@ async def cmd_ls(cookie: str, pdir_fid: str = "0") -> None:
         print(f"{t:<4} {size:>10}  {f['fid']:<32}  {f['file_name']}")
 
 async def cmd_save(cookie: str, share_url: str, to_fid: str = "0") -> None:
-    """【需要登录】转存分享链接中的文件到网盘。"""
+    """
+    【需要登录】转存分享链接中的文件到网盘。
+    转存前先检查目标目录是否已有同名文件夹/文件，已有则跳过转存直接复用。
+    返回实际可用的目标 fid（已有文件所在目录 fid 或转存后的 fid）。
+    """
     pwd_id, password = parse_share_url(share_url)
     tok = await get_stoken(pwd_id, password)
-    is_owner, files = await get_share_detail(pwd_id, tok)
+    is_owner, share_files = await get_share_detail(pwd_id, tok)
     if is_owner:
         print("[save] 该分享是您自己的文件，无需转存")
         return
-    if not files:
+    if not share_files:
         print("[save] 分享为空或已失效")
         return
-    print(f"[save] 共 {len(files)} 个条目，开始转存……")
+
+    # ── 转存前检查网盘是否已有同名内容 ──────────────────────────────────────
+    share_names = {f["file_name"] for f in share_files}
+    existing = await api_list_all(cookie, to_fid)
+    existing_map = {f["file_name"]: f for f in existing}
+    already = share_names & existing_map.keys()
+    if already:
+        print(f"[save] ℹ️  网盘目标目录已有相同文件/文件夹，跳过转存：")
+        for name in sorted(already):
+            f = existing_map[name]
+            size_str = "-" if f.get("dir") else _fmt_size(f.get("size", 0))
+            print(f"         {name}  ({size_str})  fid={f['fid']}")
+        return
+
+    # ── 正式转存 ──────────────────────────────────────────────────────────────
+    print(f"[save] 共 {len(share_files)} 个条目，开始转存……")
     task_id = await api_save_share(
         cookie, pwd_id, tok,
-        [f["fid"] for f in files],
-        [f["share_fid_token"] for f in files],
+        [f["fid"] for f in share_files],
+        [f["share_fid_token"] for f in share_files],
         to_fid,
     )
     print(f"[save] 等待任务完成……")
@@ -417,31 +560,57 @@ async def cmd_save(cookie: str, share_url: str, to_fid: str = "0") -> None:
     folder = result.get("save_as", {}).get("to_pdir_name", "根目录")
     print(f"[save] ✅ 转存完成，已保存至：{folder}")
 
-async def cmd_dl(cookie: str, share_url: str,
-                 save_dir: Optional[str] = None) -> None:
+async def cmd_dl(cookie: str, share_url_or_fids: str,
+                 save_dir: Optional[str] = None,
+                 extra_fids: Optional[list[str]] = None,
+                 rename_map: Optional[dict[str, str]] = None) -> None:
     """
-    【需要登录】下载自己分享的文件到本地。
-    夸克限制：/file/download 只允许下载自己网盘内的文件。
-    他人分享请先 save 转存后再下载。
+    【需要登录】下载网盘文件到本地，支持两种模式：
+
+    模式 1 — 分享链接（必须是自己的分享）：
+        python3 quark_hub.py dl <分享链接> [本地目录]
+    模式 2 — 直接传 fid（不依赖分享链接，适合已在网盘的文件）：
+        内部调用时传 extra_fids=[fid1, fid2, ...]
+
+    rename_map: {原文件名: 保存文件名}，可选，用于字幕等重命名。
+    使用后台线程下载，每 10s 打印进度和 1min 均速。
     """
-    pwd_id, password = parse_share_url(share_url)
-    tok = await get_stoken(pwd_id, password)
-    is_owner, files = await get_share_detail(pwd_id, tok)
-    if not is_owner:
-        print("[dl] ⚠️  只能下载自己网盘的分享文件，请先 save 转存后再下载")
-        return
-    file_only = [f for f in files if not f["dir"]]
-    if not file_only:
-        print("[dl] 没有可直接下载的文件")
-        return
-    dl_list = await api_get_download_urls(cookie, [f["fid"] for f in file_only])
     base = Path(save_dir) if save_dir else DOWNLOAD_DIR
-    base.mkdir(parents=True, exist_ok=True)
-    print(f"[dl] 共 {len(dl_list)} 个文件，保存至 {base}")
+    rename_map = rename_map or {}
+
+    if extra_fids:
+        # 模式 2：直接 fid
+        fids = extra_fids
+    else:
+        # 模式 1：通过分享链接
+        pwd_id, password = parse_share_url(share_url_or_fids)
+        tok = await get_stoken(pwd_id, password)
+        is_owner, files = await get_share_detail(pwd_id, tok)
+        if not is_owner:
+            print("[dl] ⚠️  只能下载自己网盘的分享文件，请先 save 转存后再下载")
+            return
+        file_only = [f for f in files if not f["dir"]]
+        if not file_only:
+            print("[dl] 没有可直接下载的文件")
+            return
+        fids = [f["fid"] for f in file_only]
+
+    dl_list = await api_get_download_urls(cookie, fids)
+    if not dl_list:
+        print("[dl] 未获取到下载地址")
+        return
+
+    items = []
     for item in dl_list:
-        print(f"[dl] ⬇  {item['file_name']}")
-        await download_file(item["download_url"], base / item["file_name"], cookie)
-    print("[dl] ✅ 全部完成")
+        orig_name = item["file_name"]
+        items.append({
+            "file_name": orig_name,
+            "save_name": rename_map.get(orig_name, orig_name),
+            "download_url": item["download_url"],
+        })
+
+    print(f"[dl] 共 {len(items)} 个文件，保存至 {base}")
+    await download_files_bg(items, base, cookie)
 
 async def cmd_mkdir(cookie: str, name: str, pdir_fid: str = "0") -> None:
     """【需要登录】在网盘中创建目录。"""


### PR DESCRIPTION
## Changes

### quark_hub.py
- **`download_file`**: switched from async aiohttp to sync urllib, making it thread-safe and suitable for use inside threads
- **New `_DLTask` class**: tracks per-file `done_bytes`, `total_size`, `speed_history` (rolling deque for 1-min average)
- **New `download_files_bg()`**: spawns one background thread per file, prints progress every 10s including download URL (truncated) and 1-min rolling average speed
- **`cmd_save`**: before transferring, checks target directory for existing same-name files; if found, skips the save and prints existing fid/size
- **`cmd_dl`**: added `extra_fids` param (download directly by fid without needing a share URL), added `rename_map` for subtitle renaming; now uses `download_files_bg` internally

### SKILL.md (v1.4.0)
- Added **best-practice flow**: `ls` → check existing → `save` (or skip) → `dl` by fid
- Added importable API reference table for use in custom scripts
- Updated command table and notes to reflect new capabilities

## Background
Discovered during real usage: when a share's target folder already existed in the user's drive (from a previous save), the `save` command would fail with a capacity error before checking for duplicates. Also needed background-thread download with live progress reporting for large files (6.7 GB MKV).