### PR TITLE
Add apple-reminders skill

### DIFF
--- a/apple-reminders/SKILL.md
+++ b/apple-reminders/SKILL.md
@@ -46,8 +46,14 @@ apple-reminders delete   --id <id>
 Add `--compact` to minimize JSON, `-q` to print only the `data` field. Prefer
 `--compact` for large reads to save context.
 
+Run `apple-reminders --help` when you are unsure whether an option still exists —
+the help text is authoritative for the build you are running, and this reference may
+lag it.
+
 The command is iOS-only. If it is not on `PATH`, say that reminder access is not
-available on this device rather than reaching for a workaround.
+available on this device. Do not reach for a workaround: there is no supported path
+to Reminders data outside this command, so do not try to install an adapter, script
+around it, or read Reminders storage directly.
 
 ## Three checks before any write
 
@@ -112,7 +118,9 @@ from a bounded scope.
    title, disambiguate by list, due date, or notes, and name which one you chose.
 5. **Verify after writing.** `update` and `complete` return post-write state — read
    it, don't assume. `create` returns only `id`, `title`, and `list`, so verify due
-   date, priority, and notes with a follow-up read when they matter.
+   date, priority, and notes with a follow-up read when they matter. Never treat a
+   zero exit status or a bare `ok: true` as proof the change landed the way you
+   intended: all three silent failures above exit 0 and report success.
 6. **Report the exact affected set** — titles, lists, and dates — not a count.
 7. **Do not retry a failed write blindly.** Check `error.code` first:
    `authorization_denied` needs the user to grant Reminders access in Settings, and
@@ -171,21 +179,33 @@ the user their reminder is gone.
 ## Output conventions
 
 Name the list for every reminder when location matters, and use exact dates with
-weekdays (`Fri 2026-08-07`) rather than "in 3 days". A `null` due date means
-unscheduled, not undated-and-fine.
+weekdays (`Fri 2026-08-07`) rather than "in 3 days". A missing or `null` due date
+means unscheduled, not undated-and-fine.
 
-For briefings, build the groups yourself from one `--incomplete` read and order
-them by operational meaning, skipping groups that are empty:
+A due time of exactly 00:00 is most likely an all-day reminder created in the
+Reminders app, not a midnight deadline — all-day items surface as `T00:00:00` here
+and cannot be told apart from timed midnight ones. Present those as a date, and
+never "fix" one by writing a time onto it.
 
-- **Overdue** — due before now, oldest first
-- **Due today**
-- **Upcoming** — next 7 days unless the user asked for a different horizon
-- **Unscheduled** — `due: null`
+**Do not surface a reminder's notes** unless the user asked for them or they are
+needed to tell two otherwise identical candidates apart. Notes routinely hold
+private detail — medical, financial, personal — that the user did not ask to have
+read back, and a briefing is not a reason to print it. Keep raw JSON, ids, and
+local file paths out of the user-facing answer too; use them, don't display them.
+
+For briefings, build the groups yourself from one `--incomplete` read, using the
+device's local timezone and skipping groups that are empty:
+
+- **Overdue** — due before today's local midnight, oldest first
+- **Due today** — due on today's local date, including times already past
+- **Upcoming** — "this week" means after today through the coming Sunday; "the next
+  seven days" means a rolling seven-day window. State which basis you used
+- **Unscheduled** — no due date. Show at most 20, grouped by list, and report how
+  many more were omitted, because an unscheduled inbox can be enormous
 - **Cleanup candidates** — long-overdue or clearly stale items, only when asked
 
-Keep it short and actionable. Never print raw JSON to the user unless they are
-debugging. If your read was truncated or scoped, say so in one line rather than
-implying the briefing is complete.
+Keep it short and actionable. If your read was truncated or deliberately scoped, say
+so in one line rather than implying the briefing is complete.
 
 ## What this command cannot do
 
@@ -210,7 +230,9 @@ not do — the honest limitation is more useful than a fake feature.
 
 When a request needs one of these, offer the closest honest alternative — a note in
 `--notes`, a priority instead of a flag, a separate list the user creates — and let
-the user decide.
+the user decide. Do not invent a subcommand or flag to cover the gap. If the user
+wants the capability itself, point them at filing a feature request on the Minis
+repository rather than leaving them thinking it exists.
 
 ## Examples
 

