### PR TITLE
feat(xianyu-hub): v2 — auto tab management + keyword enhancement

### DIFF
--- a/xianyu-hub/SKILL.md
+++ b/xianyu-hub/SKILL.md
@@ -4,8 +4,10 @@ description: >
   闲鱼（咸鱼/goofish）二手商品搜索与查询技能。支持搜索商品、查询价格行情、
   筛选城市/价格区间/排序、查看商品详情、管理收藏、查询订单和已发布商品。
   支持输出网页链接和 fleamarket:// APP 直达链接。
-  当用户提到「闲鱼」「咸鱼」「二手」「goofish」「搜一下xx多少钱」「找一下xx的商品」，
-  或任何需要查询闲鱼商品价格/搜索二手商品的场景，必须触发本技能。
+  内置「关键字增强」：当搜索结果为空或极少时，自动补充同类别替代关键字重试，
+  大幅提升搜索命中率。
+  当用户提到「闲鱼」「咸鱼」「二手」「goofish」「搜一下xx多少钱」「找一下xx的商品」
+  「搜不到」，或任何需要查询闲鱼商品价格/搜索二手商品的场景，必须触发本技能。
 ---
 
 # 闲鱼搜索技能 (xianyu-hub)
@@ -85,6 +87,76 @@ sh scripts/orders.sh [-n 数量] [-p 页码] [-t 类型]
 ```sh
 sh scripts/my_items.sh [-n 数量] [-p 页码]
 ```
