### PR TITLE
Add android-ui-automation skill: deep-link launch + a11y tap automation

### DIFF
--- a/android-ui-automation/SKILL.md
+++ b/android-ui-automation/SKILL.md
@@ -12,13 +12,38 @@ description: >
   use when the user asks why an automation didn't work (permissions, missing
   app, hidden view trees). Android-only; requires the Minis Accessibility
   Service enabled.
-compatibility: Android, requires the Minis Accessibility Service; uses the bundled android-a11y-cli
+compatibility: Android-only; requires the Minis app (Android) with its bundled android-a11y-cli / android-open CLIs and the Minis Accessibility Service enabled
 ---
 
 # Android UI Automation
 
 Drive Android apps through their **UI layer** when they have no public API or
 web version. This is the fallback that makes "phone-only" apps automatable.
+
+## Environment & dependencies (read first)
+
+This skill drives **the user's Android phone**. It relies on two CLI tools
+that ship with the **Minis app for Android** (installed at
+`/usr/local/bin/` inside the Minis runtime):
+
+| CLI | Role |
+|---|---|
+| `android-a11y-cli` | Accessibility-Service bridge: `ui dump`, `tap node`, `gesture swipe`, `wait`, `extract`, ... |
+| `android-open` | Launch any URL/scheme via the system handler (`spotify://...`, `weixin://...`, `tel:`, ...) |
+
+**Prerequisites on the device:**
+
+1. Minis app installed (Android). These CLIs do **not** exist on other hosts
+   (macOS/Windows/other Linux) — verify with `which android-a11y-cli` first,
+   and if missing, tell the user this skill only runs inside Minis on Android.
+2. **Minis Accessibility Service enabled**: Settings → Accessibility → Minis.
+   Check with `android-a11y-cli service ping`; if it reports not running, ask
+   the user to re-enable it before anything else.
+3. The target app installed on the same device.
+
+These are **device-side capabilities**, not network APIs — no API keys, no
+OAuth, no server. If a step returns `permission_denied` from the a11y service,
+it means the service was revoked; recover via Settings → Accessibility.
 
 ## When to use
 