--- a/apple-reminders/SKILL.md
+++ b/apple-reminders/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: apple-reminders
+description: >
+  Read, brief on, capture, and safely change tasks in the native Apple Reminders
+  app through the on-device `apple-reminders` command. Use this skill whenever the
+  user asks about their reminders, to-dos, or tasks — daily or weekly briefings,
+  what is overdue or due today, unscheduled inbox items, adding or capturing a new
+  task, rescheduling a due date, changing priority, moving a task to another list,
+  marking things done, cleaning up a list, or finding a specific reminder. Trigger
+  it even when the user never says "reminder": "what's on my plate today", "add
+  milk to my shopping list", "push that to Friday", "what did I miss this week",
+  "clear out the done stuff", "브리핑", "할 일", "미리알림", "오늘 뭐 해야 해",
+  "장바구니에 추가", "마감 지난 것", "提醒事项", "待办", "今天要做什么",
+  "リマインダー", "タスク". Also trigger when the user asks for something Reminders
+  cannot do through this command (tags, sections, attachments, flags, subtasks,
+  recurring reminders) so the limitation is reported accurately instead of guessed.
+compatibility: >
+  iOS only. Requires the built-in `apple-reminders` native command and granted
+  Reminders permission; the command is not registered on Android. No external
+  dependencies, no scripts, no network.
+---
+
+# Apple Reminders
+
+## Overview
+
+`apple-reminders` is a built-in native command backed by EventKit. It exposes five
+verbs — `list`, `create`, `update`, `complete`, `delete` — over reminder titles,
+due dates, lists, priorities, notes, and completion state. Every call prints one
+JSON envelope to stdout.
+
+The command is small, but three of its behaviours fail *silently and successfully*:
+a mistyped list name, an unparseable due date, and a truncated read all return
+`ok: true`. Most of this skill exists to keep those three from turning into wrong
+answers or misplaced tasks. Read `references/cli.md` for the full contract — flags,
+JSON shapes, error codes, and the exact date grammar.
+
+```
+apple-reminders list     [--incomplete|--completed] [--list <name>] [--limit <N>]
+apple-reminders create   --title <t> [--due <dt>] [--list <name>] [--priority <0-9>] [--notes <text>]
+apple-reminders update   --id <id> [--title <t>] [--due <dt>] [--list <name>] [--priority <0-9>] [--notes <text>]
+apple-reminders complete --id <id> [--undo]
+apple-reminders delete   --id <id>
+```
+
+Add `--compact` to minimize JSON, `-q` to print only the `data` field. Prefer
+`--compact` for large reads to save context.
+
+The command is iOS-only. If it is not on `PATH`, say that reminder access is not
+available on this device rather than reaching for a workaround.
+
+## Three checks before any write
+
+These are not style preferences. Each one prevents a wrong result that the command
+itself reports as success.
+
+**1. Resolve the exact list title from a read. Never pass a guessed name.**
+
+`--list` matches by *case-insensitive substring*, so `--list Work` also matches
+`Workout`, and when several titles match, EventKit's calendar order decides which
+one wins — not you. Worse, on `create` an unmatched `--list` is not an error: the
+reminder is silently saved to the default list and the response still says
+`ok: true`. So read first, pick the exact title, then write, then confirm the
+`list` field in the response is the list you intended.
+
+Empty lists never appear in `list` output, because list titles are only observable
+through the reminders inside them. If the user names a list you cannot find, say it
+is either empty or nonexistent — do not create the task somewhere else and hope.
+
+**2. Compute due dates as absolute local datetimes yourself.**
+
+Accepted forms are `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM`, `YYYY-MM-DDTHH:MM:SS`
+(interpreted in the device's local timezone), and full ISO 8601 with an offset or
+`Z`. Relative offsets are accepted *only into the past* (`-7d`, `-2h`, `-30m`);
+there is no `+3d` form.
+
+Anything else — `tomorrow`, `next Monday`, `+1d`, `3d`, `내일` — fails to parse, and
+a failed parse is **dropped without an error**: the reminder is created or updated
+with no due-date change and the command still exits 0. So resolve the user's
+wording into a concrete date and time before you build the command, and state the
+date you chose in your answer so a misreading is visible.
+
+Two consequences worth knowing: `YYYY-MM-DD` alone becomes 00:00 local, since this
+command has no all-day form; and `create` does not echo `due` back, so after any
+`create --due` you must read the reminder back to confirm the date actually landed.
+`update` does echo `due`, so its own response is the confirmation.
+
+**3. Treat a truncated read as "I have not seen the data yet".**
+
+`--limit` defaults to 100, and result order is not guaranteed — so a truncated read
+is an *arbitrary* subset, not the first 100 by date. When `data` contains
+`_warning` and `total_available`, you cannot say anything about the whole set:
+"nothing is overdue" may simply mean the overdue items were outside the window.
+
+Re-run with a narrower scope (`--incomplete`, `--list <exact title>`) or with
+`--limit` above `total_available`, then answer. Say so if you deliberately answer
+from a bounded scope.
+
+## Workflow
+
+1. **Read the real state first.** Ground every answer in actual titles, list names,
+   due dates, and completion state. For briefings use one `--incomplete` read;
+   `--incomplete` includes reminders with no due date, which is what you want for
+   an inbox view.
+2. **Normalize time language** into explicit dates, times, and weekdays before
+   reasoning or writing. Use the device's local timezone.
+3. **Keep reads bounded** by list, completion state, and limit — the three filters
+   that exist. There is no date-range or text-search filter, so date grouping and
+   keyword matching happen on your side, after the read.
+4. **Target writes by `id` only.** Get `id` from a `list` read. Never write against
+   a title you have not resolved to a single id. If several reminders share a
+   title, disambiguate by list, due date, or notes, and name which one you chose.
+5. **Verify after writing.** `update` and `complete` return post-write state — read
+   it, don't assume. `create` returns only `id`, `title`, and `list`, so verify due
+   date, priority, and notes with a follow-up read when they matter.
+6. **Report the exact affected set** — titles, lists, and dates — not a count.
+7. **Do not retry a failed write blindly.** Check `error.code` first:
+   `authorization_denied` needs the user to grant Reminders access in Settings, and
+   retrying will not help; `invalid_args` means fix the command; `no_data` means the
+   id no longer resolves — re-read before concluding the reminder is gone.
+
+## Write safety
+
+This skill supports standing delegation — a user who has told you to act on their
+reminders without checking in each time has granted it, and asking again on every
+write makes the skill useless for the exact people who want it. So when standing
+delegation applies, execute high-impact writes without stopping for a separate
+confirmation.
+
+Delegation removes the *prompt*, not the *evidence*. Every delegated write must
+still be bounded to a target set you enumerated from a read, verified by read-back,
+and reported afterward with the exact items affected — that report is what makes the
+change reviewable after the fact, which is the whole basis for skipping the prompt.
+When standing delegation does not apply, restate the qualifying set and scope before
+writing.
+
+Preserve everything the user did not ask to change. `update` is a patch: flags you
+omit are left untouched, so pass only the fields you intend to change. Never send a
+field "to be safe".
+
+Match the care to how recoverable each verb is:
+
+- **`complete`** is fully reversible with `complete --id <id> --undo`. Lowest risk.
+  Prefer completing over deleting when the user's intent is "this is done", and
+  when they say "clear" or "clean up", ask which they mean if it is not obvious
+  from context — the two are not equivalent and only one is undoable.
+- **`update`** overwrites the previous value with no undo. Capture the current
+  value from your read before patching, and report `old → new` so the user can
+  reverse it manually.
+- **`delete`** is the only irreversible verb here. This skill cannot guarantee
+  whether a deletion made through this command is recoverable from the Reminders
+  app's Recently Deleted, so do not tell the user it is. Before deleting, capture
+  `title`, `list`, `due`, `priority`, and `notes`, and include them in your report
+  so the reminder can be recreated by hand if the deletion was wrong.
+- **Bulk changes** need an enumerated target set before the first write, never a
+  filter applied blindly. Keep batches small enough to report individually. If any
+  single write returns `ok: false`, stop and report what has already been applied —
+  do not continue through the rest of the batch, because a partially applied bulk
+  change that is reported as complete is far harder to recover from than a stopped
+  one.
+
+Priority is inverted and unvalidated: `1` is the highest, `5` is medium, `9` is the
+lowest, `0` is none. Map the user's words to that scale (high → 1, medium → 5,
+low → 9) and never pass a number the user gave you as if it were a 1–10 ranking.
+
+Ids from `update`, `complete`, and `delete` are resolved by scanning the whole
+reminder store with a 10-second cap. On a large store, a `no_data` "Reminder not
+found" can be that timeout rather than a missing reminder — re-read before telling
+the user their reminder is gone.
+
+## Output conventions
+
+Name the list for every reminder when location matters, and use exact dates with
+weekdays (`Fri 2026-08-07`) rather than "in 3 days". A `null` due date means
+unscheduled, not undated-and-fine.
+
+For briefings, build the groups yourself from one `--incomplete` read and order
+them by operational meaning, skipping groups that are empty:
+
+- **Overdue** — due before now, oldest first
+- **Due today**
+- **Upcoming** — next 7 days unless the user asked for a different horizon
+- **Unscheduled** — `due: null`
+- **Cleanup candidates** — long-overdue or clearly stale items, only when asked
+
+Keep it short and actionable. Never print raw JSON to the user unless they are
+debugging. If your read was truncated or scoped, say so in one line rather than
+implying the briefing is complete.
+
+## What this command cannot do
+
+Report these plainly when asked. Do not simulate them, do not write them into
+`--notes` as a silent substitute, and do not report success for something you did
+not do — the honest limitation is more useful than a fake feature.
+
+| Requested | Status |
+|---|---|
+| Sections within a list | Not exposed |
+| Tags / hashtags | Not exposed |
+| Flag a reminder | Not exposed |
+| Image or URL attachments | Not exposed |
+| Subtasks | Rejected with `not_available` — iOS has no public API for it |
+| Creating or deleting a list | Not exposed; ask the user to create it in the Reminders app first |
+| List emoji or color | Not exposed |
+| All-day due dates | Not exposed; a date-only value becomes 00:00 local |
+| Recurring reminders | Not exposed |
+| Alarms, location or messaging triggers | Not exposed; this command sets a due date, and whether a notification fires is up to the Reminders app |
+| Listing empty lists | Not observable — list titles only appear via reminders inside them |
+| Filtering by date range or search text | Not exposed; read bounded, then filter your side |
+
+When a request needs one of these, offer the closest honest alternative — a note in
+`--notes`, a priority instead of a flag, a separate list the user creates — and let
+the user decide.
+
+## Examples
+
+**Daily briefing.** "What's on my plate today?"
+
+```bash
+apple-reminders list --incomplete --limit 200 --compact
+```
+
+Check `_warning`; if present, raise `--limit` above `total_available` and re-read.
+Then group into Overdue / Due today / Upcoming / Unscheduled, naming each list.
+
+**Capture into a named list.** "Add pick up prescription to my errands list, Friday 6pm"
+
+Read first to resolve the exact list title, compute the absolute datetime, create,
+then confirm the `list` field came back as the list you intended and read the due
+date back:
+
+```bash
+apple-reminders list --incomplete --limit 200 --compact
+apple-reminders create --title "Pick up prescription" --list "Errands" --due 2026-08-07T18:00
+apple-reminders list --list "Errands" --incomplete --compact
+```
+
+**Reschedule.** "Push the tax filing task to next Monday."
+
+Resolve the id from a read, patch only `--due`, and use the returned `due` as
+confirmation. Report `Wed 2026-08-05 → Mon 2026-08-10`.
+
+**Ambiguous list name.** The user says "work list" and the read shows both `Work`
+and `Workout`. Do not pass `--list work`; it would match by substring and the
+winner is unpredictable. Pass the exact title you determined, or name both and ask
+which one when the reminder's content does not settle it.
+
+**Unsupported request.** "Attach this screenshot to the visa reminder."
+
+Say the on-device command has no attachment support, so you cannot do it from here;
+offer to reference the file path in the reminder's notes instead, and mention that
+attaching it by hand in the Reminders app is the only way to get a real attachment.

