### PR TITLE
Add openstreetmap-marker skill

### DIFF
--- a/openstreetmap-marker/SKILL.md
+++ b/openstreetmap-marker/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: openstreetmap-marker
+version: 1.1.0
+description: Generate a mobile-first, immersive, Amap(Gaode)-style custom landmark marker HTML map for travel itinerary planning, place showcasing, location sharing, etc. Built on Leaflet + OpenStreetMap, no API key required. Trigger when the user mentions "annotate a map", "travel map", "itinerary map", "mark locations", "map display", "trip planning map", "OpenStreetMap marker", or asks to generate a map page for a city/set of places. Includes a built-in GCJ-02 (Mars/China coordinate system used by Amap/Tencent/Baidu/Apple Maps search results in mainland China) to WGS-84 (Leaflet basemap coordinate system) conversion tool to avoid marker offset in mainland China.
+---
+
+# OpenStreetMap Marker
+
+Generates a self-contained, browser-previewable custom marker map HTML page styled after Amap's mobile app (light minimal basemap + circular colored icon + text label + immersive full-screen layout with safe-area support).
+
+## Core Workflow
+
+1. **Get marker coordinates**: prefer `apple-maps search --query "place name city" --lat <city lat> --lon <city lng> --limit 1 -q --compact`, which returns JSON with `lat`/`lon`/`coordinate_system`.
+2. **Coordinate conversion (critical, do not skip)**: apple-maps / Amap / Tencent / Baidu almost always return **GCJ-02** coordinates in mainland China, while this skill's Leaflet+OSM/CartoDB basemap uses **WGS-84**. Using GCJ-02 directly causes markers to drift tens to hundreds of meters (often landing in a river/sea). Coordinates within mainland China MUST be converted with `scripts/gcj_convert.py` before writing to landmarks.json; the script auto-skips conversion for points outside China (out_of_china check).
+   ```bash
+   python3 /var/minis/skills/openstreetmap-marker/scripts/gcj_convert.py <lng> <lat>
+   # outputs "wgs_lat,wgs_lng"
+   ```
+3. **Assemble landmarks.json**: an array, each item:
+   ```json
+   {"name": "West Lake", "desc": "UNESCO World Heritage Site, Hangzhou's iconic landmark", "address": "Xihu District, Hangzhou", "lat": 30.2614, "lng": 120.1443, "type": "green", "icon": "fa-tree"}
+   ```
+   - `name`/`lat`/`lng` required; `desc`/`address`/`type`/`icon` optional
+   - `type` determines the marker dot color: `red` (government/medical/core attraction) `green` (park/nature) `blue` (transport/building) `purple` (commercial/venue) `brown` (heritage/university) `orange` (other), defaults to blue. Each type also has a sensible **default Font Awesome icon** (red→fa-star, green→fa-tree, blue→fa-building, purple→fa-bag-shopping, brown→fa-landmark, orange→fa-circle-dot) — leave `icon` empty to use it.
+   - `icon` (optional): a Font Awesome 6 **solid**-style icon class name, e.g. `"fa-train"`, `"fa-utensils"`, `"fa-mosque"`, `"fa-museum"`, `"fa-mountain"`. Overrides the type default. Look up icon names at fontawesome.com/icons (free "solid" set) — do NOT use emoji, all icons are unified Font Awesome glyphs rendered via `<i class="fa-solid ...">` for a consistent cross-device look.
+   - Write this JSON array to a temp file with file_write, e.g. `/tmp/landmarks.json`
+4. **Generate the page**:
+   ```bash
+   python3 /var/minis/skills/openstreetmap-marker/scripts/build_map.py \
+     /tmp/landmarks.json /var/minis/workspace/<descriptive-filename>.html \
+     --title "West Lake Area Landmarks" --header "⚡ Hangzhou Trip" \
+     --style light
+   ```
+   - `--style light` (default, light minimal, Amap-like palette) or `--style dark` (dark immersive)
+   - Without `--center`/`--zoom`, the script auto-centers/zooms to fit all points with padding; a single point defaults to zoom 14
+5. **Deliver**: present the result to the user as a Markdown link `[Preview](minis://workspace/<filename>.html)`, tappable to open in the built-in browser.
+
+## Built-in style features (already handled by the template, no need to re-explain)
+
+- Full-screen immersive: `viewport-fit=cover` + `env(safe-area-inset-*)` for notch/Dynamic Island devices
+- Semi-transparent top status bar (live clock on the left, custom header text on the right)
+- No bottom search bar / tab bar / side floating buttons (kept minimal per user preference — just map + markers)
+- Markers are circular colored icons (Font Awesome, loaded via CDN `cdnjs.cloudflare.com/.../font-awesome/...`) + white text label pills for a unified, non-emoji icon style
+- Leaflet zoom control hidden by default (`zoomControl: false`) for a clean UI
+- **Tapping a marker opens a Google-Maps-style bottom info card** (not Leaflet's default popup) showing: title (with FA icon), address (if provided, 📍-style row), coordinates (lat, lng), and desc as a note below a divider — no ratings/route/save/share buttons, kept intentionally minimal. A close (✕) button and tapping the basemap both dismiss it.
+- The info card has a single **"Open Location in..." button**, which slides up a bottom action sheet listing available map apps vertically (Amap / Google Maps / Apple Maps), each with an FA icon; a "Cancel" row closes the sheet. Available options are platform-aware:
+  - **Amap** (labeled "高德地图" in the sheet UI): only shown if the point falls within mainland China (coarse lat/lng range check). landmarks.json stores WGS-84 — the frontend JS auto-converts WGS-84→GCJ-02 before building the Amap deep link.
+  - **Google Maps**: always shown.
+  - **Apple Maps**: only shown on iOS (UA-detected); hidden on Android since it's not a relevant/installable app there.
+  - Platform is detected via `navigator.userAgent` (`isAndroid` / `isIOS`). Each option first tries a **native URL scheme / intent** to directly launch the installed app even from inside an embedded WebView — plain `https://` links alone do NOT auto-launch native apps in an embedded webview (only a full browser like Safari/Chrome does that reliably). A short `setTimeout` fallback then redirects to the equivalent `https://` web link if the scheme silently fails (app not installed):
+    - Amap: `iosamap://` (iOS) / `amapuri://` (Android) → fallback `https://uri.amap.com/marker?...`
+    - Google Maps: `comgooglemaps://` (iOS) / `geo:lat,lng?q=...` (Android) → fallback `https://www.google.com/maps/search/?api=1&query=...`
+    - Apple Maps: `maps://` → fallback `https://maps.apple.com/?ll=...`
+
+## Tile provider note
+
+Uses CARTO's free Voyager/Dark basemap tiles (no API key required) — fine for personal/demo use, but subject to CARTO's rate limits and non-commercial-scale terms. For high-traffic production use, switch `TILE_STYLES` in `scripts/build_map.py` to a licensed provider (Mapbox, Stadia Maps, etc.).
+
+## Common adjustments
+
+- Change basemap: edit `TILE_STYLES` in `scripts/build_map.py` and add a new key, e.g. Esri World Imagery tile URL for satellite view
+- Add routes/tracks: append `L.polyline([[lat,lng],...]).addTo(map)` to the generated HTML; these coordinates also need GCJ-02→WGS-84 conversion first if in mainland China
+- Multi-day itineraries: generate one HTML per day, or use different `type` colors to distinguish Day1/Day2/Day3
+
+## Reference files
+
+- `scripts/gcj_convert.py` — GCJ-02→WGS-84 coordinate conversion (single-point CLI and batch JSON mode)
+- `scripts/build_map.py` — map HTML generator
+- `assets/template.html` — page template with placeholders `__PAGE_TITLE__` `__HEADER_TEXT__` `__LANDMARKS_JSON__` `__CENTER_LAT__` `__CENTER_LNG__` `__ZOOM__` `__TILE_URL__`

--- a/openstreetmap-marker/assets/template.html
+++ b/openstreetmap-marker/assets/template.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<meta name="theme-color" content="#eef1f4">
+<title>__PAGE_TITLE__</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"/>
+<style>
+  * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  html, body {
+    height: 100%; width: 100%; margin: 0; padding: 0;
+    background: #eef1f4;
+    font-family: -apple-system, "PingFang SC", "Helvetica Neue", sans-serif;
+    overflow: hidden; overscroll-behavior: none; position: fixed; inset: 0;
+  }
+  #map {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    height: 100%; width: 100%;
+    background: #eef1f4;
+  }
+
+  /* ---- top status bar ---- */
+  .status-bar {
+    position: absolute;
+    top: env(safe-area-inset-top, 0px);
+    left: 0; right: 0;
+    height: 30px;
+    z-index: 1000;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 18px;
+    font-size: 13px; font-weight: 600; color: #1a1a1a;
+    pointer-events: none;
+  }
+
+  /* ---- Amap-style marker: circular colored icon + text pill ---- */
+  .amap-marker { display: flex; align-items: center; white-space: nowrap; }
+  .amap-marker .dot {
+    width: 26px; height: 26px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 12px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+    border: 2px solid #fff;
+    flex-shrink: 0;
+  }
+  .amap-marker .tag {
+    margin-left: 4px;
+    background: rgba(255,255,255,0.95);
+    padding: 3px 8px;
+    border-radius: 6px;
+    font-size: 12px; font-weight: 600;
+    color: #333;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+  }
+  .amap-marker.type-red .tag { color: #d0021b; }
+  .amap-marker.type-green .tag { color: #1a9850; }
+  .amap-marker.type-blue .tag { color: #1a73e8; }
+  .amap-marker.type-purple .tag { color: #7b3fbf; }
+  .amap-marker.type-brown .tag { color: #8a5a2b; }
+  .amap-marker.type-orange .tag { color: #d9822b; }
+
+  .leaflet-control-attribution {
+    background: rgba(255,255,255,0.8) !important;
+    font-size: 10px;
+  }
+  .leaflet-control-zoom { display: none; }
+
+  .leaflet-control-attribution {
+    background: rgba(255,255,255,0.8) !important;
+    font-size: 10px;
+  }
+  .leaflet-control-zoom { display: none; }
+  .leaflet-popup { display: none !important; } /* replaced by custom bottom info card */
+
+  /* ---- Locate button ---- */
+  .locate-btn {
+    position: fixed;
+    right: 14px;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 22px);
+    z-index: 1200;
+    width: 44px; height: 44px; border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.18);
+    border: none; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px; color: #1a73e8;
+    transition: background 0.15s;
+  }
+  .locate-btn.locating { color: #aaa; }
+  .locate-btn.located  { color: #1a73e8; }
+
+  /* pulsing blue dot for current location */
+  .user-dot-outer {
+    width: 20px; height: 20px; border-radius: 50%;
+    background: rgba(26,115,232,0.18);
+    display: flex; align-items: center; justify-content: center;
+    animation: pulse 1.8s ease-out infinite;
+  }
+  .user-dot-inner {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: #1a73e8; border: 2px solid #fff;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  }
+  @keyframes pulse {
+    0%   { transform: scale(1);   opacity: 1; }
+    70%  { transform: scale(2.2); opacity: 0; }
+    100% { transform: scale(1);   opacity: 0; }
+  }
+
+  /* ---- Google-Maps-style bottom info card ---- */
+  .info-card {
+    position: fixed;
+    left: 0; right: 0; bottom: 0;
+    z-index: 1500;
+    background: #fff;
+    border-radius: 16px 16px 0 0;
+    padding: 8px 20px calc(env(safe-area-inset-bottom, 0px) + 20px);
+    box-shadow: 0 -6px 28px rgba(0,0,0,0.22);
+    transform: translateY(115%);
+    transition: transform 0.28s cubic-bezier(.32,.72,0,1);
+  }
+  .info-card.visible { transform: translateY(0); }
+  .info-card-handle {
+    width: 36px; height: 4px; border-radius: 2px;
+    background: #d8d8d8; margin: 6px auto 14px;
+  }
+  .info-card-close {
+    position: absolute; top: 14px; right: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: #f1f3f4; border: none;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; color: #444; cursor: pointer;
+  }
+  .info-card-title {
+    font-size: 19px; font-weight: 700; color: #1a1a1a;
+    margin-bottom: 6px; padding-right: 36px; line-height: 1.3;
+  }
+  .info-card-row {
+    display: flex; align-items: flex-start; gap: 8px;
+    font-size: 13px; color: #555; margin-bottom: 6px; line-height: 1.4;
+  }
+  .info-card-row .row-icon { flex-shrink: 0; margin-top: 1px; }
+  .info-card-desc {
+    font-size: 13px; color: #666; margin: 10px 0 16px;
+    padding-top: 10px; border-top: 1px solid #f0f0f0;
+    line-height: 1.5;
+  }
+  .open-in-btn {
+    display: flex; align-items: center; justify-content: center; gap: 6px;
+    width: 100%;
+    font-size: 15px; font-weight: 600; color: #fff;
+    background: #1a73e8;
+    padding: 12px; border-radius: 10px;
+    border: none; cursor: pointer;
+  }
+
+  /* ---- Bottom action sheet (map app chooser) ---- */
+  .sheet-overlay {
+    position: fixed; inset: 0; z-index: 2000;
+    background: rgba(0,0,0,0.35);
+    display: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+  .sheet-overlay.visible { display: block; opacity: 1; }
+  .sheet-panel {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    background: #fff;
+    border-radius: 16px 16px 0 0;
+    padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) + 16px);
+    transform: translateY(100%);
+    transition: transform 0.25s ease;
+    box-shadow: 0 -4px 24px rgba(0,0,0,0.2);
+  }
+  .sheet-overlay.visible .sheet-panel { transform: translateY(0); }
+  .sheet-handle {
+    width: 36px; height: 4px; border-radius: 2px;
+    background: #d8d8d8; margin: 8px auto 12px;
+  }
+  .sheet-title {
+    text-align: center; font-size: 13px; color: #999;
+    margin-bottom: 12px; font-weight: 500;
+  }
+  .sheet-option {
+    display: flex; align-items: center; gap: 12px;
+    padding: 14px 8px;
+    font-size: 16px; font-weight: 500; color: #1a1a1a;
+    border-bottom: 1px solid #f0f0f0;
+  }
+  .sheet-option:last-of-type { border-bottom: none; }
+  .sheet-option .opt-icon {
+    width: 32px; height: 32px; border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 16px; color: #fff; flex-shrink: 0;
+  }
+  .sheet-option.amap .opt-icon { background: #1eb989; }
+  .sheet-option.gmap .opt-icon { background: #4285f4; }
+  .sheet-option.applemap .opt-icon { background: #3a3a3c; }
+  .sheet-cancel {
+    margin-top: 8px; text-align: center;
+    padding: 14px 8px; font-size: 16px; font-weight: 600; color: #1a73e8;
+  }
+</style>
+</head>
+<body>
+
+<div class="status-bar">
+  <span id="clock">--:--</span>
+  <span>__HEADER_TEXT__</span>
+</div>
+
+<div id="map"></div>
+
+<!-- locate button: only rendered when __SHOW_LOCATION__ == true -->
+<button class="locate-btn" id="locateBtn" onclick="locateMe()" title="Show my location" style="display:__LOCATE_BTN_DISPLAY__">
+  <i class="fa-solid fa-location-crosshairs"></i>
+</button>
+
+<div class="info-card" id="infoCard">
+  <div class="info-card-handle"></div>
+  <button class="info-card-close" onclick="closeInfoCard()"><i class="fa-solid fa-xmark"></i></button>
+  <div class="info-card-title" id="infoTitle"></div>
+  <div class="info-card-row" id="infoAddressRow" style="display:none;">
+    <span class="row-icon"><i class="fa-solid fa-location-dot"></i></span><span id="infoAddress"></span>
+  </div>
+  <div class="info-card-row">
+    <span class="row-icon"><i class="fa-solid fa-globe"></i></span><span id="infoCoords"></span>
+  </div>
+  <div class="info-card-desc" id="infoDesc" style="display:none;"></div>
+  <button class="open-in-btn" id="infoOpenBtn"><i class="fa-solid fa-map-location-dot"></i> Open Location in...</button>
+</div>
+
+<div class="sheet-overlay" id="sheetOverlay" onclick="if(event.target===this) closeSheet();">
+  <div class="sheet-panel">
+    <div class="sheet-handle"></div>
+    <div class="sheet-title" id="sheetTitle">Open Location in...</div>
+    <div id="sheetOptions"></div>
+    <div class="sheet-cancel" onclick="closeSheet()">Cancel</div>
+  </div>
+</div>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  // type options: red green blue purple brown orange — controls marker dot color
+  var landmarks = __LANDMARKS_JSON__;
+
+  var colorMap = {
+    red: "#e0483f",
+    green: "#3aa76d",
+    blue: "#4a90d9",
+    purple: "#8b5cd6",
+    brown: "#a06a3a",
+    orange: "#d9822b"
+  };
+
+  // ---- Font Awesome icon per marker `type` (used when landmarks.json item has no explicit `icon` field) ----
+  var typeIconMap = {
+    red: "fa-star",
+    green: "fa-tree",
+    blue: "fa-building",
+    purple: "fa-bag-shopping",
+    brown: "fa-landmark",
+    orange: "fa-circle-dot"
+  };
+  function faIconFor(item) {
+    if (item.icon && item.icon.indexOf('fa-') === 0) return item.icon; // already a FA class
+    return typeIconMap[item.type] || "fa-location-dot";
+  }
+
+  // ---- WGS-84 -> GCJ-02 (used only to build the Amap deep link; the basemap coordinates remain WGS-84) ----
+  function isInChina(lng, lat) {
+    return lng > 73.66 && lng < 135.05 && lat > 3.86 && lat < 53.55;
+  }
+  function transformLat(x, y) {
+    var ret = -100.0 + 2.0 * x + 3.0 * y + 0.2 * y * y + 0.1 * x * y + 0.2 * Math.sqrt(Math.abs(x));
+    ret += (20.0 * Math.sin(6.0 * x * Math.PI) + 20.0 * Math.sin(2.0 * x * Math.PI)) * 2.0 / 3.0;
+    ret += (20.0 * Math.sin(y * Math.PI) + 40.0 * Math.sin(y / 3.0 * Math.PI)) * 2.0 / 3.0;
+    ret += (160.0 * Math.sin(y / 12.0 * Math.PI) + 320 * Math.sin(y * Math.PI / 30.0)) * 2.0 / 3.0;
+    return ret;
+  }
+  function transformLng(x, y) {
+    var ret = 300.0 + x + 2.0 * y + 0.1 * x * x + 0.1 * x * y + 0.1 * Math.sqrt(Math.abs(x));
+    ret += (20.0 * Math.sin(6.0 * x * Math.PI) + 20.0 * Math.sin(2.0 * x * Math.PI)) * 2.0 / 3.0;
+    ret += (20.0 * Math.sin(x * Math.PI) + 40.0 * Math.sin(x / 3.0 * Math.PI)) * 2.0 / 3.0;
+    ret += (150.0 * Math.sin(x / 12.0 * Math.PI) + 300.0 * Math.sin(x / 30.0 * Math.PI)) * 2.0 / 3.0;
+    return ret;
+  }
+  function wgs84ToGcj02(lng, lat) {
+    if (!isInChina(lng, lat)) return [lng, lat];
+    var a = 6378245.0, ee = 0.00669342162296594323;
+    var dlat = transformLat(lng - 105.0, lat - 35.0);
+    var dlng = transformLng(lng - 105.0, lat - 35.0);
+    var radlat = lat / 180.0 * Math.PI;
+    var magic = Math.sin(radlat);
+    magic = 1 - ee * magic * magic;
+    var sqrtmagic = Math.sqrt(magic);
+    dlat = (dlat * 180.0) / ((a * (1 - ee)) / (magic * sqrtmagic) * Math.PI);
+    dlng = (dlng * 180.0) / (a / sqrtmagic * Math.cos(radlat) * Math.PI);
+    return [lng + dlng, lat + dlat];
+  }
+
+  function showInfoCard(index) {
+    var item = landmarks[index];
+    document.getElementById('infoTitle').innerHTML = '<i class="fa-solid ' + faIconFor(item) + '"></i> ' + item.name;
+
+    var addressRow = document.getElementById('infoAddressRow');
+    if (item.address) {
+      document.getElementById('infoAddress').textContent = item.address;
+      addressRow.style.display = 'flex';
+    } else {
+      addressRow.style.display = 'none';
+    }
+
+    document.getElementById('infoCoords').textContent = item.lat.toFixed(6) + ', ' + item.lng.toFixed(6);
+
+    var descEl = document.getElementById('infoDesc');
+    if (item.desc) {
+      descEl.textContent = item.desc;
+      descEl.style.display = 'block';
+    } else {
+      descEl.style.display = 'none';
+    }
+
+    var btn = document.getElementById('infoOpenBtn');
+    btn.onclick = function() { openLocationSheet(index); };
+
+    document.getElementById('infoCard').classList.add('visible');
+  }
+
+  function closeInfoCard() {
+    document.getElementById('infoCard').classList.remove('visible');
+  }
+
+  // ---- Platform detection ----
+  var UA = navigator.userAgent || '';
+  var isAndroid = /Android/i.test(UA);
+  var isIOS = /iPhone|iPad|iPod/i.test(UA) || (/Macintosh/i.test(UA) && 'ontouchend' in document);
+
+  // Try a native URL scheme / intent first (triggers the app even from inside a WKWebView / Android WebView);
+  // if the app isn't installed / the scheme fails silently, fall back to the https web link after a short delay.
+  // NOTE: switching to another app backgrounds the page (visibilitychange/blur fires) but does NOT
+  // reliably fire pagehide/unload in an embedded webview, so we must listen for visibility/blur instead
+  // to cancel the fallback once the native app has actually opened.
+  function openWithFallback(schemeUrl, webUrl) {
+    var didHide = false;
+    var fallbackTimer = setTimeout(function() {
+      if (!didHide) {
+        window.location.href = webUrl;
+      }
+    }, 1500);
+
+    function onHide() {
+      didHide = true;
+      clearTimeout(fallbackTimer);
+      document.removeEventListener('visibilitychange', onHide);
+      window.removeEventListener('blur', onHide);
+      window.removeEventListener('pagehide', onHide);
+    }
+    document.addEventListener('visibilitychange', function() {
+      if (document.hidden) onHide();
+    });
+    window.addEventListener('blur', onHide);
+    window.addEventListener('pagehide', onHide);
+
+    window.location.href = schemeUrl;
+  }
+
+  function openLocationSheet(index) {
+    var item = landmarks[index];
+    var lng = item.lng, lat = item.lat;
+    var name = item.name;
+    var encName = encodeURIComponent(name);
+    var inChina = isInChina(lng, lat);
+
+    var options = [];
+
+    if (inChina) {
+      var gcj = wgs84ToGcj02(lng, lat);
+      var amapScheme = isAndroid
+        ? 'amapuri://viewMap?sourceApplication=PikachuMap&poiname=' + encName + '&lat=' + gcj[1].toFixed(6) + '&lon=' + gcj[0].toFixed(6) + '&dev=0'
+        : 'iosamap://viewMap?sourceApplication=PikachuMap&poiname=' + encName + '&lat=' + gcj[1].toFixed(6) + '&lon=' + gcj[0].toFixed(6) + '&dev=0';
+      var amapWeb = 'https://uri.amap.com/marker?position=' + gcj[0].toFixed(6) + ',' + gcj[1].toFixed(6) +
+                    '&name=' + encName + '&src=mypage&coordinate=gaode&callnative=1';
+      options.push({ cls: 'amap', icon: 'fa-location-dot', label: '高德地图', scheme: amapScheme, web: amapWeb });
+    }
+
+    var gmapScheme = isAndroid
+      ? 'geo:' + lat + ',' + lng + '?q=' + lat + ',' + lng + '(' + encName + ')'
+      : 'comgooglemaps://?q=' + lat + ',' + lng + '&center=' + lat + ',' + lng;
+    var gmapWeb = 'https://www.google.com/maps/search/?api=1&query=' + lat + ',' + lng;
+    options.push({ cls: 'gmap', icon: 'fa-map', label: 'Google Maps', scheme: gmapScheme, web: gmapWeb });
+
+    if (isIOS) {
+      var appleScheme = 'maps://?ll=' + lat + ',' + lng + '&q=' + encName;
+      var appleWeb = 'https://maps.apple.com/?ll=' + lat + ',' + lng + '&q=' + encName;
+      options.push({ cls: 'applemap', icon: 'fa-compass', label: 'Apple Maps', scheme: appleScheme, web: appleWeb });
+    }
+
+    var container = document.getElementById('sheetOptions');
+    container.innerHTML = '';
+    options.forEach(function(opt) {
+      var row = document.createElement('div');
+      row.className = 'sheet-option ' + opt.cls;
+      row.innerHTML = '<span class="opt-icon"><i class="fa-solid ' + opt.icon + '"></i></span><span>' + opt.label + '</span>';
+      row.addEventListener('click', function() {
+        openWithFallback(opt.scheme, opt.web);
+        closeSheet();
+      });
+      container.appendChild(row);
+    });
+
+    document.getElementById('sheetTitle').textContent = name;
+    document.getElementById('sheetOverlay').classList.add('visible');
+  }
+
+  function closeSheet() {
+    document.getElementById('sheetOverlay').classList.remove('visible');
+  }
+
+  var map = L.map('map', { zoomControl: false, fadeAnimation: false }).setView([__CENTER_LAT__, __CENTER_LNG__], __ZOOM__);
+
+  L.tileLayer('__TILE_URL__', {
+    attribution: '&copy; OpenStreetMap contributors &copy; CARTO',
+    subdomains: 'abcd',
+    maxZoom: 19,
+    updateWhenZooming: false
+  }).addTo(map);
+
+  var markers = [];
+  landmarks.forEach(function(item, index) {
+    var color = colorMap[item.type] || "#666";
+    var html =
+      '<div class="amap-marker type-' + item.type + '">' +
+        '<div class="dot" style="background:' + color + '"><i class="fa-solid ' + faIconFor(item) + '"></i></div>' +
+        '<div class="tag">' + item.name + '</div>' +
+      '</div>';
+
+    var icon = L.divIcon({
+      className: '',
+      html: html,
+      iconSize: null,
+      iconAnchor: [13, 13]
+    });
+
+    var marker = L.marker([item.lat, item.lng], { icon: icon }).addTo(map);
+    marker.on('click', function() {
+      showInfoCard(index);
+    });
+    markers.push(marker);
+  });
+
+  // tapping the basemap (not a marker) dismisses the info card
+  map.on('click', function() {
+    closeInfoCard();
+  });
+
+  if (markers.length > 1) {
+    var group = new L.featureGroup(markers);
+    map.fitBounds(group.getBounds().pad(0.25));
+  }
+
+  // Fix stale/incomplete tile grid caused by the map container not having
+  // its final size yet at L.map() init time (common in embedded WebViews).
+  setTimeout(function () { map.invalidateSize(); }, 100);
+  setTimeout(function () { map.invalidateSize(); }, 500);
+  window.addEventListener('resize', function () { map.invalidateSize(); });
+
+  // ---- Current location ----
+  var userMarker = null;
+
+  function locateMe() {
+    if (!navigator.geolocation) return;
+    var btn = document.getElementById('locateBtn');
+    btn.classList.add('locating');
+    btn.querySelector('i').className = 'fa-solid fa-spinner fa-spin';
+
+    navigator.geolocation.getCurrentPosition(function(pos) {
+      var lat = pos.coords.latitude, lng = pos.coords.longitude;
+
+      if (userMarker) { map.removeLayer(userMarker); }
+
+      var dotHtml = '<div class="user-dot-outer"><div class="user-dot-inner"></div></div>';
+      var userIcon = L.divIcon({ className: '', html: dotHtml, iconSize: [20, 20], iconAnchor: [10, 10] });
+      userMarker = L.marker([lat, lng], { icon: userIcon, zIndexOffset: 500 }).addTo(map);
+
+      map.setView([lat, lng], Math.max(map.getZoom(), 14));
+      btn.classList.remove('locating');
+      btn.classList.add('located');
+      btn.querySelector('i').className = 'fa-solid fa-location-crosshairs';
+    }, function() {
+      btn.classList.remove('locating');
+      btn.querySelector('i').className = 'fa-solid fa-location-crosshairs';
+    }, { enableHighAccuracy: true, timeout: 8000 });
+  }
+
+  // ---- Clock ----
+  function updateClock() {
+    var d = new Date();
+    var h = d.getHours(), m = d.getMinutes();
+    document.getElementById('clock').textContent = h + ':' + (m < 10 ? '0' + m : m);
+  }
+  updateClock();
+  setInterval(updateClock, 30000);
+</script>
+</body>
+</html>

--- a/openstreetmap-marker/scripts/build_map.py
+++ b/openstreetmap-marker/scripts/build_map.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate a previewable marker map HTML page from the template + a landmarks JSON file.
+
+Usage:
+  python3 build_map.py <landmarks.json> <output.html> [--title "Title"] [--header "⚡ text"]
+                       [--center lat,lng] [--zoom N] [--style light|dark]
+
+landmarks.json format (array of objects):
+  {"name": "West Lake", "desc": "UNESCO World Heritage Site", "address": "West Lake, Xihu District, Hangzhou",
+   "lat": 30.2614, "lng": 120.1443, "type": "green", "icon": "fa-tree"}
+
+  Required: name, lat, lng
+  Optional: desc (extra note shown in the info card), address (shown under a 📍 row, Google-Maps-style),
+            type (red/green/blue/purple/brown/orange, dot color AND default Font Awesome icon, defaults to blue),
+            icon (a Font Awesome solid icon class like "fa-store", overrides the type default; if omitted,
+                  the marker uses a sensible icon based on type)
+
+If --center/--zoom are omitted, the map auto-fits all points (single point excepted, uses --center or
+that point's coordinates, zoom defaults to 14).
+"""
+import sys, json, argparse
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+TEMPLATE = SKILL_DIR / "assets" / "template.html"
+
+TILE_STYLES = {
+    "light": "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
+    "dark": "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("landmarks_json")
+    ap.add_argument("output_html")
+    ap.add_argument("--title", default="Custom Marker Map")
+    ap.add_argument("--header", default="⚡ Pikachu Map")
+    ap.add_argument("--center", default=None, help="lat,lng manual center override")
+    ap.add_argument("--zoom", type=int, default=None)
+    ap.add_argument("--style", default="light", choices=list(TILE_STYLES.keys()))
+    ap.add_argument("--show-location", action="store_true", default=False,
+                    help="Show a locate button that displays the user's current position as a pulsing blue dot")
+    args = ap.parse_args()
+
+    with open(args.landmarks_json, encoding="utf-8") as f:
+        landmarks = json.load(f)
+
+    for item in landmarks:
+        item.setdefault("desc", "")
+        item.setdefault("type", "blue")
+        item.setdefault("icon", "")  # empty -> template picks a Font Awesome icon based on `type`
+
+    if args.center:
+        clat, clng = map(float, args.center.split(","))
+    elif landmarks:
+        clat = sum(i["lat"] for i in landmarks) / len(landmarks)
+        clng = sum(i["lng"] for i in landmarks) / len(landmarks)
+    else:
+        clat, clng = 30.0, 120.0
+
+    zoom = args.zoom if args.zoom else (14 if len(landmarks) <= 1 else 12)
+
+    tpl = TEMPLATE.read_text(encoding="utf-8")
+    html = (
+        tpl.replace("__PAGE_TITLE__", args.title)
+        .replace("__HEADER_TEXT__", args.header)
+        .replace("__LANDMARKS_JSON__", json.dumps(landmarks, ensure_ascii=False))
+        .replace("__CENTER_LAT__", str(clat))
+        .replace("__CENTER_LNG__", str(clng))
+        .replace("__ZOOM__", str(zoom))
+        .replace("__TILE_URL__", TILE_STYLES[args.style])
+        .replace("__LOCATE_BTN_DISPLAY__", "flex" if args.show_location else "none")
+    )
+
+    Path(args.output_html).write_text(html, encoding="utf-8")
+    print(f"Generated {args.output_html} ({len(landmarks)} markers)")
+
+
+if __name__ == "__main__":
+    main()

--- a/openstreetmap-marker/scripts/gcj_convert.py
+++ b/openstreetmap-marker/scripts/gcj_convert.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""GCJ-02 (Mars/China coordinate system, returned by Amap/Tencent/Apple Maps in mainland China)
+-> WGS-84 (OSM/Leaflet basemap coordinate system) conversion.
+
+Usage:
+  python3 gcj_convert.py <lng> <lat>              # single point, outputs "wgs_lat,wgs_lng"
+  python3 gcj_convert.py --json in.json out.json  # batch convert lat/lng fields of every object in a JSON array
+"""
+import sys, json, math
+
+
+def gcj02_to_wgs84(lng, lat):
+    a = 6378245.0
+    ee = 0.00669342162296594323
+
+    def out_of_china(lng, lat):
+        return not (73.66 < lng < 135.05 and 3.86 < lat < 53.55)
+
+    def transform_lat(x, y):
+        ret = -100.0 + 2.0 * x + 3.0 * y + 0.2 * y * y + 0.1 * x * y + 0.2 * math.sqrt(abs(x))
+        ret += (20.0 * math.sin(6.0 * x * math.pi) + 20.0 * math.sin(2.0 * x * math.pi)) * 2.0 / 3.0
+        ret += (20.0 * math.sin(y * math.pi) + 40.0 * math.sin(y / 3.0 * math.pi)) * 2.0 / 3.0
+        ret += (160.0 * math.sin(y / 12.0 * math.pi) + 320 * math.sin(y * math.pi / 30.0)) * 2.0 / 3.0
+        return ret
+
+    def transform_lng(x, y):
+        ret = 300.0 + x + 2.0 * y + 0.1 * x * x + 0.1 * x * y + 0.1 * math.sqrt(abs(x))
+        ret += (20.0 * math.sin(6.0 * x * math.pi) + 20.0 * math.sin(2.0 * x * math.pi)) * 2.0 / 3.0
+        ret += (20.0 * math.sin(x * math.pi) + 40.0 * math.sin(x / 3.0 * math.pi)) * 2.0 / 3.0
+        ret += (150.0 * math.sin(x / 12.0 * math.pi) + 300.0 * math.sin(x / 30.0 * math.pi)) * 2.0 / 3.0
+        return ret
+
+    if out_of_china(lng, lat):
+        return lng, lat
+
+    dlat = transform_lat(lng - 105.0, lat - 35.0)
+    dlng = transform_lng(lng - 105.0, lat - 35.0)
+    radlat = lat / 180.0 * math.pi
+    magic = math.sin(radlat)
+    magic = 1 - ee * magic * magic
+    sqrtmagic = math.sqrt(magic)
+    dlat = (dlat * 180.0) / ((a * (1 - ee)) / (magic * sqrtmagic) * math.pi)
+    dlng = (dlng * 180.0) / (a / sqrtmagic * math.cos(radlat) * math.pi)
+    mglat = lat + dlat
+    mglng = lng + dlng
+    return lng * 2 - mglng, lat * 2 - mglat
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] != "--json":
+        lng, lat = float(sys.argv[1]), float(sys.argv[2])
+        wlng, wlat = gcj02_to_wgs84(lng, lat)
+        print(f"{wlat:.6f},{wlng:.6f}")
+    elif len(sys.argv) == 4 and sys.argv[1] == "--json":
+        with open(sys.argv[2], encoding="utf-8") as f:
+            data = json.load(f)
+        for item in data:
+            wlng, wlat = gcj02_to_wgs84(item["lng"], item["lat"])
+            item["lat"], item["lng"] = round(wlat, 6), round(wlng, 6)
+        with open(sys.argv[3], "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        print(f"Converted {len(data)} points -> {sys.argv[3]}")
+    else:
+        print(__doc__)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Adds the `openstreetmap-marker` skill: generates a mobile-first, Amap(Gaode)-style custom landmark marker HTML map for travel itinerary planning, place showcasing, and location sharing. Built on Leaflet + OpenStreetMap, no API key required. Includes a built-in GCJ-02 → WGS-84 coordinate conversion tool to avoid marker offset for mainland China locations.

## Contents

- `SKILL.md` — workflow, coordinate conversion notes, landmark JSON schema, output styling docs
- `scripts/build_map.py` — HTML generator (landmarks.json + template → self-contained map page)
- `scripts/gcj_convert.py` — GCJ-02→WGS-84 conversion (single-point CLI + batch JSON mode)
- `assets/template.html` — page template (Leaflet + CartoDB tiles + Font Awesome markers + bottom info card + "open in Amap/Google Maps/Apple Maps" action sheet)

## Compliance / privacy self-review before submission

- No hardcoded secrets, API keys, or credentials anywhere in the skill
- No personal/private coordinates or addresses bundled (only a public "West Lake, Hangzhou" example used in docs/comments)
- Uses only free public services: OSM tiles via CARTO Voyager/Dark, Font Awesome + Leaflet via CDN — no analytics/tracking/telemetry calls
- Optional locate-me button uses the standard browser Geolocation API, user-triggered only, renders locally, sends nothing to any server
- Added an explicit note in SKILL.md about CARTO's free-tile rate limits/terms, recommending a licensed provider for high-traffic production use

## Checklist

- [x] Directory name is lowercase kebab-case
- [x] SKILL.md has valid YAML frontmatter (name + description)
- [x] description covers what + when to trigger
- [x] SKILL.md body under 500 lines
- [x] Imperative instructions with rationale
- [x] No hardcoded secrets/API keys/credentials
- [x] scripts/ + assets/ used correctly
- [ ] evals/evals.json (not included in this PR; happy to add if requested)