### PR TITLE
feat(xianyu-hub): Goofish (闲鱼) search & management skill

### DIFF
--- a/xianyu-hub/SKILL.md
+++ b/xianyu-hub/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: xianyu-hub
+description: >
+  闲鱼（咸鱼/goofish）二手商品搜索与查询技能。通过在已登录的浏览器页面内调用
+  mtop API，无需 Cookie/签名即可搜索商品、查询价格行情、筛选城市/价格区间/排序。
+  支持输出网页链接和 fleamarket:// APP 直达链接。
+  当用户提到「闲鱼」「咸鱼」「二手」「goofish」「搜一下xx多少钱」「找一下xx的商品」，
+  或任何需要查询闲鱼商品价格/搜索二手商品的场景，必须触发本技能。
+---
+
+# 闲鱼搜索技能 (xianyu-hub)
+
+## 核心原理
+
+在已登录闲鱼的浏览器 tab 内通过 `minis-browser-use execute_js` 调用 `window.lib.mtop.request()`，
+天然复用登录态，无需签名或 Cookie 管理。
+
+## 启动流程（每次使用前执行）
+
+全程用 `minis-browser-use` CLI。
+
+### Step 1：确保浏览器有闲鱼 tab
+
+```sh
+minis-browser-use list_tabs --compact -q  # 看有没有 goofish.com
+# 没有则：
+minis-browser-use navigate --url "https://www.goofish.com"
+```
+
+### Step 2：检查登录状态
+
+```sh
+minis-browser-use execute_js --tab-id <id> \
+  --script 'return window.location.href.includes("passport") ? "not_login" : (window.lib && window.lib.mtop ? "ok" : "loading")' \
+  --compact -q
+```
+
+- `"ok"` → 已登录，执行操作
+- 其他 → 未登录，执行：
+  ```sh
+  minis-open https://www.goofish.com
+  ```
+  并告知用户：「闲鱼尚未登录，已打开内置浏览器，请完成登录后告诉我 🐟」
+
+## 脚本一览
+
+所有脚本位于 `/var/minis/skills/xianyu-hub/scripts/`，用 `sh` 执行。
+
+### 1. 搜索商品 — search.sh
+
+```sh
+sh scripts/search.sh -k <关键词> [选项]
+
+# 选项：
+#   -k <词>        关键词（必填）
+#   -n <数>        每页数量（默认20，最大30）
+#   -p <页>        页码（默认1）
+#   -s <排序>      default | price_asc | price_desc | time | reduce
+#   --min-price <元>  最低价
+#   --max-price <元>  最高价
+#   --city <城市>     城市过滤
+#   --personal-only   仅个人闲置
+#   -j              输出 JSON
+
+# 示例
+sh scripts/search.sh -k "MacBook Air" -s price_asc --min-price 2000 -n 10
+sh scripts/search.sh -k "iPhone15" --city 上海 -s time
+```
+
+### 2. 商品详情 — detail.sh
+
+```sh
+sh scripts/detail.sh <商品ID>
+
+# 返回：标题、价格、描述、浏览/想要/收藏数、卖家信息（好评率、回复率、售出数）
+```
+
+### 3. 收藏管理 — favorites.sh
+
+```sh
+sh scripts/favorites.sh list [-n 数量] [-p 页码]   # 查看收藏列表
+sh scripts/favorites.sh add <商品ID>               # 收藏商品
+sh scripts/favorites.sh remove <商品ID>            # 取消收藏
+```
+
+### 4. 订单查询 — orders.sh
+
+```sh
+sh scripts/orders.sh [-n 数量] [-p 页码] [-t 类型]
+
+# 类型: all | wait_pay | wait_send | wait_receive | refund
+```
+
+### 5. 我发布的 — my_items.sh
+
+```sh
+sh scripts/my_items.sh [-n 数量] [-p 页码]
+```
+
+## 打开商品
+
+```sh
+apple-open "fleamarket://item?id=<商品ID>"    # 跳转闲鱼 APP
+```
+
+对话中用 Markdown 链接：`[在闲鱼APP中打开](fleamarket://item?id=xxx)`
+
+## URL 规则
+
+| 用途 | 格式 |
+|---|---|
+| 网页 | `https://www.goofish.com/item?id=<id>` |
+| APP | `fleamarket://item?id=<id>` |
+| 订单 | `fleamarket://order_detail?id=<orderId>` |
+
+## 注意事项
+
+- `price_asc` 排序服务端可能返回低价垃圾数据，建议配合 `--min-price` 过滤
+- 城市/价格区间为客户端过滤
+- `--personal-only` 按评价数判断（>10条视为店铺），不绝对准确
+- 敏感词被平台屏蔽时返回空结果，属正常现象