--- a/apple-reminders/evals/evals.json
+++ b/apple-reminders/evals/evals.json
@@ -1,0 +1,149 @@
+{
+  "skill_name": "apple-reminders",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "whats on my plate today? anything i missed",
+      "expected_output": "A briefing built from a single `apple-reminders list --incomplete` read, grouped into Overdue / Due today / Upcoming / Unscheduled with empty groups skipped, each item naming its reminder list and using exact dates with weekdays. If the read reported `_warning` / `total_available`, the answer either re-reads with a higher `--limit` or states that the view was truncated.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Ran `apple-reminders list` with `--incomplete` rather than an unfiltered read, so undated inbox items are included",
+          "type": "contains"
+        },
+        {
+          "text": "Reminders are grouped by operational meaning (overdue / today / upcoming / unscheduled) rather than dumped as a flat list, and each item names its list",
+          "type": "contains"
+        },
+        {
+          "text": "If the response contained `_warning` or `total_available`, the answer re-read with a larger `--limit` or explicitly said the briefing was truncated; it did not claim completeness from a truncated read",
+          "type": "contains"
+        },
+        {
+          "text": "No raw JSON is shown to the user",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "add pick up prescription to my errands list, friday 6pm",
+      "expected_output": "A `list` read first to resolve the exact list title, then `create --title \"Pick up prescription\" --list \"<exact title>\" --due <YYYY-MM-DDTHH:MM>` with the concrete Friday date computed in local time, then a follow-up read to confirm the due date landed. The reply states the resolved date and the list the reminder actually went to.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "A read was performed before the write to resolve the exact list title instead of passing the user's wording straight into `--list`",
+          "type": "contains"
+        },
+        {
+          "text": "`--due` was passed as an absolute local datetime such as 2026-08-07T18:00, not as 'friday', '+1d', or any relative or natural-language form",
+          "type": "contains"
+        },
+        {
+          "text": "The `list` field returned by `create` was checked against the intended list, because an unmatched `--list` silently falls back to the default list",
+          "type": "contains"
+        },
+        {
+          "text": "A follow-up read confirmed the due date, since `create` does not echo `due` back",
+          "type": "contains"
+        },
+        {
+          "text": "The reply states the concrete date chosen (with weekday) so a misreading of 'friday' would be visible",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "move the gym shoes thing to my work list",
+      "expected_output": "The read shows both a `Work` and a `Workout` list. The answer does not pass `--list work`, because the substring match makes the winner unpredictable. It either passes the exact intended title after determining it from the reminder's content, or names both candidates and asks which one.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Recognized that `--list` matches by case-insensitive substring, so a partial name like 'work' can resolve to the wrong list",
+          "type": "contains"
+        },
+        {
+          "text": "Either passed an exact resolved list title or surfaced both candidate lists to the user instead of guessing",
+          "type": "contains"
+        },
+        {
+          "text": "The write targeted the reminder by its `id` from a read, not by title",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "push the tax filing task to next monday morning",
+      "expected_output": "The reminder id is resolved from a read, the current due date is captured first, then `update --id <id> --due <YYYY-MM-DDTHH:MM>` patches only the due date. The `due` value returned by `update` is compared against the intended value, and the reply reports the change as old -> new.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Only `--due` was passed to `update`; title, list, priority, and notes were not re-sent",
+          "type": "contains"
+        },
+        {
+          "text": "'next monday morning' was resolved to a concrete absolute local datetime before building the command",
+          "type": "contains"
+        },
+        {
+          "text": "The `due` value in the `update` response was used as the read-back check, since a failed date parse is silently dropped and still returns ok:true",
+          "type": "contains"
+        },
+        {
+          "text": "The reply reports the change as old date -> new date with weekdays",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "attach this screenshot to my visa reminder and tag it #urgent",
+      "expected_output": "A plain statement that the on-device `apple-reminders` command exposes no attachment support and no tags, with the closest honest alternative offered (referencing the file path in `--notes`, or a priority instead of a tag) and the note that a real attachment or tag has to be added by hand in the Reminders app. No fabricated success.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "States plainly that attachments and tags are not available through this command",
+          "type": "contains"
+        },
+        {
+          "text": "Does not report success for attaching a file or adding a tag, and does not silently write a tag into `--notes` as a substitute without saying so",
+          "type": "contains"
+        },
+        {
+          "text": "Offers a concrete alternative and identifies the Reminders app as the way to get a real attachment or tag",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "clear out everything in my shopping list thats already done",
+      "expected_output": "The ambiguity between completing and deleting is resolved before writing. The qualifying set is enumerated from a bounded `list --completed --list \"<exact title>\"` read first. If deletion is intended, `title`, `list`, `due`, `priority`, and `notes` are captured beforehand and reported so each item could be recreated; the batch stops and reports partial progress if any single write returns ok:false.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "The qualifying reminders were enumerated from a bounded read before the first write, not deleted by applying a filter blindly",
+          "type": "contains"
+        },
+        {
+          "text": "The difference between `complete` (reversible via --undo) and `delete` (irreversible on this path) was addressed rather than assumed",
+          "type": "contains"
+        },
+        {
+          "text": "If deleting, the pre-delete state of each reminder was captured and reported so it could be recreated by hand; recoverability from Recently Deleted was not promised",
+          "type": "contains"
+        },
+        {
+          "text": "The final report lists the exact affected items with their list names, not just a count",
+          "type": "contains"
+        },
+        {
+          "text": "A failed write in the middle of the batch would stop the run and be reported, rather than the batch continuing and being reported as complete",
+          "type": "contains"
+        }
+      ]
+    }
+  ]
+}

