### PR TITLE
fix(xianyu-hub): add ensure_tab.sh, fix tab detection & auto login polling

### DIFF
--- a/xianyu-hub/SKILL.md
+++ b/xianyu-hub/SKILL.md
@@ -17,30 +17,19 @@ description: >
 
 ## 启动流程（每次使用前执行）
 
-全程用 `minis-browser-use` CLI。
+所有脚本都会**自动调用 `ensure_tab.sh`** 完成以下步骤，**无需手动传 `--tab-id`**。
 
-### Step 1：确保浏览器有闲鱼 tab
+### ensure_tab.sh 自动处理逻辑
 
-```sh
-minis-browser-use list_tabs --compact -q  # 看有没有 goofish.com
-# 没有则：
-minis-browser-use navigate --url "https://www.goofish.com"
-```
+1. **扫描所有 tab** — 解析 `list_tabs` 文本，找含 `goofish.com` 的 tab
+2. **检查登录态** — 执行 JS 判断当前页是否已登录
+3. **已登录** → 直接输出 tab_id，脚本继续执行
+4. **未登录** → 自动执行：
+   - `navigate` 跳转到闲鱼首页
+   - `minis-open` 弹出内置浏览器供用户登录
+   - **每 5 秒轮询登录状态，最多等 120 秒**，登录成功自动继续
 
-### Step 2：检查登录状态
-
-```sh
-minis-browser-use execute_js --tab-id <id> \
-  --script 'return window.location.href.includes("passport") ? "not_login" : (window.lib && window.lib.mtop ? "ok" : "loading")' \
-  --compact -q
-```
-
-- `"ok"` → 已登录，执行操作
-- 其他 → 未登录，执行：
-  ```sh
-  minis-open https://www.goofish.com
-  ```
-  并告知用户：「闲鱼尚未登录，已打开内置浏览器，请完成登录后告诉我 🐟」
+> 若需手动指定 tab，可传 `--tab-id <id>`，脚本仍会验证登录态。
 
 ## 脚本一览
 
@@ -119,3 +108,5 @@ apple-open "fleamarket://item?id=<商品ID>"    # 跳转闲鱼 APP
 - 城市/价格区间为客户端过滤
 - `--personal-only` 按评价数判断（>10条视为店铺），不绝对准确
 - 敏感词被平台屏蔽时返回空结果，属正常现象
+- `ensure_tab.sh` 依赖 `list_tabs` 返回文本格式（`Tab N: 标题 — URL`），格式变更需同步更新解析逻辑
+- 未登录时 `ensure_tab.sh` 会自动轮询等待，**无需用户手动确认登录**，等待期间脚本会阻塞（最多 120 秒）