--- a/xianyu-hub/scripts/detail.sh
+++ b/xianyu-hub/scripts/detail.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# 闲鱼商品详情查询
+# 用法: detail.sh <商品ID>
+ITEM_ID="$1"
+if [ -z "$ITEM_ID" ]; then echo "用法: detail.sh <商品ID>" >&2; exit 1; fi
+
+# 自动定位闲鱼 tab
+TAB_ID=$(minis-browser-use list_tabs --compact -q 2>/dev/null | python3 -c "
+import json,sys,re
+for l in json.load(sys.stdin).get('text','').split('\n'):
+  if 'goofish.com' in l:
+    m=re.search(r'Tab (\d+)',l)
+    if m: sys.stdout.write(m.group(1)); break
+")
+TAB_ARG=""
+[ -n "$TAB_ID" ] && TAB_ARG="--tab-id $TAB_ID"
+
+JS_FILE="/tmp/xy_detail_$$.js"
+cat > "$JS_FILE" << JSEOF
+return new Promise(function(resolve) {
+  window.lib.mtop.request({
+    api: 'mtop.taobao.idle.pc.detail', v: '1.0',
+    data: { itemId: "${ITEM_ID}" }
+  }).then(function(res) {
+    var d = res.data || {};
+    var item = d.itemDO || {};
+    var seller = d.sellerDO || {};
+    var b2c = d.b2cItemDO || {};
+    resolve(JSON.stringify({
+      ok: true,
+      item: {
+        itemId:       item.itemId || '',
+        title:        item.title || '',
+        price:        item.soldPrice || '',
+        originalPrice:item.originalPrice || '',
+        desc:         item.desc || '',
+        stuffStatus:  item.stuffStatus || '',
+        quantity:     item.quantity || '1',
+        wantCnt:      item.wantCnt || '0',
+        browseCnt:    b2c.browseCnt || item.browseCnt || '0',
+        collectCnt:   item.collectCnt || '0',
+        itemStatus:   item.itemStatusStr || '',
+        gmtCreate:    item.gmtCreate || '',
+        transportFee: item.transportFee || '',
+        defaultPrice: item.defaultPrice || '',
+        url:          'https://www.goofish.com/item?id=' + (item.itemId || ''),
+        appUrl:       'fleamarket://item?id=' + (item.itemId || '')
+      },
+      seller: {
+        nick:         seller.nick || '',
+        sellerId:     seller.sellerId || '',
+        city:         seller.city || '',
+        signature:    seller.signature || '',
+        registerDays: seller.userRegDay || '',
+        soldCount:    seller.hasSoldNumInteger || '',
+        goodRate:     seller.newGoodRatioRate || '',
+        replyRate:    seller.replyRatio24h || '',
+        itemCount:    seller.itemCount || '',
+        portraitUrl:  seller.portraitUrl || ''
+      }
+    }));
+  }).catch(function(e) {
+    resolve(JSON.stringify({ ok: false, error: e.ret ? e.ret.join('; ') : String(e) }));
+  });
+});
+JSEOF
+
+RESULT=$(minis-browser-use execute_js $TAB_ARG --script "$(cat $JS_FILE)" --compact -q 2>/dev/null \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('text','').strip().split('\n')[0].strip())")
+rm -f "$JS_FILE"
+
+if [ -z "$RESULT" ]; then echo "❌ 请求失败" >&2; exit 1; fi
+
+echo "$RESULT" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read().strip())
+if not d.get('ok'): print('❌', d.get('error','')); sys.exit(1)
+it = d['item']; s = d['seller']
+print(f'📦 {it[\"title\"]}')
+print(f'   💰 ¥{it[\"price\"]}' + (f'  原价¥{it[\"originalPrice\"]}' if it.get('originalPrice') else ''))
+print(f'   📝 {it[\"desc\"][:80]}')
+print(f'   📊 {it[\"browseCnt\"]}浏览  ❤️{it[\"wantCnt\"]}想要  ⭐{it[\"collectCnt\"]}收藏')
+print(f'   📦 库存{it[\"quantity\"]}  运费{it.get(\"transportFee\",\"包邮\")}')
+print(f'   🔗 {it[\"url\"]}')
+print(f'   📱 {it[\"appUrl\"]}')
+print()
+print(f'👤 卖家: {s[\"nick\"]}')
+print(f'   📍{s[\"city\"]}  注册{s[\"registerDays\"]}天  售出{s[\"soldCount\"]}件')
+print(f'   👍好评率{s[\"goodRate\"]}  💬24h回复率{s[\"replyRate\"]}  📦在售{s[\"itemCount\"]}件')
+"