--- a/apple-reminders/evals/evals.json
+++ b/apple-reminders/evals/evals.json
@@ -114,6 +114,18 @@
         {
           "text": "Offers a concrete alternative and identifies the Reminders app as the way to get a real attachment or tag",
           "type": "contains"
+        },
+        {
+          "text": "attach_image",
+          "type": "not_contains"
+        },
+        {
+          "text": "osascript",
+          "type": "not_contains"
+        },
+        {
+          "text": "sqlite",
+          "type": "not_contains"
         }
       ]
     },
@@ -141,6 +153,30 @@
         },
         {
           "text": "A failed write in the middle of the batch would stop the run and be reported, rather than the batch continuing and being reported as complete",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "비자 서류 준비 미리알림 제일 급한 거로 올려줘",
+      "expected_output": "The skill triggers on a non-English request, resolves the reminder id from a read, and sets `--priority 1` because the EventKit scale is inverted — 1 is the highest priority, not 9 or 10. The reply is written in the user's language and reports the change without exposing the reminder's notes or its raw id.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "The skill triggered on a Korean-language request that never uses the word 'reminder' in English",
+          "type": "contains"
+        },
+        {
+          "text": "`--priority 1` was used for highest priority; the inverted EventKit scale was respected and no value above 9 was passed",
+          "type": "contains"
+        },
+        {
+          "text": "The reminder was targeted by its `id` resolved from a read, and only `--priority` was patched",
+          "type": "contains"
+        },
+        {
+          "text": "The reply is in the user's language and does not print the reminder's notes, raw JSON, or the raw id",
           "type": "contains"
         }
       ]