--- a/xianyu-hub/scripts/ensure_tab.sh
+++ b/xianyu-hub/scripts/ensure_tab.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# ensure_tab.sh
+# 确保浏览器有已登录的闲鱼 tab，输出 tab_id。
+# 若未登录，自动打开闲鱼并用 minis-open 提示用户登录，等待最多 120s。
+#
+# 环境变量：
+#   TAB_ID  — 若已知 tab_id，跳过自动检测（仍会验证登录态）
+
+# ---------- 辅助：检测某 tab 的登录状态 ----------
+check_login() {
+  local tid="$1"
+  minis-browser-use execute_js --tab-id "$tid" \
+    --script 'return window.location.href.includes("passport") ? "not_login" : (window.lib && window.lib.mtop ? "ok" : "loading")' \
+    --compact -q 2>/dev/null \
+    | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('text','').split('\n')[0].strip())
+except Exception:
+    print('error')
+" 2>/dev/null
+}
+
+# ---------- 辅助：扫描所有 tab，找含有闲鱼域名的 tab ----------
+# list_tabs 返回格式：{"success":true,"text":"Open tabs:\n  Tab 0: 标题 — https://... *"}
+find_logged_tab() {
+  local raw
+  raw=$(minis-browser-use list_tabs --compact -q 2>/dev/null)
+  python3 -c "
+import json, sys, re
+try:
+    d = json.loads(sys.argv[1])
+    text = d.get('text', '')
+    for line in text.split('\n'):
+        m = re.search(r'Tab (\d+):.*?(https?://\S+)', line)
+        if m:
+            tab_id = m.group(1)
+            url = m.group(2).rstrip('* ')
+            if 'goofish.com' in url or 'xianyu' in url:
+                print(tab_id)
+                break
+except Exception:
+    pass
+" "$raw" 2>/dev/null
+}
+
+# ---------- 主流程 ----------
+
+# 若调用方已指定 TAB_ID，直接验证并返回
+if [ -n "$TAB_ID" ]; then
+  STATUS=$(check_login "$TAB_ID")
+  if [ "$STATUS" = "ok" ]; then
+    echo "$TAB_ID"
+    exit 0
+  fi
+  # 已指定但未登录，走下面的等待流程
+  TRY_TAB="$TAB_ID"
+else
+  TRY_TAB=$(find_logged_tab)
+fi
+
+# 若找到 tab，检查是否已登录
+if [ -n "$TRY_TAB" ]; then
+  STATUS=$(check_login "$TRY_TAB")
+  if [ "$STATUS" = "ok" ]; then
+    echo "$TRY_TAB"
+    exit 0
+  fi
+fi
+
+# ---------- 未登录：自动 navigate 到闲鱼 ----------
+echo "⏳ 未检测到已登录的闲鱼页面，正在打开…" >&2
+
+# 优先复用已有 tab，没有则打开新页面
+if [ -n "$TRY_TAB" ]; then
+  minis-browser-use navigate --tab-id "$TRY_TAB" --url "https://www.goofish.com" --compact -q >/dev/null 2>&1
+else
+  minis-browser-use navigate --url "https://www.goofish.com" --compact -q >/dev/null 2>&1
+  TRY_TAB=$(find_logged_tab)
+fi
+
+# 同时用 minis-open 让用户看到浏览器
+minis-open "https://www.goofish.com" >/dev/null 2>&1
+
+echo "🐟 已打开闲鱼，请在浏览器中完成登录，最多等待 120 秒…" >&2
+
+# ---------- 轮询等待登录完成（每 5s 一次，最多 24 次）----------
+i=0
+while [ $i -lt 24 ]; do
+  sleep 5
+  i=$((i + 1))
+
+  # 每次重新扫 tab，以防用户在新 tab 登录
+  if [ -z "$TRY_TAB" ]; then
+    TRY_TAB=$(find_logged_tab)
+  fi
+  [ -z "$TRY_TAB" ] && continue
+
+  STATUS=$(check_login "$TRY_TAB")
+  if [ "$STATUS" = "ok" ]; then
+    echo "✅ 登录成功！" >&2
+    echo "$TRY_TAB"
+    exit 0
+  fi
+done
+
+echo "❌ 等待超时，未检测到登录。请手动登录后重试。" >&2
+exit 1


### PR DESCRIPTION
## 问题

之前 `search.sh` / `detail.sh` 等脚本依赖 `ensure_tab.sh` 来自动检测登录状态，但该文件缺失，导致每次调用都必须手动传 `--tab-id`，且未登录时需要用户手动确认后才能继续。

## 改动内容

### 新增：`xianyu-hub/scripts/ensure_tab.sh`

- **自动扫描 tab**：用 Python 正则解析 `list_tabs` 的文本输出（格式：`Tab N: 标题 — URL`），正确提取含 `goofish.com` 的 tab ID
- **自动登录等待**：未登录时自动执行 `navigate` + `minis-open` 弹出浏览器，然后每 5 秒轮询一次登录状态，最多等待 120 秒，登录成功后自动继续，无需用户手动确认
- **修复根本 bug**：旧版用 `grep -o` 解析 JSON 的方式完全无法工作，导致所有脚本自动检测 tab 失效

### 更新：`xianyu-hub/SKILL.md`

- 更新启动流程文档，说明 `ensure_tab.sh` 的自动处理机制
- 补充注意事项：格式依赖说明 + 自动轮询等待行为

## 测试验证

- 在已登录闲鱼的 tab 下，直接运行 `sh scripts/search.sh -k 'Pixel 9' -n 3` 无需 `--tab-id`，正常返回结果 ✅
- `ensure_tab.sh` 单独运行直接输出正确的 tab_id（`0`）✅