--- a/xianyu-hub/scripts/favorites.sh
+++ b/xianyu-hub/scripts/favorites.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# 闲鱼收藏管理
+# 用法:
+#   favorites.sh list [-n 数量] [-p 页码]     查看收藏列表
+#   favorites.sh add <商品ID>                 收藏商品
+#   favorites.sh remove <商品ID>              取消收藏
+
+ACTION="$1"; shift
+case "$ACTION" in
+  list|add|remove) ;;
+  *) echo "用法: favorites.sh <list|add|remove> [参数]" >&2; exit 1 ;;
+esac
+
+PAGE_SIZE=20; PAGE_NO=1; ITEM_ID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n) PAGE_SIZE="$2"; shift 2 ;;
+    -p) PAGE_NO="$2"; shift 2 ;;
+    *)  ITEM_ID="$1"; shift ;;
+  esac
+done
+
+TAB_ID=$(minis-browser-use list_tabs --compact -q 2>/dev/null | python3 -c "
+import json,sys,re
+for l in json.load(sys.stdin).get('text','').split('\n'):
+  if 'goofish.com' in l:
+    m=re.search(r'Tab (\d+)',l)
+    if m: sys.stdout.write(m.group(1)); break
+")
+TAB_ARG=""; [ -n "$TAB_ID" ] && TAB_ARG="--tab-id $TAB_ID"
+
+JS_FILE="/tmp/xy_fav_$$.js"
+
+if [ "$ACTION" = "list" ]; then
+  cat > "$JS_FILE" << JSEOF
+return new Promise(function(resolve) {
+  window.lib.mtop.request({
+    api: 'mtop.taobao.idle.web.favor.item.list', v: '1.0',
+    data: { pageSize: ${PAGE_SIZE}, pageNo: ${PAGE_NO} }
+  }).then(function(res) {
+    var d = res.data || {};
+    var items = (d.items || []).map(function(it) {
+      return {
+        itemId: it.id || it.longItemId || '',
+        title: (it.title || '').replace(/\n/g,' ').substring(0,50),
+        price: it.price || '',
+        area: (it.province || '') + ' ' + (it.city || ''),
+        seller: it.userNick || '',
+        status: it.offline ? '已下架' : '在售',
+        favorTime: it.favorTime || '',
+        url: 'https://www.goofish.com/item?id=' + (it.id || it.longItemId || ''),
+        appUrl: 'fleamarket://item?id=' + (it.id || it.longItemId || '')
+      };
+    });
+    resolve(JSON.stringify({ ok:true, total:d.totalCount||'0', page:${PAGE_NO}, items:items }));
+  }).catch(function(e) {
+    resolve(JSON.stringify({ ok:false, error: e.ret ? e.ret.join('; ') : String(e) }));
+  });
+});
+JSEOF
+else
+  if [ -z "$ITEM_ID" ]; then echo "错误: 请提供商品ID" >&2; exit 1; fi
+  OP=$([ "$ACTION" = "add" ] && echo "1" || echo "0")
+  cat > "$JS_FILE" << JSEOF
+return new Promise(function(resolve) {
+  window.lib.mtop.request({
+    api: 'mtop.taobao.idle.collect.item', v: '1.0',
+    data: { itemId: '${ITEM_ID}', operate: '${OP}' }
+  }).then(function(res) {
+    resolve(JSON.stringify({ ok:true, result: (res.data||{}).favorResult }));
+  }).catch(function(e) {
+    resolve(JSON.stringify({ ok:false, error: e.ret ? e.ret.join('; ') : String(e) }));
+  });
+});
+JSEOF
+fi
+
+RESULT=$(minis-browser-use execute_js $TAB_ARG --script "$(cat $JS_FILE)" --compact -q 2>/dev/null \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('text','').strip().split('\n')[0].strip())")
+rm -f "$JS_FILE"
+
+if [ -z "$RESULT" ]; then echo "❌ 请求失败" >&2; exit 1; fi
+
+echo "$RESULT" | python3 -c "
+import json, sys, datetime
+d = json.loads(sys.stdin.read().strip())
+if not d.get('ok'): print('❌', d.get('error','')); sys.exit(1)
+
+if 'items' in d:
+    print(f'⭐ 收藏列表  共{d[\"total\"]}件  第{d[\"page\"]}页')
+    print('─' * 60)
+    for i, it in enumerate(d['items'], 1):
+        status = '🔴已下架' if it['status']=='已下架' else '🟢在售'
+        print(f'[{i:02d}] ¥{it[\"price\"]}  {status}')
+        print(f'     {it[\"title\"]}')
+        print(f'     📍{it[\"area\"]}  👤{it[\"seller\"]}')
+        print(f'     🔗 {it[\"url\"]}')
+        print(f'     📱 {it[\"appUrl\"]}')
+        print()
+else:
+    action_name = '收藏' if d.get('result')=='true' else '取消收藏'
+    print(f'✅ {action_name}成功')
+"

--- a/xianyu-hub/scripts/my_items.sh
+++ b/xianyu-hub/scripts/my_items.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# 闲鱼我发布的商品列表
+# 用法: my_items.sh [-n 数量] [-p 页码]
+
+PAGE_SIZE=20; PAGE_NO=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n) PAGE_SIZE="$2"; shift 2 ;;
+    -p) PAGE_NO="$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+
+TAB_ID=$(minis-browser-use list_tabs --compact -q 2>/dev/null | python3 -c "
+import json,sys,re
+for l in json.load(sys.stdin).get('text','').split('\n'):
+  if 'goofish.com' in l:
+    m=re.search(r'Tab (\d+)',l)
+    if m: sys.stdout.write(m.group(1)); break
+")
+TAB_ARG=""; [ -n "$TAB_ID" ] && TAB_ARG="--tab-id $TAB_ID"
+
+# 先获取当前用户 ID
+USER_ID=$(minis-browser-use execute_js $TAB_ARG \
+  --script 'return new Promise(function(r){window.lib.mtop.request({api:"mtop.taobao.idlemessage.pc.loginuser.get",v:"1.0",data:{}}).then(function(res){r((res.data||{}).userId||"")}).catch(function(){r("")})})' \
+  --compact -q 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('text','').strip().split('\n')[0].strip())")
+
+if [ -z "$USER_ID" ]; then echo "❌ 获取用户ID失败" >&2; exit 1; fi
+
+JS_FILE="/tmp/xy_myitems_$$.js"
+cat > "$JS_FILE" << JSEOF
+return new Promise(function(resolve) {
+  window.lib.mtop.request({
+    api: 'mtop.idle.web.xyh.item.list', v: '1.0',
+    data: { pageNumber: ${PAGE_NO}, pageSize: ${PAGE_SIZE}, userId: '${USER_ID}' }
+  }).then(function(res) {
+    var d = res.data || {};
+    var items = (d.cardList || []).map(function(card) {
+      var cd = card.cardData || {};
+      var dp = cd.detailParams || {};
+      var pi = cd.priceInfo || {};
+      var price = '';
+      if (pi.priceItems) {
+        pi.priceItems.forEach(function(p) { if (p.type === 'integer') price = p.text; });
+      }
+      return {
+        itemId:    dp.itemId || cd.id || '',
+        title:     (cd.title || '').replace(/\n/g,' ').substring(0,50),
+        price:     price || dp.soldPrice || '',
+        status:    cd.itemStatus || '',
+        url:       'https://www.goofish.com/item?id=' + (dp.itemId || cd.id || ''),
+        appUrl:    'fleamarket://item?id=' + (dp.itemId || cd.id || '')
+      };
+    });
+    resolve(JSON.stringify({ ok:true, total:d.totalCount||'0', page:${PAGE_NO}, items:items }));
+  }).catch(function(e) {
+    resolve(JSON.stringify({ ok:false, error: e.ret ? e.ret.join('; ') : String(e) }));
+  });
+});
+JSEOF
+
+RESULT=$(minis-browser-use execute_js $TAB_ARG --script "$(cat $JS_FILE)" --compact -q 2>/dev/null \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('text','').strip().split('\n')[0].strip())")
+rm -f "$JS_FILE"
+
+if [ -z "$RESULT" ]; then echo "❌ 请求失败" >&2; exit 1; fi
+
+echo "$RESULT" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read().strip())
+if not d.get('ok'): print('❌', d.get('error','')); sys.exit(1)
+
+items = d.get('items', [])
+status_map = {'0':'在售','1':'已下架','2':'已售出'}
+print(f'📤 我发布的  共{d[\"total\"]}件  第{d[\"page\"]}页')
+print('─' * 60)
+if not items:
+    print('   暂无发布')
+for i, it in enumerate(items, 1):
+    st = status_map.get(str(it.get('status','')), str(it.get('status','')))
+    print(f'[{i:02d}] ¥{it[\"price\"]}  [{st}]')
+    print(f'     {it[\"title\"]}')
+    print(f'     🔗 {it[\"url\"]}')
+    print(f'     📱 {it[\"appUrl\"]}')
+    print()
+"