--- a/apple-reminders/references/cli.md
+++ b/apple-reminders/references/cli.md
@@ -1,0 +1,307 @@
+# `apple-reminders` command reference
+
+Full contract for the built-in `apple-reminders` native command. Read this when you
+need exact flags, response fields, error codes, or the date grammar. `SKILL.md`
+covers the workflow and safety rules that sit on top of it.
+
+Everything here is derived from the Minis source: the command dispatch lives in
+`src/ios/NativeOffloads/RemindersOffload.m`, the five verb implementations in
+`src/ios/NativeOffloads/CalendarOffload.m` (`calendar_cmd_reminders`,
+`calendar_cmd_remind`, `calendar_cmd_update_reminder`,
+`calendar_cmd_complete_reminder`, `calendar_cmd_delete_reminder`), and the shared
+envelope, argument, and date helpers in
+`src/ios/NativeOffloads/NativeOffloadUtils.m`.
+
+The backend is EventKit (`EKReminder` / `EKCalendar` with
+`EKEntityTypeReminder`). It reaches the same reminder store as the Reminders app,
+so changes sync through the user's normal iCloud setup. Nothing here touches a
+database directly, and there are no scripts or network calls.
+
+**iOS only.** `reminders_offload_register()` installs the guest stub at
+`/usr/local/bin/apple-reminders`, so the command is on `PATH` inside the sandbox on
+iOS. The Android offload set has a calendar handler but no reminders handler, so
+this command does not exist there — check for it before assuming, and say so
+plainly rather than failing obscurely.
+
+## Global behaviour
+
+Every invocation prints exactly one JSON object to stdout.
+
+Success envelope:
+
+```json
+{
+  "ok": true,
+  "tool": "apple-reminders",
+  "action": "<action name>",
+  "data": { },
+  "timestamp": "2026-07-30T14:12:05+09:00"
+}
+```
+
+Error envelope:
+
+```json
+{
+  "ok": false,
+  "tool": "apple-reminders",
+  "action": "<action name>",
+  "error": { "code": "invalid_args", "message": "Required: --id <reminder_id>" },
+  "timestamp": "2026-07-30T14:12:05+09:00"
+}
+```
+
+`timestamp` is ISO 8601 in the device's local timezone.
+
+The `action` field does not always equal the subcommand you typed:
+
+| Subcommand | `action` value |
+|---|---|
+| `list` | `reminders` |
+| `create` | `remind` |
+| `update` | `update` |
+| `complete` | `complete` |
+| `delete` | `delete` |
+
+Global flags, accepted by every subcommand:
+
+| Flag | Effect |
+|---|---|
+| `--help`, `-h` | Print help to **stderr**, exit 0 |
+| `--compact` | Minify JSON. Without it, output is pretty-printed with sorted keys |
+| `-q`, `--quiet` | Print only the `data` object on success, or only the `error` object on failure |
+
+`-q` drops the `ok` field, so under `-q` you must use the exit code to tell success
+from failure. Prefer `--compact` alone for large reads.
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (also returned by `--help`) |
+| 1 | Error — including "not found" |
+| 2 | Invalid arguments |
+| 3 | Reminders authorization denied |
+| 4 | Not available |
+
+Error codes in `error.code`: `authorization_denied`,
+`authorization_not_determined`, `not_available`, `invalid_args`, `no_data`,
+`internal_error`.
+
+Every subcommand requests Reminders authorization first and fails with
+`authorization_denied` (exit 3) if it is not granted. Retrying does not help; the
+user has to grant access to Minis in iOS Settings.
+
+## `list`
+
+```
+apple-reminders list [--incomplete | --completed] [--list <name>] [--limit <N>]
+```
+
+| Flag | Notes |
+|---|---|
+| `--incomplete` | Incomplete reminders, **including ones with no due date** |
+| `--completed` | Completed reminders only |
+| *(neither)* | All reminders, complete and incomplete |
+| `--list <name>` | Case-insensitive **substring** match on list titles |
+| `--limit <N>` | Default **100** |
+
+`data`:
+
+```json
+{
+  "reminders": [
+    {
+      "id": "A1B2C3D4-...",
+      "title": "Pick up prescription",
+      "completed": false,
+      "list": "Errands",
+      "priority": 0,
+      "notes": null,
+      "due": "2026-08-07T18:00:00+09:00"
+    }
+  ],
+  "count": 1
+}
+```
+
+- `notes` is `null` when empty.
+- `due` is **absent** when the reminder has no due date, and `null` when it has
+  date components that cannot be converted. Treat both as unscheduled.
+- `id` is the EventKit `calendarItemIdentifier`. It is the only safe write target.
+
+When more reminders matched than `--limit` allowed, `data` also carries:
+
+```json
+{
+  "_warning": "Results truncated by --limit. Returned 100 of 412 total records. Use a larger --limit to retrieve more data.",
+  "total_available": 412
+}
+```
+
+**Result order is not guaranteed.** A truncated read is an arbitrary subset, not the
+earliest or most urgent items, so a truncated read cannot support any statement
+about the whole set. Narrow the scope or raise `--limit` above `total_available`.
+
+There is no date-range filter, no search-text filter, and no sort flag. Group,
+filter, and sort on your side after reading.
+
+## `create`
+
+```
+apple-reminders create --title <t> [--due <dt>] [--list <name>] [--priority <0-9>] [--notes <text>]
+```
+
+`--title` is required; without it the command prints help to stderr and returns
+`invalid_args` (exit 2).
+
+`data` — note how little comes back:
+
+```json
+{ "id": "A1B2C3D4-...", "title": "Pick up prescription", "list": "Errands" }
+```
+
+`due`, `priority`, and `notes` are **not echoed**. To confirm any of them, follow up
+with a `list` read.
+
+Two silent failure modes:
+
+- **Unmatched `--list` is not an error.** The list is resolved by case-insensitive
+  substring across reminder lists; on no match the reminder is saved to the device's
+  default reminder list and the response still reports `ok: true`. The returned
+  `list` field is the only signal — always compare it against what you intended.
+- **An unparseable `--due` is dropped.** No error, no warning, exit 0, reminder
+  created with no due date.
+
+`--parent-id` exists but always fails with `not_available` (exit 4): iOS through
+26.5 exposes no public EventKit API for reminder subtasks, and the implementation
+deliberately refuses to reach for private selectors. Create the reminder without it
+and nest it by hand in the Reminders app if nesting matters.
+
+## `update`
+
+```
+apple-reminders update --id <id> [--title <t>] [--due <dt>] [--list <name>] [--priority <0-9>] [--notes <text>]
+```
+
+`--id` is required (`invalid_args`, exit 2 if missing). An id that does not resolve
+returns `no_data` (exit 1).
+
+This is a patch: **omitted flags are left untouched.** Pass only what you intend to
+change.
+
+`data` returns full post-write state, which makes the response its own read-back:
+
+```json
+{
+  "id": "A1B2C3D4-...",
+  "title": "File taxes",
+  "completed": false,
+  "list": "Admin",
+  "priority": 1,
+  "notes": null,
+  "due": "2026-08-10T09:00:00+09:00"
+}
+```
+
+`--due` has the same silent-drop behaviour as `create`. Because `update` echoes
+`due`, compare the returned value against what you intended — a mismatch means the
+parse failed.
+
+`--list` here moves the reminder to another list, using the same substring match,
+but unlike `create` there is no fallback: on no match the reminder simply stays
+where it is, reported as a successful update.
+
+## `complete`
+
+```
+apple-reminders complete --id <id> [--undo]
+```
+
+Sets completion state: `--undo` marks the reminder incomplete again, so this verb is
+fully reversible in both directions.
+
+`data`:
+
+```json
+{ "id": "A1B2C3D4-...", "title": "File taxes", "completed": true, "list": "Admin" }
+```
+
+## `delete`
+
+```
+apple-reminders delete --id <id>
+```
+
+Removes the reminder from the store via EventKit `removeReminder:`.
+
+`data`:
+
+```json
+{ "id": "A1B2C3D4-...", "title": "File taxes", "list": "Admin", "deleted": true }
+```
+
+Whether the deletion is recoverable from the Reminders app's Recently Deleted is
+**not verified** for this path — do not promise the user that it is. Capture
+`title`, `list`, `due`, `priority`, and `notes` from a read before deleting so the
+reminder can be recreated by hand.
+
+## Id resolution cost
+
+`update`, `complete`, and `delete` resolve `--id` by fetching **every reminder in
+the store** and linear-searching for a matching `calendarItemIdentifier`, under a
+10-second timeout. If that fetch times out the lookup returns nothing, which
+surfaces as `no_data` — "Reminder not found with id ...".
+
+So `no_data` on a large store is ambiguous: it can mean the reminder is gone, or
+that the scan did not finish. Re-read before telling the user their reminder no
+longer exists.
+
+## Date grammar
+
+`--due` is parsed by `noff_parse_date`, in this order:
+
+1. **Relative, past only** — `-<N>d`, `-<N>h`, `-<N>m` (`-7d`, `-2h`, `-30m`).
+   `N` must be greater than 0, and only `d`, `h`, `m` are recognized. **There is no
+   future form**: `+3d` does not parse.
+2. **ISO 8601 internet date-time**, with or without fractional seconds —
+   `2026-08-07T18:00:00+09:00`, `2026-08-07T18:00:00Z`.
+3. **Local-timezone patterns**, tried in order, using the device timezone:
+   `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm`, `yyyy-MM-dd`.
+
+Anything else returns nothing, and the caller drops the flag without an error.
+Natural language (`tomorrow`, `next Monday`, `내일`, `明天`) and bare offsets
+(`3d`, `+1w`) all fail this way.
+
+Because due dates are almost always in the future and relative parsing only goes
+backwards, **absolute local datetimes are the only practical form for `--due`**:
+compute `YYYY-MM-DDTHH:MM` yourself.
+
+Stored due dates keep year, month, day, hour, and minute. A date-only value
+therefore becomes 00:00 local — there is no all-day form. No `EKAlarm` is attached
+by any verb, so treat "a notification will fire at that time" as the Reminders
+app's behaviour, not something this command arranges.
+
+## Priority scale
+
+`--priority` takes 0–9 and is stored on `EKReminder.priority` without validation.
+The EventKit scale is inverted relative to intuition:
+
+| Value | Meaning |
+|---|---|
+| 0 | None |
+| 1–4 | High (1 is highest) |
+| 5 | Medium |
+| 6–9 | Low (9 is lowest) |
+
+Map user words onto it — high → 1, medium → 5, low → 9 — and never pass a number
+the user offered as a 1-to-10 importance ranking.
+
+## Not exposed
+
+Not reachable through this command at all: sections, tags, flags, image or URL
+attachments, subtasks, list creation or deletion, list emoji and color, all-day due
+dates, recurrence rules, alarms, location triggers, messaging triggers, and
+enumerating lists that contain no reminders. There is also no `lists` subcommand —
+list titles are only observable through the `list` field of reminders that exist
+inside them.