--- a/android-ui-automation/SKILL.md
+++ b/android-ui-automation/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: android-ui-automation
+description: >
+  Automate Android apps that have no public API or web version by driving the
+  UI layer through the Accessibility Service. Handles: deep-link launch (open
+  an app into a specific screen), intelligent node location (find a button or
+  text by fuzzy match, not exact text), tap-and-verify (confirm an action had
+  its effect), and human-like swipes. Use this whenever the user wants to
+  control a phone-only app on Android — e.g. "open Spotify and play X",
+  "tap the like button", "swipe through my feed", "play 连名带姓", anything
+  involving `spotify://`, `weixin://`, or apps with no web/API surface. Also
+  use when the user asks why an automation didn't work (permissions, missing
+  app, hidden view trees). Android-only; requires the Minis Accessibility
+  Service enabled.
+compatibility: Android, requires the Minis Accessibility Service; uses the bundled android-a11y-cli
+---
+
+# Android UI Automation
+
+Drive Android apps through their **UI layer** when they have no public API or
+web version. This is the fallback that makes "phone-only" apps automatable.
+
+## When to use
+
+- The target app has **no API / no web page** (WeChat Moments, many CN apps).
+- Offload fine-grained clicking to reliable scripts instead of brittle commands.
+- The user asks to **play/search/open/tap/swipe** inside an installed Android app.
+
+Do **not** use this for apps that already have a proper skill (e.g.
+`bilibili-hub`, `spotify-hub`) — prefer the API path when one exists.
+
+## Core workflow
+
+Follow this order. Each step has a reason; don't skip verification.
+
+1. **Resolve the target**
+   Confirm the app is installed. If unsure, ask the user or try the deep link
+   and check the foreground package (see step 2).
+
+2. **Launch via deep link** — `scripts/open_deep_link.py`
+   ```
+   python3 scripts/open_deep_link.py "spotify://search/circles%20post%20malone" --pkg com.spotify.music
+   ```
+   - It constructs/opens the link **and verifies the app reached the foreground**.
+   - Percent-encode query values (CJK and `&`/`?` break raw links).
+   - If it returns `ok:false`, don't proceed — the app is missing, the scheme
+     is unhandled, or something redirected. Surface the error.
+   - ⚠️ Some apps (Spotify) land on a **suggestion page**, not results — tap a
+     suggestion row first (see `references/app-deep-links.md`), then locate the
+     result.
+
+3. **Locate the node** — `scripts/find_node.py`
+   ```
+   python3 scripts/find_node.py "Circles" --clickable-only --top 5
+   ```
+   - Uses fuzzy scoring (exact > substring > node-fragment), prefers clickable.
+   - Read the `nodeId` and `center` from the top result.
+
+4. **Tap and verify** — `scripts/tap_and_verify.py`
+   ```
+   python3 scripts/tap_and_verify.py --query "Circles – Post Malone" --marker "暂停"
+   ```
+   - The `marker` is the proof it worked (e.g. after tapping play, a **pause**
+     button must appear). Never report success without a marker.
+   - Retries a few times with relocation in case the tree changed.
+
+5. **Human-like swipes** (when the tree is unavailable) — use gestures:
+   ```
+   android-a11y-cli gesture swipe X1 Y1 X2 Y2
+   ```
+   Vary distance/pause randomly to look natural. This is the ONLY fallback when
+   an app (like WeChat Moments) hides its view tree.
+
+## Why the verify step matters
+
+A raw tap is fire-and-forget: the UI may be mid-animation or the node may have
+drifted. Verifying a **success marker** (pause button, title, toast) converts
+"I clicked something" into "I know it worked". If the marker never appears,
+say so honestly instead of claiming success.
+
+## Known limitations
+
+- Apps can **hide their view tree** from the Accessibility Service (WeChat
+  Moments is a known case). When `ui dump` returns no app nodes, **do NOT
+  blind-tap guessed coordinates** — either use swipes (scroll-only) or ask the
+  user to tap precisely.
+- The Accessibility Service can be **revoked** (e.g. after a force-stop). Check
+  `android-a11y-cli service status`; if not running, ask the user to re-enable
+  it in Settings → Accessibility.
+- Deep-link support varies by app/build. Read `references/app-deep-links.md`
+  for the tested set and always confirm foreground.
+
+## Examples
+
+**Play a song on Spotify (no API key, no Premium):**
+```
+python3 scripts/open_deep_link.py "spotify://search/circles%20post%20malone"
+python3 scripts/find_node.py "添加建议"          # suggestion page → tap to get results
+python3 scripts/tap_and_verify.py --query "添加建议“circles post malone”" --marker "Circles"
+python3 scripts/find_node.py "Circles – Post Malone" --clickable-only
+python3 scripts/tap_and_verify.py --query "Circles – Post Malone" --marker "暂停"
+```
+
+**Human-like feed scroll (WeChat Moments):**
+```
+android-a11y-cli ui info            # confirm weixin:// foreground
+android-a11y-cli gesture swipe 540 1600 540 800   # repeat with varied distance/pause
+```
+
+**Decline gracefully when the app can't be reached:**
+Report `ok:false` from `open_deep_link.py` rather than proceeding blind.
+
+## Output format
+
+Always report the confirmed state, e.g.:
+
+# [Result]
+- Opened: spotify://search/... via deep link, foreground=com.spotify.music
+- Tapped: node <id> ("Circles – Post Malone")
+- Verified: playback bar shows pause button → playing

--- a/android-ui-automation/evals/evals.json
+++ b/android-ui-automation/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "android-ui-automation",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "放首歌，打开 Spotify 搜 Circles 然后播放",
+      "expected_output": "Spotify reached foreground via spotify://search/circles; the top matching row is tapped; the playback bar shows the track and the play button reads 'pause' (verification marker hit). No API key or OAuth involved.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "opens Spotify via a spotify:// deep link",
+          "type": "contains"
+        },
+        {
+          "text": "confirms playback with a pause-button marker",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "搜一首歌：连名带姓 张惠妹 然后播第一首",
+      "expected_output": "Deep link spotify://search/连名带姓%20张惠妹 (percent-encoded CJK) opens Spotify; the first song row matching the query is located and tapped; playback verified by marker.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "percent-encodes the CJK query in the deep link",
+          "type": "contains"
+        },
+        {
+          "text": "verifies playback before reporting success",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "打开微信朋友圈，随便滑一滑",
+      "expected_output": "weixin:// deep link brings WeChat foreground; since Moments hides its tree from accessibility, the skill performs human-like random swipes instead of trying to dump/tap inner nodes; it does NOT guess button coordinates.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "falls back to gesture swipes when the app tree is unavailable",
+          "type": "contains"
+        },
+        {
+          "text": "does not blind-tap unverified coordinates",
+          "type": "contains"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "打开一个没有前台的 app，比如一个没装的 app",
+      "expected_output": "open_and_verify returns ok=false with a clear error; the skill surfaces the failure instead of pretending the action succeeded.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "surfaces open failure instead of claiming success",
+          "type": "contains"
+        }
+      ]
+    }
+  ]
+}