--- a/xianyu-hub/scripts/orders.sh
+++ b/xianyu-hub/scripts/orders.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# 闲鱼订单查询 — 我买到的
+# 用法: orders.sh [-n 数量] [-p 页码] [-t 类型]
+# 类型: all(全部) wait_pay(待付款) wait_send(待发货) wait_receive(待收货) refund(退款)
+
+PAGE_SIZE=20; PAGE_NO=1; TAB_TYPE="all"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n) PAGE_SIZE="$2"; shift 2 ;;
+    -p) PAGE_NO="$2"; shift 2 ;;
+    -t) TAB_TYPE="$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+
+TAB_ID=$(minis-browser-use list_tabs --compact -q 2>/dev/null | python3 -c "
+import json,sys,re
+for l in json.load(sys.stdin).get('text','').split('\n'):
+  if 'goofish.com' in l:
+    m=re.search(r'Tab (\d+)',l)
+    if m: sys.stdout.write(m.group(1)); break
+")
+TAB_ARG=""; [ -n "$TAB_ID" ] && TAB_ARG="--tab-id $TAB_ID"
+
+JS_FILE="/tmp/xy_orders_$$.js"
+cat > "$JS_FILE" << JSEOF
+return new Promise(function(resolve) {
+  window.lib.mtop.request({
+    api: 'mtop.idle.web.trade.bought.list', v: '1.0',
+    data: { pageSize: ${PAGE_SIZE}, pageNo: ${PAGE_NO}, tabType: '${TAB_TYPE}' }
+  }).then(function(res) {
+    var d = res.data || {};
+    var items = (d.items || []).map(function(it) {
+      var c = it.commonData || {};
+      var head = it.head || {};
+      var content = it.content || {};
+
+      // 提取头部信息
+      var headItems = (head.headItems || []);
+      var sellerName = '';
+      headItems.forEach(function(h) { if (h.type === 'TEXT') sellerName = h.content || ''; });
+
+      // 提取商品信息
+      var contentItems = (content.contentItems || []);
+      var title = '', price = '', picUrl = '';
+      contentItems.forEach(function(ci) {
+        if (ci.type === 'ITEM_INFO') {
+          title = (ci.title || '').replace(/\n/g,' ').substring(0,50);
+          price = ci.price || '';
+          picUrl = ci.picUrl || '';
+        }
+      });
+
+      // 提取尾部操作按钮
+      var tailItems = ((it.tail || {}).tailItems || []);
+      var actions = tailItems.map(function(t) { return t.title || ''; }).filter(function(t) { return t; });
+
+      return {
+        orderId:   c.orderIdStr || c.orderId || '',
+        itemId:    c.itemId || '',
+        title:     title,
+        price:     price,
+        status:    c.tradeStatusEnum || '',
+        seller:    sellerName || (c.seller||{}).nick || '',
+        actions:   actions,
+        appUrl:    c.orderDetailUrl || ''
+      };
+    });
+    resolve(JSON.stringify({ ok:true, total:d.totalCount||'0', page:${PAGE_NO}, items:items }));
+  }).catch(function(e) {
+    resolve(JSON.stringify({ ok:false, error: e.ret ? e.ret.join('; ') : String(e) }));
+  });
+});
+JSEOF
+
+RESULT=$(minis-browser-use execute_js $TAB_ARG --script "$(cat $JS_FILE)" --compact -q 2>/dev/null \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('text','').strip().split('\n')[0].strip())")
+rm -f "$JS_FILE"
+
+if [ -z "$RESULT" ]; then echo "❌ 请求失败" >&2; exit 1; fi
+
+echo "$RESULT" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read().strip())
+if not d.get('ok'): print('❌', d.get('error','')); sys.exit(1)
+
+items = d.get('items', [])
+status_map = {
+    'TRADE_CLOSED':'已关闭','TRADE_FINISHED':'已完成','WAIT_BUYER_PAY':'待付款',
+    'WAIT_SELLER_SEND_GOODS':'待发货','WAIT_BUYER_CONFIRM_GOODS':'待收货',
+    'TRADE_REFUNDING':'退款中','TRADE_SUCCESS':'交易成功'
+}
+print(f'🛒 我买到的  共{d[\"total\"]}单  第{d[\"page\"]}页')
+print('─' * 60)
+if not items:
+    print('   暂无订单')
+for i, it in enumerate(items, 1):
+    st = status_map.get(it['status'], it['status'])
+    acts = '  '.join(it.get('actions',[])) if it.get('actions') else ''
+    print(f'[{i:02d}] ¥{it[\"price\"]}  [{st}]')
+    print(f'     {it[\"title\"]}')
+    print(f'     👤{it[\"seller\"]}  订单号:{it[\"orderId\"]}')
+    if acts: print(f'     🔘 {acts}')
+    if it.get('appUrl'): print(f'     📱 {it[\"appUrl\"]}')
+    print()
+"