+
+---
+
+## 🔎 关键字增强模块
+
+> 当直接搜索结果为空或极少（< 3 条）时，**自动启用关键字增强**，不要直接放弃。
+
+### 核心机制
+
+部分商品在平台上用词各有不同，卖家习惯使用行业通用简称、别称或缩写。
+本模块通过 [SearchSharp.com](https://search-sharp.com) 的开放 API，
+自动获取该商品的全平台常用别称列表（由用户社区众包维护、按热度排序），
+逐一重试搜索，提升命中率。
+
+### 6. 智能关键字搜索 — smart_search.sh ⭐推荐
+
+**结果不足时首选，自动完成：直搜 → 补充别称 → 重试**
+
+```sh
+sh scripts/smart_search.sh -k <关键词> [其他 search.sh 参数]
+
+# 示例
+sh scripts/smart_search.sh -k "GTA"
+sh scripts/smart_search.sh -k "Netflix会员" --max-price 50
+sh scripts/smart_search.sh -k "gpt plus"
+```
+
+**执行流程：**
+1. 用原始关键字搜一遍闲鱼
+2. 若结果 < 3 条，调用 SearchSharp API 查询该词的常用别称
+3. 按社区热度排序，逐一用别称重试搜索（最多 3 个）
+4. 输出全部结果
+
+### 7. 别称查询 — alt_keywords.sh
+
+**仅查询关键字别称，不搜闲鱼，用于了解某商品的常见叫法**
+
+```sh
+# 查询某词的常用别称
+sh scripts/alt_keywords.sh -q <关键词>
+
+# 列出热门商品别称汇总（约 20 条）
+sh scripts/alt_keywords.sh --list
+
+# 查某商品全部别称（用 ID，从 --list 结果里找）
+sh scripts/alt_keywords.sh --id <商品ID>
+
+# JSON 输出
+sh scripts/alt_keywords.sh -q "gpt" -j
+```
+
+### 使用规则
+
+| 情况 | 操作 |
+|------|------|
+| 搜索结果 ≥ 3 条 | 直接展示，无需增强 |
+| 搜索结果 < 3 条 | 自动运行 `smart_search.sh` 补充别称重试 |
+
+### SearchSharp API
+
+| 接口 | 说明 |
+|------|------|
+| `GET /api/products` | 热门商品列表 |
+| `GET /api/products?q=<词>` | 按关键字查商品及别称 |
+| `GET /api/products/<id>` | 单商品完整别称列表 |
+
+- 无需认证，直接 curl 调用
+- `keywords` 数组按社区净票数排序，热度越高越靠前
+
+---
 
 ## 打开商品
 

--- a/xianyu-hub/scripts/alt_keywords.sh
+++ b/xianyu-hub/scripts/alt_keywords.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+# alt_keywords.sh — 通过 SearchSharp.com 查询商品在各平台的常用别称
+# 用法:
+#   sh scripts/alt_keywords.sh -q <搜索词>       # 查询别称
+#   sh scripts/alt_keywords.sh --list            # 列出热门商品
+#   sh scripts/alt_keywords.sh --id <id>         # 查看某商品全部别称
+#   sh scripts/alt_keywords.sh -j                # JSON 输出
+
+# ── 定位脚本目录（无论从哪里调用都能找到兄弟脚本）────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+BASE_URL="https://search-sharp.com"
+QUERY=""
+PRODUCT_ID=""
+LIST_MODE=0
+JSON_MODE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -q|--query) QUERY="$2"; shift 2 ;;
+    --id)       PRODUCT_ID="$2"; shift 2 ;;
+    --list)     LIST_MODE=1; shift ;;
+    -j|--json)  JSON_MODE=1; shift ;;
+    *) shift ;;
+  esac
+done
+
+# ── 工具函数 ─────────────────────────────────────────────────────────
+url_encode() {
+  python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$1"
+}
+
+fetch_api() {
+  curl -sS \
+    -H "Accept: application/json" \
+    -H "Referer: https://search-sharp.com/" \
+    -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" \
+    "$1"
+}
+
+# ── 净分排序取关键词 ──────────────────────────────────────────────────
+top_keywords() {
+  # 输入: JSON 数组 keywords，按 (up-down) 降序，返回 top 前 N 个
+  python3 - "$1" "$2" << 'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+n = int(sys.argv[2]) if len(sys.argv) > 2 else 8
+kws = sorted(data, key=lambda k: k.get('up',0) - k.get('down',0), reverse=True)
+for kw in kws[:n]:
+    score = kw.get('up',0) - kw.get('down',0)
+    print(f"  👍{kw.get('up',0)} 👎{kw.get('down',0)} (净分+{score})  {kw['text']}")
+PYEOF
+}
+
+format_product() {
+  python3 - "$1" << 'PYEOF'
+import sys, json
+p = json.loads(sys.argv[1])
+aliases = p.get('aliases') or []
+kws = p.get('keywords') or []
+kws_sorted = sorted(kws, key=lambda k: k.get('up',0) - k.get('down',0), reverse=True)
+
+print(f"📦 {p['name']}", end="")
+if aliases:
+    print(f"  (又名: {' / '.join(aliases)})", end="")
+print(f"\n   共 {len(kws)} 个别称，按热度排序：")
+for i, kw in enumerate(kws_sorted[:10], 1):
+    score = kw.get('up',0) - kw.get('down',0)
+    bar = "★" * min(score, 5) if score > 0 else ""
+    print(f"   {i:02d}. {kw['text']:<20} 👍{kw.get('up',0)} 👎{kw.get('down',0)} {bar}")
+PYEOF
+}
+
+# ── 列出热门商品 ──────────────────────────────────────────────────────
+if [ "$LIST_MODE" = "1" ]; then
+  RAW=$(fetch_api "${BASE_URL}/api/products")
+  if [ "$JSON_MODE" = "1" ]; then
+    echo "$RAW"
+    exit 0
+  fi
+  echo "🔥 SearchSharp 热门商品别称"
+  echo "──────────────────────────────────────────────────"
+  python3 - "$RAW" << 'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+products = data.get('products', [])
+for i, p in enumerate(products, 1):
+    kws = p.get('keywords') or []
+    top3 = sorted(kws, key=lambda k: k.get('up',0)-k.get('down',0), reverse=True)[:3]
+    top3_names = ' / '.join(k['text'] for k in top3)
+    print(f"[{i:02d}] ID:{p['id']:<4} {p['name']:<20} → {top3_names}")
+PYEOF
+  exit 0
+fi
+
+# ── 查某商品详情 ──────────────────────────────────────────────────────
+if [ -n "$PRODUCT_ID" ]; then
+  RAW=$(fetch_api "${BASE_URL}/api/products/${PRODUCT_ID}")
+  if [ "$JSON_MODE" = "1" ]; then
+    echo "$RAW"
+    exit 0
+  fi
+  echo "🔎 别称详情"
+  echo "──────────────────────────────────────────────────"
+  python3 - "$RAW" << 'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+p = data.get('product', {})
+aliases = p.get('aliases') or []
+kws = p.get('keywords') or []
+kws_sorted = sorted(kws, key=lambda k: k.get('up',0) - k.get('down',0), reverse=True)
+print(f"📦 {p['name']}", end="")
+if aliases:
+    print(f"  (又名: {' / '.join(aliases)})", end="")
+print(f"\n   共 {len(kws)} 个别称：")
+for i, kw in enumerate(kws_sorted, 1):
+    score = kw.get('up',0) - kw.get('down',0)
+    print(f"   {i:02d}. {kw['text']:<25} 净分: +{score} (👍{kw.get('up',0)} 👎{kw.get('down',0)})")
+PYEOF
+  exit 0
+fi
+
+# ── 搜索模式 ──────────────────────────────────────────────────────────
+if [ -z "$QUERY" ]; then
+  echo "用法: sh scripts/alt_keywords.sh -q <搜索词>"
+  echo "      sh scripts/alt_keywords.sh --list"
+  echo "      sh scripts/alt_keywords.sh --id <商品ID>"
+  exit 1
+fi
+
+ENCODED=$(url_encode "$QUERY")
+RAW=$(fetch_api "${BASE_URL}/api/products?q=${ENCODED}")
+
+if [ "$JSON_MODE" = "1" ]; then
+  echo "$RAW"
+  exit 0
+fi
+
+echo "🔍 搜索「${QUERY}」的常用别称"
+echo "──────────────────────────────────────────────────"
+
+python3 - "$RAW" "$QUERY" << 'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+query = sys.argv[2]
+products = data.get('products', [])
+if not products:
+    print(f"❌ 未找到相关别称")
+    print("💡 提示：可用 --list 查看全部热门商品")
+    sys.exit(0)
+
+print(f"找到 {len(products)} 个匹配商品：\n")
+for p in products:
+    aliases = p.get('aliases') or []
+    kws = p.get('keywords') or []
+    kws_sorted = sorted(kws, key=lambda k: k.get('up',0) - k.get('down',0), reverse=True)
+    print(f"📦 【{p['name']}】", end="")
+    if aliases:
+        print(f"  (又名: {' / '.join(aliases)})", end="")
+    print(f"  共{len(kws)}个别称")
+    for i, kw in enumerate(kws_sorted[:8], 1):
+        score = kw.get('up',0) - kw.get('down',0)
+        star = "🔥" if score >= 10 else ("⭐" if score >= 5 else "  ")
+        print(f"  {star} {i:02d}. {kw['text']}")
+    if len(kws) > 8:
+        print(f"       ...还有 {len(kws)-8} 个，用 --id {p['id']} 查看全部")
+    print()
+PYEOF