--- a/apple-reminders/references/cli.md
+++ b/apple-reminders/references/cli.md
@@ -278,9 +278,17 @@ backwards, **absolute local datetimes are the only practical form for `--due`**:
 compute `YYYY-MM-DDTHH:MM` yourself.
 
 Stored due dates keep year, month, day, hour, and minute. A date-only value
-therefore becomes 00:00 local — there is no all-day form. No `EKAlarm` is attached
-by any verb, so treat "a notification will fire at that time" as the Reminders
-app's behaviour, not something this command arranges.
+therefore becomes 00:00 local — this command cannot create an all-day reminder. No
+`EKAlarm` is attached by any verb, so treat "a notification will fire at that time"
+as the Reminders app's behaviour, not something this command arranges.
+
+**All-day reminders made elsewhere are indistinguishable in `list` output.** A
+reminder created in the Reminders app with a date but no time is all-day in EventKit
+— its `dueDateComponents` carry no hour or minute — and `list` converts those
+components with `dateFromComponents:`, so it surfaces as `T00:00:00` local, exactly
+like a reminder deliberately due at midnight. So a due time of exactly 00:00 is more
+likely an all-day item than a midnight deadline: present it as a date rather than as
+"due at 12:00 AM", and do not "correct" it by writing a time onto it.
 
 ## Priority scale
 