--- a/android-ui-automation/references/app-deep-links.md
+++ b/android-ui-automation/references/app-deep-links.md
@@ -1,0 +1,55 @@
+# Android App Deep Link Reference
+
+Deep links let us jump straight into a target app's view without an API.
+Scheme handling differs per app; test each once before relying on it.
+
+## Spotify (`com.spotify.music`)
+Directly supports search via `spotify://search/<query>`:
+
+```
+spotify://search/circles%20post%20malone
+spotify://search/<percent-encoded-query>
+```
+
+- Opens Spotify and pre-fills the search — no OAuth, no API key. Works on Free accounts.
+- **Known limitation (verified 2026-08-11):** the deep link lands on the
+  *suggestion* page, NOT finished results. To reach results: tap a suggestion
+  row such as `添加建议"<query>"` (find_node query: the suggestion text), then
+  tap the result row. Tapping a suggestion may start playback from the queue
+  immediately — verify with the `暂停` (pause) marker on the bottom bar.
+- Foreground package to expect: `com.spotify.music`.
+- After opening, the first result row usually matches; tap and verify a pause
+  button appears to confirm playback.
+
+## WeChat / Weixin (`com.tencent.mm`)
+```
+weixin://               → opens the app (often the chat list)
+weixin://dl/moments     → Moments (朋友圈) foreground directly on some builds
+```
+
+- **Known limitation:** Moments shields its inner view tree from the
+  Accessibility Service — `ui dump` may return no `com.tencent.mm` nodes. Do
+  NOT blindly tap guessed coordinates; prefer `gesture swipe` for scroll-only
+  automation, and ask the user to tap anything that needs exact positioning.
+
+## YouTube (`com.google.android.youtube`)
+```
+https://www.youtube.com/results?search_query=<encoded>   → search results
+vnd.youtube:<videoId>                                    → play a video
+```
+
+## Bilibili (`tv.danmaku.bili`)
+```
+bilibili://search/?keyword=<encoded>
+https://www.bilibili.com/video/BV1... → web link, usually opens the app
+```
+
+Not all schemes are registered on every build. If `ui info` shows the expected
+package did not reach the foreground, the scheme may be unhandled — fall back to
+coordinating with the user or find another entry point.
+
+## Guidance
+- **Always verify foreground** after opening (see `open_deep_link.py`).
+- **Percent-encode** query values; CJK and `&`/`?` break otherwise.
+- When a scheme is unreliable, ask the user for an alternative entry point
+  (home screen tap, etc.) rather than guessing.