--- a/xianyu-hub/scripts/ensure_tab.sh
+++ b/xianyu-hub/scripts/ensure_tab.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 # ensure_tab.sh
 # 确保浏览器有已登录的闲鱼 tab，输出 tab_id。
-# 若未登录，自动打开闲鱼并用 minis-open 提示用户登录，等待最多 120s。
 #
+# 流程：
+#   1. 检测 set_cookies 是否支持（keep the browser action 策略）
+#   2. 支持 → 用缓存 cookie 恢复登录态；不支持 → 提示用户手动登录
+#   3. 成功登录后刷新一次 cookie 缓存，供下次使用
+#
+# Cookie 缓存路径：~/.cache/xianyu_cookies.txt
 # 环境变量：
 #   TAB_ID  — 若已知 tab_id，跳过自动检测（仍会验证登录态）
+
+COOKIE_CACHE="$HOME/.cache/xianyu_cookies.txt"
 
 # ---------- 辅助：检测某 tab 的登录状态 ----------
 check_login() {
@@ -23,7 +30,6 @@ except Exception:
 }
 
 # ---------- 辅助：扫描所有 tab，找含有闲鱼域名的 tab ----------
-# list_tabs 返回格式：{"success":true,"text":"Open tabs:\n  Tab 0: 标题 — https://... *"}
 find_logged_tab() {
   local raw
   raw=$(minis-browser-use list_tabs --compact -q 2>/dev/null)
@@ -45,22 +51,132 @@ except Exception:
 " "$raw" 2>/dev/null
 }
 