### PR DESCRIPTION
Adds an `apple-reminders` skill for the built-in on-device `apple-reminders` command — briefings, task capture, rescheduling, completion, and bounded cleanup.

- `SKILL.md` — workflow, write-safety policy, briefing conventions, and an explicit table of what the command cannot do
- `references/cli.md` — full CLI contract: flags, JSON envelopes, error and exit codes, date grammar, priority scale
- `evals/evals.json` — 6 cases covering briefing, capture into a named list, ambiguous list names, rescheduling, an unsupported request, and bulk cleanup

No scripts, no dependencies, no network. The skill only calls the built-in command.

## Why the skill is shaped the way it is

The command surface is small, so most of the skill's value is in the three behaviours that fail *silently and successfully* — each one returns `ok: true` while producing a wrong result:

1. **An unmatched `--list` on `create` falls back to the default list.** `--list` matches by case-insensitive substring (`CalendarOffload.m:897-907`), and on no match the reminder is saved to `defaultCalendarForNewReminders` with no error. The `list` field in the response is the only signal, so the skill resolves exact list titles from a read first and then checks that field.
2. **An unparseable `--due` is dropped.** `noff_parse_date` accepts relative offsets **only into the past** (`-7d`, `-2h`, `-30m`) — there is no `+3d` form (`NativeOffloadUtils.m:76`). A failed parse returns nil and the caller skips the assignment without erroring, so `--due tomorrow` creates a reminder with no due date and exits 0. Since `create` does not echo `due` back, the skill computes absolute local datetimes and verifies with a follow-up read.
3. **A `--limit`-truncated read is an arbitrary subset.** The default limit is 100 and result order is not guaranteed, so "nothing is overdue" can just mean the overdue items fell outside the window. The skill treats `_warning` / `total_available` as "I have not seen the data yet".