--- a/android-ui-automation/scripts/find_node.py
+++ b/android-ui-automation/scripts/find_node.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+find_node.py — Smart UI element location for Android Accessibility.
+
+Wraps `android-a11y-cli ui dump` and returns the best-matching node(s) for a
+query. Unlike a raw "tap by exact text", this script:
+
+  * decodes the JSON envelope and flattens the node tree;
+  * scores every node by how well it matches on text OR contentDescription,
+    both exact and fuzzy (substring), with clickable nodes preferred;
+  * supports regex matching;
+  * returns ranked candidates so the caller can verify before acting.
+
+This is the layer that turns a brittle "find this button" into a robust
+"find the most likely button" — essential for apps that label UI inconsistently.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+def dump_tree() -> list:
+    """Call android-a11y-cli ui dump and return the node list."""
+    proc = subprocess.run(
+        ["android-a11y-cli", "ui", "dump", "--compact"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"android-a11y-cli dump failed: {proc.stderr.strip()}")
+    payload = proc.stdout
+    # The CLI may print a "proot info" line before the JSON. Jump to first '{'.
+    start = payload.find("{")
+    if start == -1:
+        raise RuntimeError("android-a11y-cli returned no JSON")
+    try:
+        data = json.loads(payload[start:])
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"android-a11y-cli returned invalid JSON: {e}")
+    if not data.get("ok"):
+        raise RuntimeError(data.get("error", {}).get("message", "dump failed"))
+    return data["data"].get("nodes", [])
+
+
+def node_text(node: dict) -> str:
+    """Join text and contentDescription for matching."""
+    parts = []
+    for key in ("text", "contentDesc"):
+        val = node.get(key)
+        if val and val.strip():
+            parts.append(val.strip())
+    return " ".join(parts)
+
+
+def score_node(node: dict, query_lower: str, regex) -> int:
+    """Return a heuristic score; higher == better match."""
+    txt = node_text(node).lower()
+    if not txt:
+        return -1
+
+    score = 0
+    if regex:
+        if regex.search(txt):
+            score += 100
+        else:
+            return -1
+    else:
+        if txt == query_lower:
+            score += 100  # exact
+        elif query_lower in txt:
+            score += 60   # substring
+        elif txt in query_lower:
+            score += 30   # node is a fragment of the query
+        else:
+            return -1
+
+    # Clickable nodes are what we want to act on — boost them.
+    if node.get("clickable"):
+        score += 10
+    return score
+
+
+def find(query: str, use_regex: bool = False, top_k: int = 5,
+         must_be_clickable: bool = False):
+    """Return ranked node candidates matching the query."""
+    query_lower = query.lower()
+    regex = re.compile(query) if use_regex else None
+
+    nodes = dump_tree()
+    scored = []
+    for node in nodes:
+        s = score_node(node, query_lower, regex)
+        if s < 0:
+            continue
+        if must_be_clickable and not node.get("clickable"):
+            continue
+        scored.append((s, node))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [
+        {
+            "score": s,
+            "nodeId": n.get("nodeId"),
+            "center": n.get("center"),
+            "clickable": n.get("clickable"),
+            "text": n.get("text") or "",
+            "contentDesc": n.get("contentDesc") or "",
+        }
+        for s, n in scored[:top_k]
+    ]
+
+
+def main():
+    p = argparse.ArgumentParser(description="Locate a UI node by fuzzy match.")
+    p.add_argument("query", help="Text or contentDescription to match")
+    p.add_argument("--regex", action="store_true", help="Treat query as regex")
+    p.add_argument("--top", type=int, default=5, help="Max candidates to return")
+    p.add_argument("--clickable-only", action="store_true",
+                   help="Only return clickable nodes")
+    p.add_argument("--jsonlines", action="store_true",
+                   help="Print one JSON object per line")
+    a = p.parse_args()
+
+    results = find(a.query, use_regex=a.regex, top_k=a.top,
+                   must_be_clickable=a.clickable_only)
+    if not results:
+        print("NO_MATCH", file=sys.stderr)
+        sys.exit(1)
+    if a.jsonlines:
+        for r in results:
+            print(json.dumps(r, ensure_ascii=False))
+    else:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/android-ui-automation/scripts/open_deep_link.py
+++ b/android-ui-automation/scripts/open_deep_link.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+open_deep_link.py — Construct and open an Android app deep link, then confirm
+the target app reached the foreground.
+
+Why this script exists instead of a raw `android-open <url>`:
+  * deep link construction (search queries, params) is URL-encoding-sensitive;
+  * "opened" doesn't mean "foreground" — app may be missing, the scheme may be
+    unregistered, or the view may be intercepted. This script verifies the
+    foreground package and offers a configurable retry/fallback.
+
+Usage (as a module):
+    from open_deep_link import open_and_verify
+    ok = open_and_verify(app_package="com.spotify.music",
+                         url="spotify://search/firework")
+"""
+
+import argparse
+import json
+import subprocess
+import time
+import urllib.parse
+import os
+
+# Well-known scheme -> expected foreground package.
+KNOWN_APPS = {
+    "spotify": "com.spotify.music",
+    "weixin": "com.tencent.mm",
+    "youtube": "com.google.android.youtube",
+    "bilibili": "tv.danmaku.bili",
+    "douyin": "com.ss.android.ugc.aweme",
+}
+
+
+def foreground_package() -> str | None:
+    """Return the currently focused/active package via ui info."""
+    try:
+        proc = subprocess.run(
+            ["android-a11y-cli", "ui", "info", "--compact"],
+            capture_output=True, text=True, timeout=15,
+        )
+        payload = proc.stdout
+        start = payload.find("{")
+        data = json.loads(payload[start:])
+        if not data.get("ok"):
+            return None
+        return data["data"].get("packageName")
+    except Exception:
+        return None
+
+
+def open_url(url: str) -> bool:
+    """Fire android-open and return success."""
+    try:
+        proc = subprocess.run(
+            ["android-open", url], capture_output=True, text=True, timeout=20
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+def wait_for_package(pkg: str | None, timeout: float = 8.0) -> bool:
+    """Poll until the expected package reaches foreground, or timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        cur = foreground_package()
+        if pkg is None or cur == pkg:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def build_search_url(scheme: str, query: str, key: str = "search") -> str:
+    """Construct <scheme>://<key>/<urlencoded-query> safely."""
+    q = urllib.parse.quote(query, safe="")
+    return f"{scheme}://{key}/{q}"
+
+
+def open_and_verify(url: str, expected_pkg: str | None = None,
+                    retries: int = 2, timeout: float = 8.0) -> dict:
+    """Open a deep link and confirm the app reached foreground.
+
+    Returns a dict with ok, url, package, attempts. Raises ValueError on
+    malformed scheme; never raises on runtime failure (returns ok=False).
+    """
+    scheme = urllib.parse.urlparse(url).scheme
+    if not scheme:
+        raise ValueError(f"not a deep link (no scheme): {url}")
+
+    expected = expected_pkg or KNOWN_APPS.get(scheme)
+
+    attempts = 0
+    last_err = None
+    while attempts <= retries:
+        attempts += 1
+        if not open_url(url):
+            last_err = f"android-open returned non-zero (attempt {attempts})"
+            time.sleep(1.0)
+            continue
+        if wait_for_package(expected, timeout=timeout):
+            return {
+                "ok": True,
+                "url": url,
+                "scheme": scheme,
+                "expected_pkg": expected,
+                "got_pkg": foreground_package(),
+                "attempts": attempts,
+            }
+        last_err = f"expected {expected} but got {foreground_package()}"
+        time.sleep(1.0)
+
+    return {
+        "ok": False,
+        "url": url,
+        "scheme": scheme,
+        "expected_pkg": expected,
+        "got_pkg": foreground_package(),
+        "attempts": attempts,
+        "error": last_err,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description="Open a deep link and verify foreground.")
+    p.add_argument("url", help="deep link, e.g. spotify://search/circles")
+    p.add_argument("--pkg", help="expected foreground package override")
+    p.add_argument("--retries", type=int, default=2)
+    p.add_argument("--timeout", type=float, default=8.0)
+    a = p.parse_args()
+    try:
+        result = open_and_verify(a.url, a.pkg, a.retries, a.timeout)
+    except ValueError as e:
+        print(json.dumps({"ok": False, "error": str(e)}, ensure_ascii=False))
+        sys.exit(2)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    sys.exit(0 if result["ok"] else 1)
+
+
+if __name__ == "__main__":
+    import sys
+    main()