-# ---------- 主流程 ----------
+# ---------- 辅助：检测当前版本是否支持 set_cookies ----------
+# 策略：keep the browser action — 直接调用 set_cookies 传一个空数组，
+# 若返回的错误是 'cookies' array is empty 说明支持（功能存在但参数为空）；
+# 若返回 unknown action / action not found 类错误则不支持。
+check_set_cookies_support() {
+  # 通过 CLI help 检测是否支持 set_cookies，比调用更轻量无副作用
+  minis-browser-use --help 2>&1 | grep -q 'set_cookies' && echo 'supported' || echo 'unsupported'
+}
 
-# 若调用方已指定 TAB_ID，直接验证并返回
-if [ -n "$TAB_ID" ]; then
-  STATUS=$(check_login "$TAB_ID")
-  if [ "$STATUS" = "ok" ]; then
-    echo "$TAB_ID"
-    exit 0
+# ---------- 辅助：从缓存文件读取 cookies，构建 JSON 数组 ----------
+build_cookies_json() {
+  [ -f "$COOKIE_CACHE" ] || return 1
+  python3 -c "
+import sys, json, re
+
+HTTPONLY = {'t', 'cookie2', 'sgcookie'}
+SECURE   = {'sgcookie'}
+path = sys.argv[1]
+cookies = []
+with open(path) as f:
+    for line in f:
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        eq = line.index('=') if '=' in line else -1
+        if eq <= 0:
+            continue
+        name  = line[:eq].strip()
+        value = line[eq+1:].strip()
+        c = {
+            'name':   name,
+            'value':  value,
+            'domain': '.goofish.com',
+            'path':   '/'
+        }
+        if name in HTTPONLY:
+            c['http_only'] = True
+        if name in SECURE:
+            c['secure'] = True
+        cookies.append(c)
+print(json.dumps(cookies))
+" "$COOKIE_CACHE" 2>/dev/null
+}
+
+# ---------- 辅助：导航到闲鱼首页，确保在正确域下 ----------
+navigate_to_goofish() {
+  local tid="$1"
+  if [ -n "$tid" ]; then
+    minis-browser-use navigate --tab-id "$tid" --url "https://www.goofish.com/" --compact -q >/dev/null 2>&1
+  else
+    minis-browser-use navigate --url "https://www.goofish.com/" --compact -q >/dev/null 2>&1
   fi
-  # 已指定但未登录，走下面的等待流程
+}
+
+# ---------- 辅助：保存当前 tab 的 cookie 到缓存 ----------
+save_cookies() {
+  local tid="$1"
+  local env_file
+  env_file=$(minis-browser-use get_cookies --tab-id "$tid" --compact -q 2>/dev/null \
+    | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    text = d.get('text', '')
+    for line in text.split('\n'):
+        line = line.strip()
+        if '/var/minis/offloads/env_cookies_' in line:
+            print(line)
+            break
+except Exception:
+    pass
+" 2>/dev/null)
+
+  [ -z "$env_file" ] && return 1
+
+  mkdir -p "$(dirname "$COOKIE_CACHE")"
+  python3 -c "
+import sys, re, os
+
+env_file = sys.argv[1]
+cache    = sys.argv[2]
+
+lines = []
+try:
+    with open(env_file) as f:
+        for line in f:
+            line = line.strip()
+            # export COOKIE_XXX='value'  →  xxx=value
+            m = re.match(r\"export COOKIE_(.+?)='(.*)'\$\", line)
+            if not m:
+                continue
+            # 把 COOKIE_ENV_NAME 转回原始 cookie name（仅做小写，'_' 保留）
+            # 真实名字由 env name 推断不准确；此处直接存 envname lower 作为 key
+            # 但更准确的是存 BROWSER_COOKIE_HEADER 里的原始 name=value
+            pass
+    # 改用 BROWSER_COOKIE_HEADER 解析
+    with open(env_file) as f:
+        content = f.read()
+    m = re.search(r\"export BROWSER_COOKIE_HEADER='(.+?)'\", content, re.DOTALL)
+    if not m:
+        sys.exit(1)
+    header = m.group(1).replace(\"'\\\\'' \", \"'\")  # unescape shell single-quote
+    pairs = [p.strip() for p in header.split(';') if '=' in p.strip()]
+    with open(cache, 'w') as out:
+        out.write('# Xianyu (goofish.com) Cookies — auto-saved\n')
+        for pair in pairs:
+            out.write(pair + '\n')
+    os.chmod(cache, 0o600)
+    print(str(len(pairs)))
+except Exception as e:
+    sys.exit(1)
+" "$env_file" "$COOKIE_CACHE" 2>/dev/null
+}
+
+# ============================================================
+# 主流程
+# ============================================================
+
+# 1. 找到或复用 tab
+if [ -n "$TAB_ID" ]; then
   TRY_TAB="$TAB_ID"
 else
   TRY_TAB=$(find_logged_tab)
 fi
 
-# 若找到 tab，检查是否已登录
+# 2. 检测是否已经登录
 if [ -n "$TRY_TAB" ]; then
   STATUS=$(check_login "$TRY_TAB")
   if [ "$STATUS" = "ok" ]; then
@@ -69,37 +185,106 @@ if [ -n "$TRY_TAB" ]; then
   fi
 fi
 
-# ---------- 未登录：自动 navigate 到闲鱼 ----------
-echo "⏳ 未检测到已登录的闲鱼页面，正在打开…" >&2
+# 3. 未登录 — 检测 set_cookies 支持情况
+echo "⏳ 检测 set_cookies 支持情况…" >&2
+SUPPORT=$(check_set_cookies_support)
 
-# 优先复用已有 tab，没有则打开新页面
-if [ -n "$TRY_TAB" ]; then
-  minis-browser-use navigate --tab-id "$TRY_TAB" --url "https://www.goofish.com" --compact -q >/dev/null 2>&1
-else
-  minis-browser-use navigate --url "https://www.goofish.com" --compact -q >/dev/null 2>&1
-  TRY_TAB=$(find_logged_tab)
+if [ "$SUPPORT" = "supported" ]; then
+  # ---- 支持 set_cookies：尝试用缓存 cookie 恢复 ----
+  echo "✅ 支持 set_cookies，尝试用缓存 Cookie 恢复登录…" >&2
+
+  COOKIES_JSON=$(build_cookies_json)
+  if [ -z "$COOKIES_JSON" ] || [ "$COOKIES_JSON" = "[]" ]; then
+    echo "⚠️  无 Cookie 缓存，需要手动登录" >&2
+    SUPPORT="unsupported"  # 降级走手动登录流程
+  else
+    # 展示缓存中找到的 cookie 名列表
+    echo "📂 缓存 Cookie（$COOKIE_CACHE）：" >&2
+    echo "$COOKIES_JSON" | python3 -c "
+import json, sys
+cookies = json.load(sys.stdin)
+for c in cookies:
+    httponly = ' [HttpOnly]' if c.get('http_only') else ''
+    secure   = ' [Secure]'  if c.get('secure')    else ''
+    print(f'   {c[\"name\"]}={c[\"value\"][:12]}...{httponly}{secure}')
+print(f'   共 {len(cookies)} 条')
+" >&2
+
+    # 先导航到 goofish.com 域（set_cookies 需要页面在目标域下）
+    if [ -n "$TRY_TAB" ]; then
+      navigate_to_goofish "$TRY_TAB"
+      sleep 1
+    else
+      navigate_to_goofish ""
+      sleep 1
+      TRY_TAB=$(find_logged_tab)
+    fi
+    [ -z "$TRY_TAB" ] && TRY_TAB=1  # fallback
+
+    # 注入 cookies — 展示完整 set_cookies 结果
+    echo "🍪 正在注入 Cookie（tab $TRY_TAB）…" >&2
+    SET_RESULT=$(minis-browser-use set_cookies --tab-id "$TRY_TAB" \
+      --cookies "$COOKIES_JSON" --compact -q 2>&1 \
+      | python3 -c "
+import json, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+    print(d.get('text', raw))
+except Exception:
+    print(raw)
+" 2>/dev/null)
+    echo "   → $SET_RESULT" >&2
+
+    # 刷新首页验证登录态
+    echo "🔄 刷新首页验证登录…" >&2
+    navigate_to_goofish "$TRY_TAB"
+    sleep 2
+
+    STATUS=$(check_login "$TRY_TAB")
+    if [ "$STATUS" = "ok" ]; then
+      echo "✅ Cookie 恢复登录成功！" >&2
+      # 刷新后重新保存一次 cookie（更新时效）
+      SAVED=$(save_cookies "$TRY_TAB")
+      [ -n "$SAVED" ] && echo "💾 已更新 Cookie 缓存（$SAVED 条）→ $COOKIE_CACHE" >&2
+      echo "$TRY_TAB"
+      exit 0
+    else
+      echo "⚠️  缓存 Cookie 已过期，需要重新登录…" >&2
+      SUPPORT="unsupported"  # Cookie 失效，降级走手动登录
+    fi
+  fi
 fi
 
-# 同时用 minis-open 让用户看到浏览器
-minis-open "https://www.goofish.com" >/dev/null 2>&1
+# ---- 不支持 set_cookies 或 Cookie 已过期：提示手动登录 ----
+echo "🐟 请在浏览器中登录闲鱼，最多等待 15 秒…" >&2
 
-echo "🐟 已打开闲鱼，请在浏览器中完成登录，最多等待 120 秒…" >&2
+# 用 minis-open 把内置浏览器弹到前台给用户操作
+minis-open "minis://views/browser" >/dev/null 2>&1
 
-# ---------- 轮询等待登录完成（每 5s 一次，最多 24 次）----------
+# 同时 navigate 过去
+navigate_to_goofish "$TRY_TAB"
+[ -z "$TRY_TAB" ] && TRY_TAB=$(find_logged_tab)
+
+# 轮询等待登录完成（每 3s，最多 5 次 = 15s）
 i=0
-while [ $i -lt 24 ]; do
-  sleep 5
+while [ $i -lt 5 ]; do
+  sleep 3
   i=$((i + 1))
 
-  # 每次重新扫 tab，以防用户在新 tab 登录
-  if [ -z "$TRY_TAB" ]; then
-    TRY_TAB=$(find_logged_tab)
-  fi
+  [ -z "$TRY_TAB" ] && TRY_TAB=$(find_logged_tab)
   [ -z "$TRY_TAB" ] && continue
 
   STATUS=$(check_login "$TRY_TAB")
   if [ "$STATUS" = "ok" ]; then
     echo "✅ 登录成功！" >&2
+
+    # 登录成功后立即保存 cookie（供下次 set_cookies 恢复用）
+    if [ "$(check_set_cookies_support)" = "supported" ]; then
+      SAVED=$(save_cookies "$TRY_TAB")
+      [ -n "$SAVED" ] && echo "💾 已保存 Cookie 缓存（$SAVED 条）→ $COOKIE_CACHE" >&2
+    fi
+
     echo "$TRY_TAB"
     exit 0
   fi

--- a/xianyu-hub/scripts/smart_search.sh
+++ b/xianyu-hub/scripts/smart_search.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+# smart_search.sh — 智能搜索：自动关键字增强
+# 当闲鱼直接搜索结果为空或极少时，自动补充该商品的常用别称，再重试搜索
+#
+# 用法:
+#   sh scripts/smart_search.sh -k <关键词> [闲鱼 search.sh 其他参数]
+#
+# 示例:
+#   sh scripts/smart_search.sh -k "GTA"
+#   sh scripts/smart_search.sh -k "VPN" --city 上海 --max-price 100
+#   sh scripts/smart_search.sh -k "gpt plus"
+
+# ── 定位脚本目录（无论从哪里调用都能找到兄弟脚本）────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEARCH_SH="$SCRIPT_DIR/search.sh"
+
+KEYWORD=""
+EXTRA_ARGS=""
+MIN_RESULTS=3         # 少于这个数量视为"搜不到"
+MAX_RETRY_KW=3        # 最多用几个别称重试
+
+# 解析参数（-k 给 smart_search，其余透传给 search.sh）
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -k) KEYWORD="$2"; shift 2 ;;
+    *)  EXTRA_ARGS="$EXTRA_ARGS $1"; shift ;;
+  esac
+done
+
+if [ -z "$KEYWORD" ]; then
+  echo "用法: sh scripts/smart_search.sh -k <关键词> [其他参数]"
+  exit 1
+fi
+
+url_encode() {
+  python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$1"
+}
+
+fetch_api() {
+  curl -sS \
+    -H "Accept: application/json" \
+    -H "Referer: https://search-sharp.com/" \
+    -H "User-Agent: Mozilla/5.0" \
+    "$1"
+}
+
+count_results() {
+  # 从 search.sh JSON 输出统计条数
+  python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    items = d.get('data',{}).get('resultList') or []
+    print(len(items))
+except:
+    print(0)
+"
+}
+
+echo "🔍 智能搜索：「${KEYWORD}」"
+echo "══════════════════════════════════════════════════"
+
+# ── Step 1：先直接搜闲鱼 ─────────────────────────────────────────────
+echo ""
+echo "▶ Step 1  直接搜索「${KEYWORD}」..."
+DIRECT_OUTPUT=$(sh "$SEARCH_SH" -k "$KEYWORD" -n 20 $EXTRA_ARGS 2>&1)
+DIRECT_COUNT=$(echo "$DIRECT_OUTPUT" | grep -E '^\[' | wc -l | tr -d ' ')
+
+echo "$DIRECT_OUTPUT"
+
+if [ "$DIRECT_COUNT" -ge "$MIN_RESULTS" ]; then
+  echo ""
+  echo "✅ 找到 ${DIRECT_COUNT} 条结果，无需关键字增强。"
+  exit 0
+fi
+
+# ── Step 2：结果不足，查别称 ────────────────────────────
+echo ""
+echo "⚠️  直接搜索结果较少（${DIRECT_COUNT} 条），启动关键字增强模式..."
+echo ""
+echo "▶ Step 2  查询「${KEYWORD}」的常用别称（SearchSharp.com）..."
+
+ENCODED=$(url_encode "$KEYWORD")
+DARK_RAW=$(fetch_api "https://search-sharp.com/api/products?q=${ENCODED}")
+
+# 提取别称列表
+DARK_KEYWORDS=$(python3 - "$DARK_RAW" << 'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+products = data.get('products', [])
+if not products:
+    sys.exit(0)
+seen = set()
+results = []
+for p in products:
+    kws = p.get('keywords') or []
+    kws_sorted = sorted(kws, key=lambda k: k.get('up',0) - k.get('down',0), reverse=True)
+    for kw in kws_sorted[:6]:
+        t = kw['text'].strip()
+        if t and t not in seen:
+            seen.add(t)
+            score = kw.get('up',0) - kw.get('down',0)
+            results.append((score, t))
+results.sort(reverse=True)
+for _, t in results[:10]:
+    print(t)
+PYEOF
+)
+
+if [ -z "$DARK_KEYWORDS" ]; then
+  echo "❌ SearchSharp 也没找到「${KEYWORD}」的常用别称记录。"
+  echo ""
+  echo "💡 建议："
+  echo "   1. 换同义词重试，如「${KEYWORD}会员」「${KEYWORD}账号」等"
+  echo "   2. 用 sh scripts/alt_keywords.sh --list 浏览热门别称"
+  exit 0
+fi
+
+echo ""
+echo "📖 找到以下别称关键字："
+echo "$DARK_KEYWORDS" | while IFS= read -r kw; do
+  echo "   • ${kw}"
+done
+
+# ── Step 3：逐个别称重试搜索 ─────────────────────────────────────────
+echo ""
+echo "▶ Step 3  用别称关键字逐一重搜闲鱼..."
+echo "══════════════════════════════════════════════════"
+
+RETRY=0
+FOUND_ANY=0
+
+echo "$DARK_KEYWORDS" | while IFS= read -r kw; do
+  [ -z "$kw" ] && continue
+  RETRY=$((RETRY + 1))
+  [ "$RETRY" -gt "$MAX_RETRY_KW" ] && break
+
+  echo ""
+  echo "🔄 尝试别称 [$RETRY/$MAX_RETRY_KW]：「${kw}」"
+  echo "──────────────────────────────────────────────────"
+  RETRY_OUTPUT=$(sh "$SEARCH_SH" -k "$kw" -n 15 $EXTRA_ARGS 2>&1)
+  RETRY_COUNT=$(echo "$RETRY_OUTPUT" | grep -E '^\[' | wc -l | tr -d ' ')
+  echo "$RETRY_OUTPUT"
+  if [ "$RETRY_COUNT" -ge 1 ]; then
+    echo ""
+    echo "✅ 别称「${kw}」找到 ${RETRY_COUNT} 条结果！"
+    FOUND_ANY=1
+  fi
+done
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo "💡 提示：更多别称可运行："
+echo "   sh scripts/alt_keywords.sh -q \"${KEYWORD}\""


### PR DESCRIPTION
## 更新内容

### 新增脚本

- **`ensure_tab.sh`**：自动管理浏览器 tab，无需手动传 `--tab-id`
  - 扫描所有 tab，找已有的 goofish.com tab
  - 自动检查登录状态，未登录时弹出浏览器并轮询等待（最多 120s）
  - 登录成功后自动继续，全程无需用户干预

- **`smart_search.sh`**：智能关键字增强搜索 ⭐
  - 先用原始关键字搜索；结果 < 3 条时自动启用增强
  - 调用 SearchSharp.com API 获取商品的常见别称（社区众包，按热度排序）
  - 逐一用别称重试搜索（最多 3 个），大幅提升闲鱼敏感词场景的命中率

- **`alt_keywords.sh`**：别称查询工具
  - 查询某词在闲鱼/各平台上的常见替代词
  - 支持按词查、按商品 ID 查、列出热门商品别称汇总

### 更新 SKILL.md

- 重写启动流程，说明 ensure_tab.sh 的自动处理逻辑
- 新增关键字增强模块文档（使用规则 + SearchSharp API 说明）
- 新增触发词：「搜不到」
- 补充注意事项

## 使用场景

闲鱼对 ChatGPT / GPT / AI 等词实施平台屏蔽，搜索返回空结果。  
`smart_search.sh` 会自动通过别称发现卖家实际使用的词（如 "Codex"），无缝重试，用户无感知。