--- a/xianyu-hub/scripts/search.sh
+++ b/xianyu-hub/scripts/search.sh
@@ -1,0 +1,244 @@
+#!/bin/sh
+# =============================================================
+# 闲鱼搜索脚本 (browser-use 版)
+#
+# 原理：在已登录的闲鱼网页内直接调用 window.lib.mtop.request()
+#       无需 Cookie/签名，天然绕过反爬限制
+#
+# 首次使用：
+#   请先在 Minis 内置浏览器中打开 https://www.goofish.com 并登录
+#   登录后本脚本即可直接使用，无需额外配置
+#
+# 用法:
+#   xianyu_search.sh -k <关键词> [选项]
+#
+# 选项:
+#   -k, --keyword    <关键词>  搜索关键词（必填）
+#   -p, --page       <页码>   页码，默认 1
+#   -n, --rows       <数量>   每页数量，默认 20（最大 30）
+#   -s, --sort       <排序>   排序方式：
+#                               default    综合排序（默认）
+#                               price_asc  价格从低到高
+#                               price_desc 价格从高到低
+#                               time       最新发布
+#                               reduce     最新降价
+#   --min-price      <价格>   最低价格过滤（元）
+#   --max-price      <价格>   最高价格过滤（元）
+#   --city           <城市>   按城市过滤（如：北京、上海、广东）
+#   --personal-only           只看个人闲置（评价数 ≤10 的卖家）
+#   --tab-id         <id>     手动指定浏览器 tab id（默认自动检测）
+#   -j, --json                输出原始 JSON
+#   -h, --help                显示帮助
+#
+# 示例:
+#   search.sh -k "MacBook Air" -s price_asc -n 10
+#   search.sh -k "iPhone15" --min-price 1000 --max-price 3000 --city 上海
+#   search.sh -k "iPad" -s time --personal-only
+#   search.sh -k "Switch" -s reduce -j
+# =============================================================
+
+KEYWORD=""
+PAGE=1
+ROWS=20
+SORT="default"
+MIN_PRICE=""
+MAX_PRICE=""
+CITY=""
+PERSONAL_ONLY=false
+OUTPUT_JSON=false
+TAB_ID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -k|--keyword)      KEYWORD="$2";       shift 2 ;;
+    -p|--page)         PAGE="$2";          shift 2 ;;
+    -n|--rows)         ROWS="$2";          shift 2 ;;
+    -s|--sort)         SORT="$2";          shift 2 ;;
+    --min-price)       MIN_PRICE="$2";     shift 2 ;;
+    --max-price)       MAX_PRICE="$2";     shift 2 ;;
+    --city)            CITY="$2";          shift 2 ;;
+    --tab-id)          TAB_ID="$2";        shift 2 ;;
+    --personal-only)   PERSONAL_ONLY=true; shift 1 ;;
+    -j|--json)         OUTPUT_JSON=true;   shift 1 ;;
+    -h|--help)         sed -n '3,37p' "$0"; exit 0 ;;
+    *)  [ -z "$KEYWORD" ] && KEYWORD="$1"; shift 1 ;;
+  esac
+done
+
+if [ -z "$KEYWORD" ]; then
+  echo "错误: 请提供搜索关键词（-k <关键词>）" >&2
+  exit 1
+fi
+
+case "$SORT" in
+  price_asc)  SORT_FIELD="price";        SORT_VALUE="asc"  ;;
+  price_desc) SORT_FIELD="price";        SORT_VALUE="desc" ;;
+  time)       SORT_FIELD="time";         SORT_VALUE="desc" ;;
+  reduce)     SORT_FIELD="price_reduce"; SORT_VALUE="desc" ;;
+  *)          SORT_FIELD="";             SORT_VALUE=""     ;;
+esac
+
+# ---------- 确保有已登录的闲鱼 tab（自动打开 + 检测登录）----------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -z "$TAB_ID" ]; then
+  TAB_ID=$(sh "$SCRIPT_DIR/ensure_tab.sh") || exit $?
+else
+  # 已手动指定 tab_id，仍走 ensure_tab 验证登录状态
+  TAB_ID=$(TAB_ID="$TAB_ID" sh "$SCRIPT_DIR/ensure_tab.sh") || exit $?
+fi
+TAB_ARG="--tab-id $TAB_ID"
+
+# ---------- 生成 JS 参数（JSON 安全编码，防注入）----------
+KW_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$KEYWORD")
+SF_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$SORT_FIELD")
+SV_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$SORT_VALUE")
+SO_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$SORT")
+CI_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$CITY")
+MN_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$MIN_PRICE")
+MX_JS=$(python3 -c "import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))" "$MAX_PRICE")
+PO_JS=$([ "$PERSONAL_ONLY" = "true" ] && echo "true" || echo "false")
+
+# ---------- 把 JS 写到临时文件（避免多行 inline 引号问题）----------
+JS_FILE="/tmp/xianyu_search_$$.js"
+cat > "$JS_FILE" << JSEOF
+return (function() {
+  var data = {
+    keyword:           ${KW_JS},
+    pageNumber:        ${PAGE},
+    rowsPerPage:       ${ROWS},
+    fromFilter:        false,
+    sortField:         ${SF_JS},
+    sortValue:         ${SV_JS},
+    searchReqFromPage: 'pcSearch'
+  };
+
+  return new Promise(function(resolve) {
+    window.lib.mtop.request({
+      api: 'mtop.taobao.idlemtopsearch.pc.search',
+      v: '1.0',
+      data: data
+    })
+    .then(function(res) {
+      var list         = (res.data || {}).resultList || [];
+      var filterCity   = ${CI_JS};
+      var minPrice     = ${MN_JS} !== "" ? parseInt(${MN_JS}) : null;
+      var maxPrice     = ${MX_JS} !== "" ? parseInt(${MX_JS}) : null;
+      var personalOnly = ${PO_JS};
+
+      var items = list.map(function(item) {
+        var main = ((item.data || {}).item || {}).main || {};
+        var ex   = main.exContent || {};
+        var args = (main.clickParam || {}).args || {};
+        var dp   = ex.detailParams || {};
+        var price = parseInt(dp.soldPrice || args.price || 0);
+
+        // 评价数 >10 视为商家店铺
+        var reviewCount = 0;
+        var tagList = ((ex.userFishShopLabel || {}).tagList) || [];
+        for (var t = 0; t < tagList.length; t++) {
+          var content = (tagList[t].data || {}).content || '';
+          var m = content.match(/(\d+)条评价/);
+          if (m) { reviewCount = parseInt(m[1]); break; }
+        }
+        var isShop = reviewCount > 10;
+
+        return {
+          itemId:      ex.itemId || args.item_id || '',
+          title:       (ex.title || dp.title || '').replace(/\n/g, ' ').replace(/\s+/g, ' ').trim(),
+          price:       price,
+          oriPrice:    ex.oriPrice || '',
+          area:        ex.area || '',
+          seller:      ex.userNickName || dp.userNick || '',
+          want:        ex.want || '0',
+          reviewCount: reviewCount,
+          isShop:      isShop,
+          publishTime: args.publishTime || '',
+          url:         'https://www.goofish.com/item?id=' + (ex.itemId || args.item_id || ''),
+          appUrl:      'fleamarket://item?id=' + (ex.itemId || args.item_id || '')
+        };
+      }).filter(function(i) {
+        if (i.price <= 0)                                    return false;
+        if (filterCity && i.area.indexOf(filterCity) === -1) return false;
+        if (minPrice !== null && i.price < minPrice)         return false;
+        if (maxPrice !== null && i.price > maxPrice)         return false;
+        if (personalOnly && i.isShop)                        return false;
+        return true;
+      });
+
+      resolve(JSON.stringify({
+        ok:          true,
+        keyword:     data.keyword,
+        page:        ${PAGE},
+        sort:        ${SO_JS},
+        city:        filterCity,
+        minPrice:    minPrice,
+        maxPrice:    maxPrice,
+        personalOnly: personalOnly,
+        count:       items.length,
+        items:       items
+      }));
+    })
+    .catch(function(e) {
+      resolve(JSON.stringify({ ok: false, error: String(e) }));
+    });
+  });
+})()
+JSEOF
+
+# ---------- 执行 ----------
+RESULT=$(minis-browser-use execute_js $TAB_ARG --script "$(cat $JS_FILE)" --compact -q 2>/dev/null \
+  | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(d.get('text','').strip().split('\n')[0].strip())
+")
+rm -f "$JS_FILE"
+
+if [ -z "$RESULT" ]; then
+  echo "❌ 未收到返回数据，请检查网络或登录状态" >&2
+  exit 1
+fi
+
+# ---------- 输出 ----------
+if [ "$OUTPUT_JSON" = "true" ]; then
+  echo "$RESULT" | python3 -c "
+import json, sys
+print(json.dumps(json.loads(sys.stdin.read().strip()), ensure_ascii=False, indent=2))
+"
+else
+  echo "$RESULT" | python3 -c "
+import json, sys, datetime
+
+d = json.loads(sys.stdin.read().strip())
+if not d.get('ok'):
+    print('❌ 搜索失败:', d.get('error','未知错误'))
+    sys.exit(1)
+
+items = d.get('items', [])
+sort_map = {'default':'综合','price_asc':'价格↑','price_desc':'价格↓','time':'最新','reduce':'降价'}
+tags = []
+if d.get('city'):         tags.append('城市:' + d['city'])
+if d.get('minPrice'):     tags.append('最低¥' + str(d['minPrice']))
+if d.get('maxPrice'):     tags.append('最高¥' + str(d['maxPrice']))
+if d.get('personalOnly'): tags.append('仅个人')
+tag_str = ('  [' + '  '.join(tags) + ']') if tags else ''
+
+print(f'🔍 \"{d[\"keyword\"]}\"  {sort_map.get(d.get(\"sort\",\"\"), d.get(\"sort\",\"\"))}{tag_str}  共{d[\"count\"]}条')
+print('─' * 66)
+for i, it in enumerate(items, 1):
+    ori   = f' 原{it[\"oriPrice\"]}' if it.get('oriPrice') else ''
+    kind  = '🏪' if it.get('isShop') else '👤'
+    title = it['title'][:50]
+    pub   = ''
+    if it.get('publishTime'):
+        ts  = int(it['publishTime']) // 1000
+        pub = datetime.datetime.fromtimestamp(ts).strftime('%m-%d %H:%M')
+    print(f'[{i:02d}] ¥{it[\"price\"]}{ori}')
+    print(f'     {title}')
+    print(f'     📍{it[\"area\"]}  {kind}({it[\"reviewCount\"]}评){it[\"seller\"]}  ❤️{it.get(\"want\",\"0\")}想  🕐{pub}')
+    app_url = 'fleamarket://item?id=' + (it['url'].split('id=')[-1])
+    print(f'     🔗 {it[\"url\"]}')
+    print(f'     📱 {app_url}')
+    print()
+"
+fi


### PR DESCRIPTION
## 🐟 xianyu-hub — Goofish (闲鱼) Skill

A browser-based skill for **Goofish (闲鱼/咸鱼)**, China's largest second-hand marketplace.

### How it works

Injects JS into a logged-in `goofish.com` browser tab via `minis-browser-use execute_js`, calling `window.lib.mtop.request()` directly — **no Cookie/signature management needed**.

### Scripts

| Script | Function |
|---|---|
| `search.sh` | Keyword search with sorting, price range, city filter, personal-only |
| `detail.sh` | Item detail — price, description, seller credit & stats |
| `favorites.sh` | Favorites management — list / add / remove |
| `orders.sh` | Order history — bought list with status filter |
| `my_items.sh` | List user's published items |

### Features

- 🔍 Full search with 5 sort modes (`default` / `price_asc` / `price_desc` / `time` / `reduce`)
- 🏷️ Price range & city client-side filtering
- 👤 Personal-only filter (by seller review count)
- 🔗 Outputs both web URLs and `fleamarket://` APP deep links
- 🔐 Auto-detects goofish tab + login state; uses `minis-open` for login when needed
- 📦 JSON output mode (`-j` flag) for programmatic use

### Prerequisites

- Minis app with built-in browser
- User logs in to `goofish.com` once in the browser (skill auto-detects and prompts if not logged in)

### Example usage

```sh
# Search MacBook Air, sorted by price
sh scripts/search.sh -k "MacBook Air" -s price_asc --min-price 2000 -n 10

# Get item details
sh scripts/detail.sh 1234567890

# Manage favorites
sh scripts/favorites.sh list
sh scripts/favorites.sh add 1234567890

# Check orders
sh scripts/orders.sh -t wait_send
```