### PR TITLE
Add youtube-downloader skill

### DIFF
--- a/youtube-downloader/SKILL.md
+++ b/youtube-downloader/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: youtube-downloader
+description: >
+  Download YouTube videos or extract audio using yt-dlp + ffmpeg in the Linux shell.
+  Trigger when the user shares a YouTube URL and wants to download, save, rip,
+  extract, or convert it — to video or audio (MP3/M4A). Also trigger for phrases
+  like "download this video", "save this YouTube", "rip audio from", "grab this
+  video", or when a YouTube link is shared with intent to save it locally.
+  Works with youtube.com/watch, youtu.be/, and youtube.com/shorts/ URLs.
+compatibility: requires yt-dlp, ffmpeg
+---
+
+# YouTube Downloader
+
+Download YouTube videos or extract audio. Files are named after the video title, saved to the user's preferred location, and remuxed to play correctly as video on iOS.
+
+## How This Skill Works
+
+This skill runs yt-dlp + ffmpeg inside the Minis Linux sandbox (iSH). Two iSH-specific workarounds are required:
+
+1. **Manual DASH merge:** yt-dlp's built-in video+audio merger crashes in iSH. For high-quality formats (1080p, 1440p), the script downloads video and audio separately using `-k` (keep video), lets the merger fail, then merges them with a direct ffmpeg call.
+
+2. **iOS container fix:** YouTube's MP4 files use the `mp42` brand, which iOS may treat as audio-only. The script remuxes to M4V (for H.264) or standard mp4 (for AV1/VP9) with `+faststart` so iOS Files plays them as video.
+
+## First Run — Onboarding
+
+On the FIRST time this skill triggers, run onboarding before downloading anything.
+
+### Step 1: Check status
+
+```bash
+sh /var/minis/skills/youtube-downloader/scripts/yt-config.sh status
+```
+
+If `onboarded: true`, skip to Normal Operation. If `onboarded: false` (or config doesn't exist), continue onboarding.
+
+### Step 2: Install dependencies
+
+If `yt-dlp: no` or `ffmpeg: no` in the status output, install them:
+
+```bash
+apk add yt-dlp ffmpeg py3-pip
+pip install --upgrade --break-system-packages yt-dlp
+```
+
+The pip upgrade is essential — Alpine's yt-dlp package is stale and YouTube's player changes frequently. This takes ~30 seconds.
+
+### Step 3: Ask the user two questions
+
+Present as a friendly numbered list. Wait for answers.
+
+**Question 1 — Quality preference:**
+> What quality do you want by default?
+> 1. **1080p video** — Full HD, best balance of quality and size (default)
+> 2. **1440p video** — 2K, highest quality, large files (~300 MB per 10 min)
+> 3. **720p video** — HD, smaller file size
+> 4. **Audio only** — best for music/podcasts, smallest file
+> 5. **Ask me every time** — no default, I'll pick per video
+
+**Question 2 — Where to save:**
+> Where should I save your downloads?
+> 1. **iOS Files app (Downloads folder)** — appears in Files → Downloads
+> 2. **iOS Photos (YouTube Downloads album)** — appears in Photos
+> 3. **Keep in Minis** — stays in the app's attachments folder
+
+### Step 4: Set up Files mount (if user chose option 1)
+
+Check if the Downloads mount already exists via the status command. If `downloads_mount: yes`, skip. If `downloads_mount: no`, tell the user:
+
+> To save videos to your Files app, I need you to mount your Downloads folder:
+> 1. Tap this link: [Mount External Folders](minis://settings/mount-external)
+> 2. Tap "Add Mount"
+> 3. Navigate to the folder you want (e.g., iCloud Drive → Downloads, or On My iPhone → Downloads)
+> 4. Name it "Downloads"
+> 5. Come back here and tell me when you're done
+
+After the user confirms, re-run the status check to verify `downloads_mount: yes`.
+
+### Step 5: Save config
+
+```bash
+sh /var/minis/skills/youtube-downloader/scripts/yt-config.sh set quality "<chosen_quality>"
+sh /var/minis/skills/youtube-downloader/scripts/yt-config.sh set save_mode "<chosen_save_mode>"
+sh /var/minis/skills/youtube-downloader/scripts/yt-config.sh complete
+```
+
+- Quality: "1080p", "1440p", "720p", "360p", "audio", or "" (empty string for "ask every time")
+- save_mode: "files", "photos", or "minis"
+
+### Step 6: Offer a test download
+
+Tell the user setup is complete. Offer to download a short test video at 360p so they can verify the flow:
+
+```bash
+sh /var/minis/skills/youtube-downloader/scripts/yt-download.sh "https://www.youtube.com/watch?v=aqz-KE-bpKQ" 360p <save_mode>
+```
+
+Replace `<save_mode>` with whatever the user chose (files, photos, or minis). 360p is used for the test because it's the most reliable quality — higher quality works the same way once configured.
+
+Confirm the file appeared where they expected. Then proceed with whatever they originally asked for.
+
+---
+
+## Normal Operation
+
+```bash
+sh /var/minis/skills/youtube-downloader/scripts/yt-download.sh "<URL>" [quality] [save_mode]
+```
+
+- Quality is optional — if omitted, uses the saved default from config
+- save_mode is optional — if omitted, uses the saved default from config (files, photos, or minis)
+- If the user specified a quality in their message ("just the audio", "1440p", etc.), use that
+- If the user specified where to save ("save to photos", "put it in files"), pass that as save_mode
+
+### After download, report to the user
+
+The script prints one of three status lines. Read it and tell the user:
+- If `SAVED_TO_FILES`: "Saved to your Files app → Downloads folder. Pull to refresh if you don't see it yet."
+- If `SAVED_TO_PHOTOS`: "Saved to the 'YouTube Downloads' album in your Photos app."
+- If `KEPT_IN_ATTACHMENTS`: The file is at `/var/minis/attachments/<filename>`. Display it inline and tell the user it's available in Minis.
+- Always include the video title and file size.
+
+---
+
+## Quality Reference
+
+| Quality | Format | Approx size (10-min video) | Reliability |
+|---------|--------|---------------------------|------------|
+| 1080p | DASH H.264 + AAC, manually merged | ~256 MB | ✅ Works (M4V container) |
+| 1440p | DASH AV1 or VP9 + AAC, manually merged | ~300-460 MB | ✅ Works (mp4 container) |
+| 720p | MP4 pre-merged (format 22) | ~80 MB | ✅ Always works |
+| 360p | MP4 pre-merged (format 18) | ~27 MB | ✅ Always works |
+| audio | M4A 128kbps (format 140) | ~10 MB | ✅ Always works |
+
+DASH formats (1080p, 1440p) download video and audio separately, then merge with ffmpeg (yt-dlp's built-in merger fails in iSH). H.264 streams go into the Apple M4V container; AV1/VP9 streams go into standard mp4. Both play as video on iOS. All video downloads are remuxed with `+faststart` and the correct container brand.
+
+---
+
+## Troubleshooting
+
+**403 Forbidden on DASH streams**: YouTube transiently blocks DASH downloads when using the android vr client fallback (no JS runtime available). Retry — it usually works within 1-2 attempts. Pre-merged formats (360p, 720p) bypass this entirely.
+
+**"No supported JavaScript runtime"**: iSH has no Deno/Node, so yt-dlp can't do YouTube's nsig extraction. Pre-merged formats (18, 22) and audio (140) work without JS. DASH formats work via the android vr client fallback but may intermittently 403.
+
+**yt-dlp out of date**: YouTube breaks extraction often. Run `pip install --upgrade --break-system-packages yt-dlp`.
+
+**Downloads mount disappears**: The mount may disconnect if iCloud sync state changes. Run `yt-config.sh status` to check. If broken, guide the user to re-mount via [Mount External Folders](minis://settings/mount-external).
+
+**Large files**: 1440p files can exceed 450 MB. If the app crashes or becomes unstable, stick to 1080p or lower.

--- a/youtube-downloader/scripts/yt-config.sh
+++ b/youtube-downloader/scripts/yt-config.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+# ============================================================================
+# yt-config.sh — Config and status manager for the YouTube downloader skill
+# ============================================================================
+#
+# This script manages a JSON config file (../config.json) that persists the
+# user's onboarding state and preferences across sessions.
+#
+# It also reports dependency and mount status so the agent can decide what
+# to do on first run (install packages, guide the user to mount a folder, etc.).
+#
+# No external dependencies (no jq). JSON field access is done with sed because
+# the config is simple flat key-value pairs, not nested structures.
+#
+# Usage:
+#   yt-config.sh status           Print config + dependency + mount status
+#   yt-config.sh init            Write default config (onboarded = false)
+#   yt-config.sh set <key> <val>  Update one config field
+#   yt-config.sh complete         Mark onboarding as complete
+#
+# ============================================================================
+
+CONFIG_FILE="$(dirname "$0")/../config.json"
+
+# Default config written on first run.
+# quality: the user's default download quality.
+# save_mode: where to save downloads — "files" (iOS Files mount), "photos"
+#   (iOS Photos album "YouTube Downloads"), or "minis" (keep in attachments).
+DEFAULT_CONFIG='{"onboarded": false, "quality": "1080p", "save_location": "", "save_mode": "files"}'
+
+# --- Simple JSON field reader (no jq needed) ---
+get_field() {
+  echo "$1" | sed -nE "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"?([^\",}]*)\"?.*/\1/p"
+}
+
+# --- Simple JSON field setter ---
+set_field() {
+  JSON="$1" KEY="$2" VAL="$3"
+  if echo "$JSON" | grep -q "\"$KEY\""; then
+    echo "$JSON" | sed -E "s/(\"$KEY\"[[:space:]]*:[[:space:]]*)(\"?[^\"]*\"?)([,}])/\1\"$VAL\"\3/"
+  else
+    echo "$JSON" | sed -E "s/}$/, \"$KEY\": \"$VAL\"}/" | sed -E 's/\{,/\{/'
+  fi
+}
+
+case "$1" in
+  init)
+    echo "$DEFAULT_CONFIG" > "$CONFIG_FILE"
+    echo "Config initialized at $CONFIG_FILE"
+    ;;
+
+  status)
+    [ ! -f "$CONFIG_FILE" ] && echo "$DEFAULT_CONFIG" > "$CONFIG_FILE"
+    CONFIG=$(cat "$CONFIG_FILE")
+
+    # --- Dependency checks ---
+    # yt-dlp: the download engine. Alpine's package version is stale —
+    #   the onboarding flow upgrades it via pip.
+    # ffmpeg: needed to merge DASH streams and remux to iOS-compatible format.
+    # pip: needed to upgrade yt-dlp to the latest version.
+    YTDLP="no"; [ -x "$(which yt-dlp 2>/dev/null)" ] && YTDLP="yes"
+    FFMPEG="no"; [ -x "$(which ffmpeg 2>/dev/null)" ] && FFMPEG="yes"
+    PIP="no"; [ -x "$(which pip 2>/dev/null)" ] && PIP="yes"
+
+    # --- Mount checks ---
+    # The user mounts an iOS Files folder (e.g., Downloads) so the script can
+    # move completed downloads there. Without a mount, files stay in /var/minis/attachments/.
+    DOWNLOADS_MOUNT="no"
+    if [ -d /var/minis/mounts/Downloads ] && [ -w /var/minis/mounts/Downloads ]; then
+      DOWNLOADS_MOUNT="yes"
+    fi
+    ANY_MOUNT="no"
+    if [ -d /var/minis/mounts/ ] && [ "$(ls -A /var/minis/mounts/ 2>/dev/null)" ]; then
+      ANY_MOUNT="yes"
+    fi
+    MOUNTS=""
+    if [ -d /var/minis/mounts/ ]; then
+      MOUNTS=$(ls /var/minis/mounts/ 2>/dev/null | tr '\n' ',')
+    fi
+
+    echo "CONFIG:"
+    echo "  onboarded: $(get_field "$CONFIG" "onboarded")"
+    echo "  quality: $(get_field "$CONFIG" "quality")"
+    echo "  save_mode: $(get_field "$CONFIG" "save_mode")"
+    echo "  save_location: $(get_field "$CONFIG" "save_location")"
+    echo ""
+    echo "DEPENDENCIES:"
+    echo "  yt-dlp: $YTDLP"
+    echo "  ffmpeg: $FFMPEG"
+    echo "  pip: $PIP"
+    echo ""
+    echo "MOUNTS:"
+    echo "  any_mount: $ANY_MOUNT"
+    echo "  downloads_mount: $DOWNLOADS_MOUNT"
+    [ -n "$MOUNTS" ] && echo "  available_mounts: $MOUNTS"
+    ;;
+
+  set)
+    [ ! -f "$CONFIG_FILE" ] && echo "$DEFAULT_CONFIG" > "$CONFIG_FILE"
+    CONFIG=$(cat "$CONFIG_FILE")
+    NEW_CONFIG=$(set_field "$CONFIG" "$2" "$3")
+    echo "$NEW_CONFIG" > "$CONFIG_FILE"
+    echo "Set $2 = $3"
+    ;;
+
+  complete)
+    [ ! -f "$CONFIG_FILE" ] && echo "$DEFAULT_CONFIG" > "$CONFIG_FILE"
+    CONFIG=$(cat "$CONFIG_FILE")
+    NEW_CONFIG=$(set_field "$CONFIG" "onboarded" "true")
+    echo "$NEW_CONFIG" > "$CONFIG_FILE"
+    echo "Onboarding marked complete"
+    ;;
+
+  *)
+    echo "Usage: yt-config.sh {status|init|set <key> <val>|complete}"
+    exit 1
+    ;;
+esac

--- a/youtube-downloader/scripts/yt-download.sh
+++ b/youtube-downloader/scripts/yt-download.sh
@@ -1,0 +1,251 @@
+#!/bin/sh
+# ============================================================================
+# yt-download.sh — YouTube downloader for Minis (running inside iSH on iOS)
+# ============================================================================
+#
+# WHAT THIS DOES
+#   Downloads a YouTube video or extracts audio, names the file after the
+#   video title, remuxes to an iOS-compatible container, and moves it to the
+#   user's iOS Files folder (if mounted).
+#
+# WHY THIS IS NON-STANDARD
+#   This script runs inside iSH — a Linux usermode emulator on iOS. Two things
+#   that work fine on a normal Linux machine are broken here:
+#
+#   1. yt-dlp's built-in video+audio merger fails in iSH.
+#      When downloading DASH formats (1080p, 1440p), YouTube serves video and
+#      audio as separate files. yt-dlp normally merges them itself — but that
+#      merge step crashes in iSH ("Error opening input files"). We work around
+#      this by passing -k (keep video) so the separate files survive the crash,
+#      then we merge them ourselves with a direct ffmpeg call.
+#
+#   2. YouTube's MP4 files use the "mp42" major brand, which iOS sometimes
+#      treats as audio-only (video track is ignored). We remux everything with
+#      ffmpeg and the correct container: H.264 → M4V (Apple's video container),
+#      AV1/VP9 → standard mp4 with +faststart.
+#
+# USAGE
+#   sh yt-download.sh "<url>" [quality] [save_mode]
+#
+#   Quality:  audio, 360p, 720p, 1080p, 1440p, best
+#   Save mode (optional, overrides config):
+#     files   — move to iOS Files mount (Downloads folder)
+#     photos  — save to iOS Photos album "YouTube Downloads" via apple-photos
+#     minis   — keep in /var/minis/attachments/
+#
+#   Default quality and save mode come from ../config.json
+#
+# OUTPUTS
+#   SUCCESS: <path> (<size>)
+#   SAVED_TO_FILES: <path>      — moved to iOS Files mount
+#   SAVED_TO_PHOTOS: <path>     — saved to iOS Photos album
+#   KEPT_IN_ATTACHMENTS: <path> — kept in sandbox
+#
+# ============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/../config.json"
+
+URL="$1"
+
+# ── Load user config ──────────────────────────────────────────────────────────
+DEFAULT_QUALITY="1080p"
+DEFAULT_SAVE_MODE="files"
+SAVE_LOCATION=""
+
+if [ -f "$CONFIG_FILE" ]; then
+  CFG=$(cat "$CONFIG_FILE")
+  DEFAULT_QUALITY=$(echo "$CFG" | sed -nE 's/.*"quality"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p')
+  DEFAULT_SAVE_MODE=$(echo "$CFG" | sed -nE 's/.*"save_mode"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p')
+  SAVE_LOCATION=$(echo "$CFG" | sed -nE 's/.*"save_location"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p')
+  # Backward compat: old config had "save_to_files": "true" → treat as "files"
+  if [ -z "$DEFAULT_SAVE_MODE" ]; then
+    OLD_FLAG=$(echo "$CFG" | sed -nE 's/.*"save_to_files"[[:space:]]*:[[:space:]]*"?([^",}]*)"?.*/\1/p')
+    [ "$OLD_FLAG" = "true" ] && DEFAULT_SAVE_MODE="files"
+  fi
+  [ -z "$DEFAULT_QUALITY" ] && DEFAULT_QUALITY="1080p"
+  [ -z "$DEFAULT_SAVE_MODE" ] && DEFAULT_SAVE_MODE="files"
+fi
+
+QUALITY="${2:-$DEFAULT_QUALITY}"
+SAVE_MODE="${3:-$DEFAULT_SAVE_MODE}"
+OUTDIR="/var/minis/attachments"
+
+[ -z "$URL" ] && { echo "ERROR: No URL provided" >&2; echo "Usage: yt-download.sh <url> [quality] [files|photos|minis]" >&2; exit 1; }
+mkdir -p "$OUTDIR"
+
+# ── Get the video title for a human-readable filename ─────────────────────────
+# yt-dlp --get-title fetches the title from YouTube's API.
+# If that fails (network error, JS runtime warning), fall back to the video ID.
+TITLE=$(yt-dlp --get-title --no-playlist "$URL" 2>/dev/null | tail -1)
+if [ -z "$TITLE" ]; then
+  TITLE=$(echo "$URL" | grep -oE 'v=[A-Za-z0-9_-]{11}' | head -1 | cut -d= -f2)
+  [ -z "$TITLE" ] && TITLE=$(echo "$URL" | grep -oE 'youtu\.be/[A-Za-z0-9_-]{11}' | head -1 | cut -d/ -f2)
+  [ -z "$TITLE" ] && TITLE=$(echo "$URL" | grep -oE 'shorts/[A-Za-z0-9_-]{11}' | head -1 | cut -d/ -f2)
+  [ -z "$TITLE" ] && TITLE="video_$(date +%s)"
+fi
+
+# Sanitize: strip characters iOS doesn't allow in filenames, trim, cap at 80 chars
+SAFE_TITLE=$(echo "$TITLE" | sed 's/[/\\:*?"<>|]/_/g' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//' | cut -c1-80)
+[ -z "$SAFE_TITLE" ] && SAFE_TITLE="video_$(date +%s)"
+
+# ── Format selection ──────────────────────────────────────────────────────────
+#
+# YouTube serves video in two ways:
+#   - Pre-merged: video + audio in a single file (format 18 = 360p, format 22 = 720p)
+#   - DASH: video and audio as separate files, must be merged afterward
+#
+# DASH formats offer higher quality (1080p, 1440p) but require the merge workaround.
+# Format fallback chains (e.g., "299+140/22/18") mean: try 299+140 first, if that
+# fails try format 22, if that fails try format 18. This way a 1080p request still
+# gets *something* even if the DASH stream is unavailable.
+
+case "$QUALITY" in
+  audio)
+    # Format 140 = 128kbps AAC audio. --fixup never skips yt-dlp's container
+    # repair step which also crashes in iSH. The raw download plays fine.
+    EXT="m4a"; FMT="140/139/bestaudio[ext=m4a]/bestaudio"; MODE="direct"
+    ;;
+  360p)
+    # Format 18 = 360p H.264 + AAC, pre-merged. Most reliable format in iSH.
+    EXT="mp4"; FMT="18"; MODE="direct"
+    ;;
+  720p)
+    # Format 22 = 720p H.264 + AAC, pre-merged. Falls back to 360p if unavailable.
+    EXT="mp4"; FMT="22/18"; MODE="direct"
+    ;;
+  1080p)
+    # Format 299 = 1080p60 H.264 (video only) + format 140 = AAC audio.
+    # Falls back to 720p pre-merged, then 360p.
+    EXT="mp4"; FMT="299+140/22/18"; MODE="dash"
+    ;;
+  1440p)
+    # Format 400 = 1440p60 AV1 (video only). AV1 is the only 1440p option.
+    # Falls back to VP9 (308), then 1080p H.264 (299), then pre-merged formats.
+    EXT="mp4"; FMT="400+140/308+251/299+140/22/18"; MODE="dash"
+    ;;
+  best)
+    EXT="mp4"; FMT="bestvideo[ext=mp4]+bestaudio[ext=m4a]/22/18"; MODE="dash"
+    ;;
+  *)
+    echo "ERROR: Unknown quality '$QUALITY'" >&2
+    echo "Valid: audio, 360p, 720p, 1080p, 1440p, best" >&2
+    exit 1
+    ;;
+esac
+
+OUTFILE="$OUTDIR/${SAFE_TITLE}.${EXT}"
+TMPDIR="/tmp/yt-dl-$$"
+mkdir -p "$TMPDIR"
+
+# ── Download ──────────────────────────────────────────────────────────────────
+
+if [ "$MODE" = "dash" ]; then
+  # ── DASH mode: download video + audio separately, merge ourselves ────────────
+  #
+  # -k (keep video): preserve the separate files even after yt-dlp's merger
+  #   crashes. Without -k, yt-dlp deletes them on failure.
+  # --no-part: don't write .part files (they cause issues in iSH).
+  # || true: yt-dlp's merger will exit with error code 1; don't let that kill
+  #   the script (we handle the merge ourselves).
+  yt-dlp -f "$FMT" -o "$TMPDIR/v.%(ext)s" --no-playlist -k --no-part "$URL" 2>&1 || true
+
+  # Find the downloaded files. yt-dlp appends format IDs to filenames
+  # (e.g., "v.f299.mp4", "v.f140.m4a") for DASH, but falls back to plain
+  # "v.mp4" / "v.webm" for pre-merged formats.
+  VIDEO_FILE=$(ls "$TMPDIR"/v.f*.mp4 "$TMPDIR"/v.f*.webm "$TMPDIR"/v.mp4 "$TMPDIR"/v.webm "$TMPDIR"/v.mkv 2>/dev/null | grep -v '\.m4a$' | head -1)
+  AUDIO_FILE=$(ls "$TMPDIR"/*.m4a 2>/dev/null | head -1)
+
+  if [ -n "$VIDEO_FILE" ] && [ -n "$AUDIO_FILE" ]; then
+    # Detect the video codec to choose the right MP4 container.
+    # H.264 → M4V container (Apple's brand, best iOS compatibility)
+    # AV1/VP9 → standard mp4 container (M4V doesn't support these codecs)
+    VCODEC=$(ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of csv=p=0 "$VIDEO_FILE" 2>/dev/null)
+
+    if [ "$VCODEC" = "h264" ]; then
+      ffmpeg -y -i "$VIDEO_FILE" -i "$AUDIO_FILE" -c copy -movflags +faststart -f ipod "$OUTFILE" 2>/dev/null
+    else
+      ffmpeg -y -i "$VIDEO_FILE" -i "$AUDIO_FILE" -c copy -movflags +faststart -f mp4 "$OUTFILE" 2>/dev/null
+    fi
+  elif [ -n "$VIDEO_FILE" ]; then
+    # Fallback: only one file means the format fallback gave us a pre-merged file
+    mv "$VIDEO_FILE" "$OUTFILE"
+  fi
+else
+  # ── Direct mode: pre-merged or audio-only ────────────────────────────────────
+  EXTRA_OPTS=""
+  [ "$QUALITY" = "audio" ] && EXTRA_OPTS="--fixup never"
+  yt-dlp -f "$FMT" $EXTRA_OPTS -o "$OUTFILE" --no-playlist "$URL" 2>&1
+
+  # Remux pre-merged video files to iOS-compatible format.
+  # YouTube's pre-merged files use the "mp42" brand which iOS may treat as
+  # audio-only. Remuxing to M4V brand fixes this. This step is fast (stream copy,
+  # no re-encoding) and produces a file iOS reliably plays as video.
+  EXT="${OUTFILE##*.}"
+  if [ "$EXT" = "mp4" ]; then
+    REMUXED="${OUTFILE}.tmp"
+    ffmpeg -y -i "$OUTFILE" -c copy -movflags +faststart -f ipod "$REMUXED" 2>/dev/null
+    [ -f "$REMUXED" ] && mv "$REMUXED" "$OUTFILE"
+  fi
+fi
+
+# ── Cleanup temp files ────────────────────────────────────────────────────────
+rm -rf "$TMPDIR" 2>/dev/null
+
+# ── Move to destination ───────────────────────────────────────────────────────
+if [ -f "$OUTFILE" ]; then
+  SIZE=$(ls -lh "$OUTFILE" | awk '{print $5}')
+  echo "SUCCESS: $OUTFILE ($SIZE)"
+
+  case "$SAVE_MODE" in
+    files)
+      # Move to iOS Files app (Downloads folder mount)
+      FILES_DIR=""
+      if [ -n "$SAVE_LOCATION" ] && [ -d "$SAVE_LOCATION" ] && [ -w "$SAVE_LOCATION" ]; then
+        FILES_DIR="$SAVE_LOCATION"
+      elif [ -d /var/minis/mounts/Downloads ] && [ -w /var/minis/mounts/Downloads ]; then
+        FILES_DIR="/var/minis/mounts/Downloads"
+      fi
+      if [ -n "$FILES_DIR" ]; then
+        mv "$OUTFILE" "$FILES_DIR/"
+        echo "SAVED_TO_FILES: $FILES_DIR/$(basename "$OUTFILE")"
+      else
+        echo "NOTICE: No Files mount available — file kept in attachments"
+        echo "KEPT_IN_ATTACHMENTS: $OUTFILE"
+      fi
+      ;;
+
+    photos)
+      # Save to iOS Photos album "YouTube Downloads" via apple-photos CLI.
+      # Photos only accepts images and video — audio (.m4a) falls back to attachments.
+      EXT="${OUTFILE##*.}"
+      if [ "$EXT" = "m4a" ] || [ "$EXT" = "mp3" ]; then
+        echo "NOTICE: Photos does not support audio files — keeping in attachments"
+        echo "KEPT_IN_ATTACHMENTS: $OUTFILE"
+      elif command -v apple-photos >/dev/null 2>&1; then
+        apple-photos save --path "$OUTFILE" --album-name "YouTube Downloads" 2>&1
+        rm -f "$OUTFILE"
+        echo "SAVED_TO_PHOTOS: YouTube Downloads album"
+      else
+        echo "NOTICE: apple-photos not available — file kept in attachments"
+        echo "KEPT_IN_ATTACHMENTS: $OUTFILE"
+      fi
+      ;;
+
+    minis)
+      # Keep in attachments — user can view/play in-chat
+      echo "KEPT_IN_ATTACHMENTS: $OUTFILE"
+      ;;
+
+    *)
+      echo "ERROR: Unknown save mode '$SAVE_MODE'" >&2
+      echo "Valid: files, photos, minis" >&2
+      echo "File left at: $OUTFILE"
+      ;;
+  esac
+else
+  echo "ERROR: Download failed — file not found" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What it does
Downloads YouTube videos and extracts audio inside the Minis Linux sandbox using yt-dlp + ffmpeg.

## Features
- **First-run onboarding** with config persistence (quality preference, save destination)
- **Three save destinations:** iOS Files (Downloads mount), Photos (YouTube Downloads album), or Minis attachments
- **DASH format support** (1080p, 1440p) with manual ffmpeg merge — works around yt-dlp's broken merger in iSH
- **iOS container remuxing** — H.264 goes to M4V container (best iOS compatibility), AV1/VP9 goes to standard mp4 with +faststart
- **All quality levels tested:** audio, 360p, 720p, 1080p, 1440p
- **Audio to Photos gracefully falls back** to Minis attachments (Photos doesn't accept audio files)

## Why the DASH merge workaround
yt-dlp's built-in video+audio merger crashes in iSH ("Error opening input files"). The script downloads separate streams with `-k` (keep video), lets the merger fail, then merges with a direct ffmpeg call. Pre-merged formats (18=360p, 22=720p) work without this workaround.

## Submission checklist
- [x] Directory name: lowercase kebab-case ✓
- [x] SKILL.md with valid YAML frontmatter (name + description) ✓
- [x] Description clearly states what and when to trigger ✓
- [x] SKILL.md body under 500 lines (149 lines) ✓
- [x] Instructions use imperative form ✓
- [x] No secrets, API keys, or credentials ✓
- [x] Bundled scripts in scripts/ ✓
- [x] No config.json shipped (runtime-only file) ✓