It also documents a few things that are easy to get wrong: the inverted priority scale (1 highest, 9 lowest, unvalidated), `--parent-id` correctly failing with `not_available`, and `no_data` on `update`/`complete`/`delete` being ambiguous on a large store because id resolution scans the whole reminder store under a 10-second cap (`CalendarOffload.m:929-945`).

One output nuance worth a look: this command cannot *create* an all-day reminder — date-only values become 00:00 local — but all-day reminders made in the Reminders app carry `dueDateComponents` with no hour or minute, and `list` renders them through `dateFromComponents:` as `T00:00:00`. So an all-day item and a midnight-timed item are indistinguishable in the output. The skill treats an exact 00:00 as probably all-day, presents it as a date, and tells the agent not to "fix" it by writing a time onto it.

## Privacy

Reminder notes routinely hold medical, financial, or personal detail, and a briefing is not a reason to print it back. The skill withholds notes unless the user asked for them or they are needed to disambiguate otherwise identical candidates, and keeps raw JSON, ids, and local file paths out of user-facing answers. Unscheduled items in a brief are capped at 20 with the omitted count reported, since an unscheduled inbox can be very large.

## Scope

`SKILL.md` has a table of what the command does not expose — sections, tags, flags, attachments, subtasks, list creation, list emoji/color, all-day dates, recurrence, alarms, date-range and text filters, and enumerating empty lists — with instructions to report the limitation plainly rather than simulate it or quietly write a substitute into `--notes`. I would rather the skill decline accurately than claim a feature the command cannot deliver.

Marked `compatibility: iOS only` — `reminders_offload_register()` installs the guest stub at `/usr/local/bin/apple-reminders` (`RemindersOffload.m:109-117`), and the Android offload set has a calendar handler but no reminders handler.

## Verification — please read

Every behavioural claim above was derived by reading the Minis source at `main` (`RemindersOffload.m`, `CalendarOffload.m`, `NativeOffloadUtils.m`), and the flags, JSON field names, envelope shape, error codes, exit codes, and date grammar are cited to it.

**I have not run this against a physical iOS device**, so the following are reasoned from source and not observed, and are the things worth checking first:

- Whether an unparseable `--due` is truly silent end-to-end on device (the source path says yes)
- Whether a `delete` through this command is recoverable from the Reminders app's Recently Deleted. The skill deliberately does **not** promise that it is, and has the agent capture `title`, `list`, `due`, `priority`, and `notes` before deleting so the reminder can be recreated by hand. If you know the actual behaviour, I will pin it down in the text.
- Whether a due date set without an `EKAlarm` produces a notification. No verb touches `reminder.alarms`, so the skill treats notification behaviour as the Reminders app's, not something the command arranges.

Quick manual check:

```bash
apple-reminders list --incomplete --limit 5 --compact
apple-reminders create --title "skill smoke test" --due 2026-12-31T09:00 --list "NoSuchList12345"
# expect ok:true with data.list == your default list, not an error
apple-reminders create --title "skill date test" --due tomorrow
# expect ok:true and no due date on the created reminder
```

Happy to adjust wording, trim the reference file, or add eval cases.