--- a/android-ui-automation/scripts/tap_and_verify.py
+++ b/android-ui-automation/scripts/tap_and_verify.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+tap_and_verify.py — Tap a located node and then PROVE the tap had its effect,
+with bounded retries.
+
+Why this script instead of a raw `tap xy`:
+  A raw tap is fire-and-forget; the UI may be mid-animation, or the node may
+  have drifted after a relayout. This script:
+
+    * taps by node id or by a fuzzy query (via find_node.py);
+    * waits for the DOM to stabilize after the tap;
+    * optionally verifies a "success marker" appears (e.g. a pause button, a
+      title, a toast) — this is how we confirm "it actually started playing";
+
+  This is the difference between "I clicked something" and "I know it worked".
+"""
+
+import argparse
+import json
+import subprocess
+import time
+import sys
+
+
+def _cli(*args) -> dict:
+    proc = subprocess.run(
+        ["android-a11y-cli", *args, "--compact"],
+        capture_output=True, text=True, timeout=20,
+    )
+    payload = proc.stdout
+    start = payload.find("{")
+    if start == -1:
+        raise RuntimeError(f"no JSON from android-a11y-cli {args}")
+    data = json.loads(payload[start:])
+    if not data.get("ok"):
+        raise RuntimeError(data.get("error", {}).get("message", "unknown"))
+    return data["data"]
+
+
+def tap_node(node_id: str) -> dict:
+    return _cli("tap", "node", node_id)
+
+
+def _node_text() -> list:
+    """Return all visible text/contentDesc as one string for marker search."""
+    data = _cli("ui", "dump")
+    parts = []
+    for n in data.get("nodes", []):
+        for k in ("text", "contentDesc"):
+            v = n.get(k)
+            if v and v.strip():
+                parts.append(v.strip())
+    return parts
+
+
+def node_by_query(query: str, clickable_only: bool = True) -> dict | None:
+    """Reuse find_node.py to locate a node, return top result or None."""
+    import find_node
+    results = find_node.find(query, must_be_clickable=clickable_only, top_k=1)
+    return results[0] if results else None
+
+
+def wait_stable(timeout: float = 3.0) -> None:
+    try:
+        _cli("wait", "stable")
+    except Exception:
+        time.sleep(1.0)
+
+
+def verify_marker(marker: str | None, timeout: float = 5.0) -> bool:
+    """Poll the UI text until `marker` appears (case-insensitive)."""
+    if not marker:
+        return True
+    m = marker.lower()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            texts = _node_text()
+        except Exception:
+            texts = []
+        if any(m in t.lower() for t in texts):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def tap_and_verify(query: str = None, node_id: str = None,
+                   marker: str = None, retries: int = 2,
+                   marker_timeout: float = 5.0) -> dict:
+    """Tap a node (by id or query) and verify an effect marker appears."""
+    if not node_id:
+        node = node_by_query(query)
+        if not node:
+            return {"ok": False, "error": f"no node found for '{query}'"}
+        node_id = node["nodeId"]
+
+    attempts = 0
+    while attempts <= retries:
+        attempts += 1
+        try:
+            tap_node(node_id)
+        except Exception as e:
+            return {"ok": False, "error": f"tap failed: {e}"}
+        wait_stable()
+        if verify_marker(marker, timeout=marker_timeout):
+            return {"ok": True, "nodeId": node_id, "attempts": attempts}
+        # Relocate in case the tree changed after the first tap.
+        if query:
+            refreshed = node_by_query(query)
+            if refreshed:
+                node_id = refreshed["nodeId"]
+
+    return {
+        "ok": False,
+        "nodeId": node_id,
+        "attempts": attempts,
+        "error": f"success marker '{marker}' never appeared",
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description="Tap a node and verify the effect.")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--query", help="fuzzy text to locate the node")
+    g.add_argument("--node", help="explicit node id to tap")
+    p.add_argument("--marker", help="text that must appear to confirm success")
+    p.add_argument("--retries", type=int, default=2)
+    p.add_argument("--marker-timeout", type=float, default=5.0)
+    a = p.parse_args()
+
+    result = tap_and_verify(query=a.query, node_id=a.node, marker=a.marker,
+                            retries=a.retries, marker_timeout=a.marker_timeout)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    sys.exit(0 if result["ok"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/android-ui-automation/tests/unit_tests.py
+++ b/android-ui-automation/tests/unit_tests.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Unit tests for android-ui-automation skill scripts (no device needed)."""
+import sys, os, json
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+passed = failed = 0
+
+import re
+def re_compiled():
+    return re.compile("播.*曲")
+
+def check(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  ✓ {name}")
+    else:
+        failed += 1
+        print(f"  ✗ {name}  {detail}")
+
+def _raises(exc, fn_, *a, **kw):
+    try:
+        fn_(*a, **kw)
+        return False
+    except exc:
+        return True
+
+# ---------- find_node.py ----------
+from find_node import score_node, find, node_text
+
+print("== find_node.score_node ==")
+node = {"text": "Circles – Post Malone", "contentDesc": "歌曲", "clickable": True}
+node2 = {"text": "", "contentDesc": "暂停", "clickable": True}
+node3 = {"text": "播放页", "contentDesc": "", "clickable": False}
+
+check("exact text+desc concatenated → substring 70",
+      score_node(node, "circles – post malone", None) == 70)
+check("exact match when no contentDesc → 110",
+      score_node({"text": "Circles – Post Malone", "clickable": True}, "circles – post malone", None) == 110)
+check("substring match scores 60+10", score_node(node, "circles", None) == 70)
+check("contentDesc exact 100+10", score_node(node2, "暂停", None) == 110)
+check("non-clickable fragment 30", score_node(node3, "暂停播放页", None) == 30)
+check("no match returns -1", score_node(node, "不存在的词", None) == -1)
+check("regex match",
+      score_node({"text": "播放歌曲", "clickable": True}, "播.*曲", re_compiled()) == 110)
+check("empty text returns -1", score_node({"text": "", "clickable": True}, "x", None) == -1)
+
+check("node_text joins text+desc",
+      node_text(node) == "Circles – Post Malone 歌曲")
+
+# ---------- find() with fake dump ----------
+import find_node as fn
+fn.dump_tree = lambda: [
+    {"nodeId": "001", "text": "Circles – Post Malone", "contentDesc": "歌曲", "clickable": True},
+    {"nodeId": "002", "text": "搜索", "contentDesc": "", "clickable": True},
+    {"nodeId": "003", "text": "推荐", "contentDesc": "", "clickable": False},
+]
+r = find("circles", top_k=3)
+check("find ranks best match first", r and r[0]["nodeId"] == "001" and r[0]["score"] == 70)
+r2 = find("搜索")
+check("find exact + clickable", r2 and r2[0]["score"] == 110)
+r3 = find("无此节点")
+check("find no match returns []", r3 == [])
+
+# ---------- open_deep_link.py ----------
+from open_deep_link import build_search_url, open_url, open_and_verify
+print("== open_deep_link.build_search_url ==")
+cases = [
+    ("spotify", "Uptown Funk", "spotify://search/Uptown%20Funk"),
+    ("youtube", "cats", "youtube://search/cats"),
+    ("bilibili", "测试 视频", "bilibili://search/%E6%B5%8B%E8%AF%95%20%E8%A7%86%E9%A2%91"),
+    ("weixin", "张三", "weixin://search/%E5%BC%A0%E4%B8%89"),
+]
+for app, q, want in cases:
+    got = build_search_url(app, q)
+    check(f"{app} '{q}' → {want}", got == want, f"got {got}")
+
+check("build_search_url never raises for unknown scheme",
+      build_search_url("nope", "x") == "nope://search/x")
+check("open_and_verify rejects URL without scheme (ValueError)",
+      _raises(ValueError, open_and_verify, "not-a-deep-link"))
+
+# ---------- tap_and_verify.py ----------
+from tap_and_verify import verify_marker, tap_and_verify
+print("== tap_and_verify.verify_marker ==")
+# fake _node_text to simulate a marker appearing
+import tap_and_verify as tv
+tv._node_text = lambda: ["暂停", "Circles – Post Malone 歌曲"]
+check("verify marker 暂停 → True", verify_marker("暂停", timeout=0.5) is True)
+tv._node_text = lambda: ["播放", "Circles – Post Malone 歌曲"]
+check("verify marker 暂停 (absent) → False", verify_marker("暂停", timeout=0.5) is False)
+
+def _raises(exc, fn_, *a, **kw):
+    try:
+        fn_(*a, **kw)
+        return False
+    except exc:
+        return True
+
+print("\n结果: {passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary
New skill **android-ui-automation**: drive Android apps through their UI layer via the Accessibility Service when they have no public API or web version.

## What it does
- **Deep-link launch** (open_deep_link.py): construct/verify app deep links (spotify://, weixin://, youtube://, bilibili://), confirm the target app reached the foreground.
- **Intelligent node location** (find_node.py): fuzzy-scored node search (exact > substring > fragment), prefers clickable nodes, supports regex.
- **Tap-and-verify** (tap_and_verify.py): tap a node and confirm a success marker (e.g. pause button) actually appeared — never fire-and-forget.
- **Human-like swipes** guidance for apps that hide their view tree (WeChat Moments).

## Environment
Relies on `android-a11y-cli` / `android-open`, which ship with the **Minis Android app** (see SKILL.md → Environment & dependencies).

## Tested
- Unit tests 19/19 passing (tests/unit_tests.py): scoring, URL encoding, scheme validation, marker verification.
- Real-device smoke tests passed: Spotify search deep link → foreground confirmed; tap suggestion → results; tap result → playback verified via pause marker.
- Known limitation documented: spotify://search/ lands on the suggestion page, not results (verified on device).