### PR TITLE
Add codex-on-ish: run OpenAI Codex CLI in the Minis iSH sandbox

### DIFF
--- a/codex-on-ish/SKILL.md
+++ b/codex-on-ish/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: codex-on-ish
+description: Install and run OpenAI Codex CLI inside the Minis/iSH Alpine sandbox on iOS, where rustls TLS and async sockets are broken. Covers the local MITM proxy with P-256 certs, version-spoofing to unlock newer models (gpt-5.6 family), forcing SSE instead of websockets, ChatGPT device-auth login driven by curl, and the refcounted proxy wrapper. Use when the user wants Codex or other Rust-based AI CLIs on the iPhone/iPad Minis shell, or hits "error sending request", "must support ECDSA_NISTP521_SHA512" panics, model "requires a newer version of Codex", or npm errno 65 inside iSH.
+---
+
+# Codex on iSH (Minis iOS sandbox)
+
+Run the OpenAI Codex CLI natively in the Alpine/iSH environment. Works around the
+platform's broken Rust networking stack with a local MITM proxy.
+
+## Why this is needed (the two bugs)
+
+1. **rustls misbehaves on iSH's translated CPU.** Official musl binaries ≥ v0.143
+   panic at the first TLS handshake (`installed rustls crypto provider must
+   support ECDSA_NISTP521_SHA512`) because aws-lc-rs CPU detection fails in the
+   emulator. v0.130 (ring provider) handshakes, but ONLY with ECDSA P-256
+   certificates — RSA and P-521 get refused.
+2. **Async sockets to remote hosts fail** (`connect errno 65` / reqwest
+   `error sending request`). Blocking-socket clients (curl, Python) work fine;
+   loopback connections work fine. Routing Rust traffic through a local proxy
+   converts the hostile leg into a reliable one.
+
+Both bugs are iSH-specific. Termux forks do NOT fix them (verified: their
+rustls code is identical to upstream).
+
+## Install
+
+```
+sh scripts/setup.sh
+```
+
+This downloads codex v0.130.0 musl aarch64, generates the P-256 CA/server certs,
+installs `pyproxy6.py` (proxy) and the `codex` wrapper into /usr/local/bin, and
+writes `~/.codex/config.toml` defaults (model, yolo approval policy).
+
+## Login (ChatGPT account)
+
+Codex's own login flows die within minutes (iOS kills the app at 48 CPU-s/min
+in background), so drive the OAuth device flow with curl instead:
+
+```
+sh scripts/token_poller3.sh &     # prints a live user_code, auto-renews
+# user visits https://auth.openai.com/codex/device, enters the code
+# poller exchanges the artifact and writes /tmp/token_result.json
+sh scripts/write_auth_json.sh     # installs ~/.codex/auth.json
+codex login status                # -> "Logged in using ChatGPT"
+```
+
+Key protocol facts (see references/auth-protocol.md):
+- `POST /api/accounts/deviceauth/usercode` JSON `{client_id}` → device_auth_id + user_code
+- poll `/deviceauth/token` with `{device_auth_id, client_id, user_code}` until it returns
+  `authorization_code` + `code_verifier`
+- exchange at `/oauth/token` **form-encoded** (JSON is rejected) with
+  `redirect_uri=https://auth.openai.com/deviceauth/callback` → id/access/refresh tokens
+- Python urllib is blocked by Cloudflare on these endpoints — always use curl.
+
+## What the wrapper does
+
+`codex` (wrapper) registers a refcount file, starts the proxy as a singleton
+(pidfile + pgrep guard), waits for the port, execs `codex.bin` with
+`SSL_CERT_FILE`/`HTTPS_PROXY` env, and cleans up on exit. The proxy tears itself
+down ~8 s after the last client leaves. Output is silent; logs live in
+/tmp/codex-proxy/.
+
+## Model gating and the version spoof
+
+The backend gates models by reported client version (e.g. gpt-5.6-* requires
+≥ 0.144.0 — the exact versions that panic on iSH). The proxy rewrites
+`0.130.0` → `0.151.0` in-flight (same byte length, so HTTP framing survives) in
+the request line, `version:` header, and bodies.
+
+It also down-translates the models catalog: drops `max`/`ultra` reasoning
+efforts v0.130 can't parse, forces `prefer_websockets=false`, and rewrites
+Content-Length. Websocket upgrades on `/backend-api/codex/responses` get a
+local 501 so codex falls back to SSE (WS frames would stall the HTTP-framed
+relay); other WS upgrades pass through raw.
+
+## Troubleshooting
+
+See references/troubleshooting.md for: cert re-generation, DNS EAI_AGAIN
+retries, "models list failed to refresh", login poller death, upstream 502s,
+and the iOS background CPU-budget kills.

--- a/codex-on-ish/evals/evals.json
+++ b/codex-on-ish/evals/evals.json
@@ -1,0 +1,24 @@
+{
+  "evals": [
+    {
+      "prompt": "Install codex CLI on this iPhone Minis terminal so I can use it as an AI coding agent",
+      "expected_behaviour": "Runs scripts/setup.sh (aarch64 + certs + v0.130 musl binary + proxy + wrapper), then explains the curl device-auth login step instead of running codex login directly."
+    },
+    {
+      "prompt": "codex keeps saying error sending request for url, curl works fine. what's wrong",
+      "expected_behaviour": "Explains iSH async-socket/rustls breakage, verifies the codex wrapper env (HTTPS_PROXY=127.0.0.1:8894, SSL_CERT_FILE), checks /tmp/codex-proxy/proxy.log for CONN/ERR entries rather than reinstalling."
+    },
+    {
+      "prompt": "codex login keeps dying after a minute, my device code never completes",
+      "expected_behaviour": "Attributes death to iOS background CPU-budget kills; switches to scripts/token_poller3.sh (curl-driven device auth) and tells the user to keep the app foregrounded while entering the code."
+    },
+    {
+      "prompt": "why can't I use gpt-5.6 in codex? it says requires a newer version",
+      "expected_behaviour": "Explains server-side min_client gating vs the iSH panic ceiling (v0.141+ unusable), confirms the proxy rewrites 0.130.0→0.151.0 (length-neutral) and transforms the models catalog; suggests -m gpt-5.6-sol."
+    },
+    {
+      "prompt": "the model picker only shows old models and there's an unknown variant max error",
+      "expected_behaviour": "Recognizes the catalog decode failure; checks pyproxy6 logs for 'models transform' (effort filter, prefer_websockets=false) and restarts the singleton proxy if the transform stopped firing."
+    }
+  ]
+}

--- a/codex-on-ish/references/auth-protocol.md
+++ b/codex-on-ish/references/auth-protocol.md
@@ -1,0 +1,56 @@
+# ChatGPT device-auth protocol (curl-driven)
+
+All endpoints on `auth.openai.com` unless noted. Use curl — Cloudflare blocks
+Python-urllib fingerprints on these paths (cf_route_error).
+
+1. **Request a device code**
+   ```
+   POST /api/accounts/deviceauth/usercode
+   content-type: application/json
+   {"client_id":"app_EMoamEEZ73f0CkXaXp7hrann"}
+   ```
+   → `{device_auth_id, user_code, interval, expires_at}` (15 min TTL).
+   The user enters the code at `https://auth.openai.com/codex/device`.
+
+2. **Poll for the approval artifact** (every 5–10 s)
+   ```
+   POST /api/accounts/deviceauth/token
+   {"device_auth_id":"...","client_id":"...","user_code":"..."}
+   ```
+   → `authorization_pending` until approved, then
+   `{status:"success", authorization_code, code_challenge, code_verifier}`.
+   NOTE: an authorization_code is burned by malformed redemption attempts —
+   send the exchange correctly on the first try.
+
+3. **Exchange for tokens** — FORM-ENCODED, not JSON:
+   ```
+   POST /oauth/token
+   content-type: application/x-www-form-urlencoded
+   grant_type=authorization_code
+   code=<authorization_code>
+   code_verifier=<code_verifier>
+   client_id=app_EMoamEEZ73f0CkXaXp7hrann
+   redirect_uri=https://auth.openai.com/deviceauth/callback
+   ```
+   → `{access_token, id_token, refresh_token, expires_in, ...}`
+   (The redirect_uri is the device-flow value — NOT the browser flow's
+   localhost:1455. JSON bodies fail with `token_exchange_user_error`.)
+
+4. **Install** via scripts/write_auth_json.sh (auth.json format for v0.130:
+   `{"OPENAI_API_KEY":null,"tokens":{"id_token","access_token","refresh_token"},
+   "last_refresh":"<ISO8601 with nonzero fraction>"}`).
+
+## Refresh
+
+Codex refreshes tokens itself through the proxy (same client_id, grant_type
+refresh_token). If refresh breaks, re-run the device flow.
+
+## Models endpoint (account capabilities)
+
+```
+GET chatgpt.com/backend-api/codex/models?client_version=<v>
+Authorization: Bearer <access_token>
+originator: codex_cli_rs
+```
+The list is filtered server-side by client_version — the reason the proxy
+spoofs 0.151.0.

--- a/codex-on-ish/references/troubleshooting.md
+++ b/codex-on-ish/references/troubleshooting.md
@@ -1,0 +1,49 @@
+# Troubleshooting Codex on iSH
+
+## Quick diagnostics
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `error sending request for url` from codex | direct reqwest sockets to remote hosts | confirm wrapper env is set (`HTTPS_PROXY=http://127.0.0.1:8894`) |
+| panic `must support ECDSA_NISTP521_SHA512` | codex ≥ 0.143 (aws-lc provider) on iSH | use codex.bin v0.130; do not `codex update` |
+| `failed to connect to websocket: 501` in stderr | proxy blocked the responses-endpoint WS upgrade | informational — SSE fallback working as designed |
+| `failed to refresh available models` | catalog contains efforts the old client can't parse | check pyproxy6 logged "models transform"; restart proxy |
+| npm-style `connect errno 65` | same iSH async-socket disease | route through any blocking-socket proxy |
+| `gaierror(-3, 'Try again')` in proxy log | iSH DNS flake | pyproxy6 retries + caches; just retry the command |
+| upstream 502 Bad Gateway from proxy | upstream connect failed | usually transient; DNS retry inside proxy handles it |
+
+## Proxy maintenance
+
+- State dir: `/tmp/codex-proxy/` (proxy.pid, clients/, proxy.log, proxy.out)
+- Kill stale singleton: `pkill -f pyproxy6 && rm -f /tmp/codex-proxy/proxy.pid`
+- Regenerate certs if expiry: rerun the cert block in scripts/setup.sh
+- Full log: `tail -f /tmp/codex-proxy/proxy.log`
+
+## iOS process-death rules (device-verified, iOS 26)
+
+- Foreground: 90 CPU-s / 180 s — advisory only
+- Background: 48 CPU-s / 60 s — **the whole app is killed**
+- Consequences: long codex runs need the app foregrounded; backgrounded runs
+  are throttled (governor) and may look frozen for a while, then resume.
+- Never leave `codex login`'s own server waiting while switching apps — use
+  the curl-driven device-auth flow instead (scripts/token_poller3.sh).
+
+## HTTP relay internals (if you must modify the proxy)
+
+- Requests are framed; bodies rewritten length-neutrally (`0.130.0` → `0.151.0`)
+- `accept-encoding` is forced to `identity` so responses are rewriteable text
+- Only `/backend-api/codex/models` responses are buffered+transformed
+  (effort filter, `prefer_websockets=false`); everything else raw-pumps
+- NEVER defer trailing bytes speculatively when scanning a stream for a token:
+  an HTTP request's final bytes will never arrive if the server is waiting on
+  them — only defer suffixes that are a true prefix of the search token
+- WebSocket upgrades on `/backend-api/codex/responses` must be 501'd (codex
+  falls back to SSE); all other WS upgrades switch to raw pump
+
+## Version notes
+
+- v0.130.0 = last musl release whose rustls (ring) works on iSH
+- v0.131–0.140 also boot but models are gated client-side at the server
+- v0.141+ panic on first TLS attempt — verified 0.144 and 0.151
+- Spoofed client version 0.151.0 unlocks gpt-5.6-sol/terra/luna for accounts
+  whose plan has them (slug `gpt-5.6` alone is API-only)

--- a/codex-on-ish/scripts/codex-wrapper.sh
+++ b/codex-on-ish/scripts/codex-wrapper.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# codex on iSH: transparent wrapper
+#  - routes codex through local MITM+spoof proxy (rustls broken natively on iSH)
+#  - proxy is a singleton, refcounted: starts on demand, tears down when last codex exits
+#  - yolo behavior comes from ~/.codex/config.toml (approval_policy/sandbox_mode)
+STATE=/tmp/codex-proxy
+CLIENTS="$STATE/clients"
+PORT=8894
+mkdir -p "$CLIENTS"
+
+CPID=$$
+echo "$CPID" > "$CLIENTS/$CPID"
+cleanup() { rm -f "$CLIENTS/$CPID" 2>/dev/null; }
+trap cleanup EXIT INT TERM
+
+# singleton proxy: start only if no live pidfile AND no starting instance
+P_PID=$(cat "$STATE/proxy.pid" 2>/dev/null)
+if { [ -z "$P_PID" ] || ! kill -0 "$P_PID" 2>/dev/null; } && ! pgrep -f "pyproxy6.py $PORT" >/dev/null 2>&1; then
+    rm -f "$STATE/proxy.pid"
+    nohup python3 /usr/local/bin/pyproxy6.py "$PORT" > "$STATE/proxy.out" 2>&1 &
+fi
+
+# wait for the port (startup on iSH can take a couple seconds)
+i=0
+while [ "$i" -lt 12 ]; do
+    python3 -c "import socket;socket.create_connection(('127.0.0.1',$PORT),0.5)" 2>/dev/null && break
+    i=$((i+1)); sleep 1
+done
+
+export SSL_CERT_FILE=/etc/pyproxy/ca256.pem
+export HTTPS_PROXY="http://127.0.0.1:$PORT"
+export HTTP_PROXY="http://127.0.0.1:$PORT"
+export NO_PROXY="localhost,127.0.0.1"
+
+/usr/local/bin/codex.bin "$@"
+RC=$?
+cleanup
+trap - EXIT INT TERM
+exit $RC

--- a/codex-on-ish/scripts/pyproxy6.py
+++ b/codex-on-ish/scripts/pyproxy6.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""pyproxy6: MITM P-256 + version spoof (0.130->0.151) + models down-translation.
+
+Adds to pyproxy5:
+- HTTP/1.1 framing on both legs (request heads tracked for path)
+- Forces accept-encoding: identity so responses are rewriteable text
+- /backend-api/codex/models responses: buffered, JSON-transformed for v0.130
+  (drop 'max'/'ultra' efforts), re-framed with new Content-Length
+- Everything else (incl. SSE streams): raw pass-through
+
+Singleton + refcount teardown identical to pyproxy5 (state: /tmp/codex-proxy).
+"""
+import socket, ssl, threading, sys, time, os, errno, re, json
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8894
+OLD, NEW = b"0.130.0", b"0.151.0"
+MODELS_MARK = b"/backend-api/codex/models"
+ALLOWED_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
+STATE = "/tmp/codex-proxy"
+CLIENTS = STATE + "/clients"
+os.makedirs(CLIENTS, exist_ok=True)
+LOGF = open(STATE + "/proxy.log", "a", buffering=1)
+
+def log(*a):
+    LOGF.write(time.strftime("%H:%M:%S ") + " ".join(map(str, a)) + "\n")
+
+def pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError as e:
+        return e.errno == errno.EPERM
+
+def monitor():
+    time.sleep(4)
+    idle = 0
+    while True:
+        try:
+            refs = os.listdir(CLIENTS)
+        except FileNotFoundError:
+            refs = []
+        alive = False
+        for r in refs:
+            try:
+                p = int(r)
+            except ValueError:
+                try: os.unlink(CLIENTS + "/" + r)
+                except OSError: pass
+                continue
+            if pid_alive(p):
+                alive = True
+            else:
+                try: os.unlink(CLIENTS + "/" + r)
+                except OSError: pass
+        if alive:
+            idle = 0
+        else:
+            idle += 1
+            if idle >= 2:
+                log("last client gone, shutting down")
+                try: os.unlink(STATE + "/proxy.pid")
+                except OSError: pass
+                os._exit(0)
+        time.sleep(2)
+
+SRV_CTX = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+SRV_CTX.load_cert_chain("/etc/pyproxy/srv256.pem", "/etc/pyproxy/srv256.key")
+SRV_CTX.set_alpn_protocols(["http/1.1"])
+
+def rewrite_ver(b):
+    if OLD in b:
+        b = b.replace(OLD, NEW)
+    return b
+
+def transform_models(body):
+    d = json.loads(body)
+    ms = d.get("models", [])
+    kept = 0
+    for m in ms:
+        # v0.130 works over SSE on this stack; WS frames would stall the relay
+        if m.get("prefer_websockets"):
+            m["prefer_websockets"] = False
+        lv = m.get("supported_reasoning_levels")
+        if isinstance(lv, list):
+            newlv = [e for e in lv if isinstance(e, dict) and e.get("effort") in ALLOWED_EFFORTS]
+            if len(newlv) != len(lv):
+                kept += len(lv) - len(newlv)
+            m["supported_reasoning_levels"] = newlv
+        dr = m.get("default_reasoning_level")
+        if dr is not None and dr not in ALLOWED_EFFORTS:
+            m["default_reasoning_level"] = "high"
+    log("models transform: %d models, dropped %d effort levels, SSE forced" % (len(ms), kept))
+    return json.dumps(d).encode()
+
+def recv_head(sock, buf):
+    """Accumulate until full HTTP head (\r\n\r\n). Returns (head, rest) or (None, buf)."""
+    while b"\r\n\r\n" not in buf:
+        try:
+            d = sock.recv(65536)
+        except OSError:
+            return None, buf
+        if not d:
+            return None, buf
+        buf += d
+    i = buf.index(b"\r\n\r\n") + 4
+    return buf[:i], buf[i:]
+
+def recv_exact(sock, buf, n):
+    """Read exactly n body bytes. Returns (body, rest) or (None, buf)."""
+    while len(buf) < n:
+        try:
+            d = sock.recv(65536)
+        except OSError:
+            return None, buf
+        if not d:
+            return None, buf
+        buf += d
+    return buf[:n], buf[n:]
+
+def recv_chunked(sock, buf):
+    """Decode chunked body. Returns (body, rest) or (None, buf)."""
+    body = b""
+    while True:
+        while b"\r\n" not in buf:
+            try:
+                d = sock.recv(65536)
+            except OSError:
+                return None, buf
+            if not d:
+                return None, buf
+            buf += d
+        line, buf = buf.split(b"\r\n", 1)
+        try:
+            size = int(line.split(b";")[0].strip(), 16)
+        except ValueError:
+            return None, buf
+        if size == 0:
+            # consume trailer until blank line
+            while b"\r\n" not in buf:
+                try:
+                    d = sock.recv(65536)
+                except OSError:
+                    return None, buf
+                if not d:
+                    return None, buf
+                buf += d
+            _, buf = buf.split(b"\r\n", 1)
+            return body, buf
+        chunk, buf = recv_exact(sock, buf, size + 2)
+        if chunk is None:
+            return None, buf
+        body += chunk[:size]
+
+def hget(head, name):
+    m = re.search(rb'(?i)^' + name + rb':\s*([^\r\n]*)', head, re.M)
+    return m.group(1).strip() if m else None
+
+def pump(a, b):
+    """Raw bidirectional-ish single direction pump."""
+    try:
+        while True:
+            d = a.recv(65536)
+            if not d:
+                break
+            b.sendall(d)
+    except OSError:
+        pass
+
+def c2u_framed(cli, up, state):
+    """Client->upstream: frame requests, rewrite version, force identity encoding."""
+    buf = b""
+    while True:
+        head, buf = recv_head(cli, buf)
+        if head is None:
+            break
+        head = rewrite_ver(head)
+        head = re.sub(rb'(?i)^accept-encoding:[^\r\n]*', b'accept-encoding: identity', head, flags=re.M)
+        parts = head.split(b"\r\n", 1)[0].split()
+        if len(parts) > 1:
+            try:
+                state["path"] = parts[1].decode(errors="replace")
+            except Exception:
+                pass
+            # Block websocket upgrades on the responses endpoint: our relay is
+            # HTTP-framed and codex falls back to SSE there. Any OTHER websocket
+            # upgrade (e.g. remote-control relay) switches to raw passthrough.
+            if re.search(rb'(?i)^upgrade:', head, re.M):
+                if state["path"].startswith("/backend-api/codex/responses"):
+                    log("blocked WS upgrade -> forcing SSE fallback")
+                    try:
+                        cli.sendall(b"HTTP/1.1 501 WebSocket unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    except OSError:
+                        pass
+                    for s in (cli, up):
+                        try: s.shutdown(socket.SHUT_RDWR)
+                        except OSError: pass
+                    return
+                # generic WS passthrough: forward head, then raw pump both legs
+                log("WS passthrough:", state["path"][:70])
+                up.sendall(head + buf)
+                buf = b""
+                pump(cli, up)
+                return
+            log("REQ", parts[0].decode(errors="replace"), state["path"][:80])
+        te = hget(head, b"transfer-encoding")
+        cl = hget(head, b"content-length")
+        if te and b"chunked" in te.lower():
+            # stream this request and connection raw from here on
+            up.sendall(head)
+            if buf:
+                up.sendall(buf)
+            pump(cli, up)
+            return
+        body = b""
+        if cl:
+            n = int(cl)
+            body, buf = recv_exact(cli, buf, n)
+            if body is None:
+                up.sendall(head)
+                if buf:
+                    up.sendall(buf)
+                return
+            body = rewrite_ver(body)
+        up.sendall(head + body)
+
+def u2c_framed(up, cli, state):
+    """Upstream->client: raw pump, except models responses which get rewritten."""
+    buf = b""
+    while True:
+        head, buf = recv_head(up, buf)
+        if head is None:
+            break
+        is_models = MODELS_MARK in state.get("path", "").encode() if state.get("path") else False
+        status = head.split(b" ", 2)
+        ok = len(status) > 1 and status[1] == b"200"
+        log("RESP", state.get("path", "?")[:60], head.split(b"\r\n", 1)[0].decode(errors="replace")[:40])
+        te = hget(head, b"transfer-encoding")
+        cl = hget(head, b"content-length")
+        chunked = te and b"chunked" in te.lower()
+        if is_models and ok and (chunked or cl):
+            if chunked:
+                body, buf = recv_chunked(up, buf)
+            else:
+                body, buf = recv_exact(up, buf, int(cl))
+            if body is None:
+                cli.sendall(head)
+                if buf:
+                    cli.sendall(buf)
+                pump(up, cli)
+                return
+            try:
+                body = transform_models(body)
+            except Exception as e:
+                log("models transform failed, passing through:", repr(e))
+            head = re.sub(rb'(?i)^transfer-encoding:[^\r\n]*\r\n', b'', head, flags=re.M)
+            head = re.sub(rb'(?i)^content-length:[^\r\n]*', b'content-length: ' + str(len(body)).encode(), head, flags=re.M)
+            if b"content-length" not in head.lower():
+                head = head.replace(b"\r\n\r\n", b"\r\ncontent-length: " + str(len(body)).encode() + b"\r\n\r\n")
+            cli.sendall(head + body)
+            continue
+        # everything else: forward head + buffered, then raw pump (streams)
+        cli.sendall(head)
+        if buf:
+            cli.sendall(buf)
+        pump(up, cli)
+        return
+
+DNS_CACHE = {}  # host -> (ips, ts)
+DNS_TTL = 300
+
+def resolve(host):
+    """DNS with cache + retry; iSH resolver intermittently returns EAI_AGAIN."""
+    now = time.time()
+    if host in DNS_CACHE:
+        ips, ts = DNS_CACHE[host]
+        if now - ts < DNS_TTL:
+            return ips
+    last = None
+    for attempt in range(4):
+        try:
+            infos = socket.getaddrinfo(host, 443, socket.AF_INET, socket.SOCK_STREAM)
+            ips = list(dict.fromkeys(i[4][0] for i in infos))
+            if ips:
+                DNS_CACHE[host] = (ips, now)
+                return ips
+        except socket.gaierror as e:
+            last = e
+            time.sleep(0.4)
+    if host in DNS_CACHE:  # stale fallback beats failure
+        ips, _ = DNS_CACHE[host]
+        return ips
+    raise last if last else socket.gaierror("resolve failed")
+
+def connect_up(host, port, timeout=30):
+    ips = resolve(host)
+    last = None
+    for ip in ips:
+        try:
+            return socket.create_connection((ip, port), timeout=timeout)
+        except OSError as e:
+            last = e
+    raise last
+
+def handle(cli):
+    host = None
+    try:
+        cli.settimeout(90)
+        head = b""
+        while b"\r\n\r\n" not in head:
+            c = cli.recv(4096)
+            if not c:
+                return
+            head += c
+        line = head.split(b"\r\n", 1)[0].decode(errors="replace")
+        parts = line.split()
+        if len(parts) < 2 or parts[0] != "CONNECT":
+            cli.sendall(b"HTTP/1.1 405 Only CONNECT\r\nContent-Length: 0\r\n\r\n")
+            return
+        host, port = parts[1].rsplit(":", 1)
+        port = int(port)
+        log("CONN", host)
+        up = ssl.create_default_context()
+        try:
+            up_s = up.wrap_socket(connect_up(host, port), server_hostname=host)
+        except Exception as ce:
+            log("upstream connect failed", host, repr(ce))
+            try:
+                cli.sendall(b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n")
+            except OSError:
+                pass
+            return
+        cli.sendall(b"HTTP/1.1 200 Tunnel established\r\n\r\n")
+        cli.settimeout(None)
+        tls_cli = SRV_CTX.wrap_socket(cli, server_side=True)
+        state = {"path": ""}
+        t = threading.Thread(target=c2u_framed, args=(tls_cli, up_s, state), daemon=True)
+        t.start()
+        u2c_framed(up_s, tls_cli, state)
+        t.join()
+    except Exception as e:
+        log("ERR", host, repr(e))
+    finally:
+        try: cli.close()
+        except OSError: pass
+
+srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    srv.bind(("127.0.0.1", PORT))
+except OSError as e:
+    if e.errno == errno.EADDRINUSE:
+        sys.exit(0)
+    raise
+srv.listen(16)
+open(STATE + "/proxy.pid", "w").write(str(os.getpid()))
+log("pyproxy6 up on %d (spoof + models down-translate) pid=%d" % (PORT, os.getpid()))
+threading.Thread(target=monitor, daemon=True).start()
+while True:
+    c, _ = srv.accept()
+    threading.Thread(target=handle, args=(c,), daemon=True).start()

--- a/codex-on-ish/scripts/setup.sh
+++ b/codex-on-ish/scripts/setup.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# setup.sh — install Codex CLI on iSH (Minis iOS sandbox)
+# Requires: apk add curl openssl python3
+set -e
+CODEX_VER="rust-v0.130.0"
+BIN="/usr/local/bin"
+
+[ "$(uname -m)" = "aarch64" ] || { echo "this skill targets aarch64 iSH"; exit 1; }
+
+# 1. certificates (ECDSA P-256 — codex's ring provider rejects RSA/P-521)
+mkdir -p /etc/pyproxy && cd /etc/pyproxy
+[ -f ca256.pem ] || {
+  openssl ecparam -name prime256v1 -genkey -noout -out ca256.key 2>/dev/null
+  openssl req -x509 -new -key ca256.key -out ca256.pem -days 3650 -subj "/CN=Minis Local CA" 2>/dev/null
+  openssl ecparam -name prime256v1 -genkey -noout -out srv256.key 2>/dev/null
+  openssl req -new -key srv256.key -out srv256.csr -subj "/CN=auth.openai.com" 2>/dev/null
+  printf 'subjectAltName=DNS:auth.openai.com,DNS:*.openai.com,DNS:chatgpt.com,DNS:*.chatgpt.com\nextendedKeyUsage=serverAuth\n' > ext.cnf
+  openssl x509 -req -in srv256.csr -CA ca256.pem -CAkey ca256.key -CAcreateserial -out srv256.pem -days 3650 -extfile ext.cnf 2>/dev/null
+  chmod 600 ca256.key srv256.key
+}
+
+# 2. codex binary (v0.130 = last release whose rustls works on iSH)
+cd /tmp
+curl -sL -o codex.tgz "https://github.com/openai/codex/releases/download/$CODEX_VER/codex-aarch64-unknown-linux-musl.tar.gz"
+tar xzf codex.tgz
+install -m 755 codex-aarch64-unknown-linux-musl "$BIN/codex.bin"
+rm -f codex.tgz codex-aarch64-unknown-linux-musl
+
+# 3. proxy + wrapper (from this skill's scripts/)
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+install -m 755 "$SKILL_DIR/scripts/pyproxy6.py" "$BIN/pyproxy6.py"
+install -m 755 "$SKILL_DIR/scripts/codex-wrapper.sh" "$BIN/codex-wrapper.sh"
+ln -sf "$BIN/codex-wrapper.sh" "$BIN/codex"
+
+# 4. config defaults (idempotent)
+mkdir -p ~/.codex
+python3 - <<'EOF'
+import os
+p = os.path.expanduser("~/.codex/config.toml")
+c = open(p).read() if os.path.exists(p) else ""
+def top(k, v):
+    global c
+    if k + " =" not in c:
+        c = k + " = " + v + "\n" + c
+top("model", '"gpt-5.5"')
+top("approval_policy", '"never"')
+top("sandbox_mode", '"danger-full-access"')
+open(p, "w").write(c)
+EOF
+
+codex --version && echo "OK — run scripts/token_poller3.sh to log in"

--- a/codex-on-ish/scripts/token_poller3.sh
+++ b/codex-on-ish/scripts/token_poller3.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Full device-auth driver: poll -> artifact -> PKCE exchange -> final tokens
+CID='app_EMoamEEZ73f0CkXaXp7hrann'
+RU='http://localhost:1455/auth/callback'
+GLOBAL_END=$(( $(date +%s) + 3600 ))
+while [ $(date +%s) -lt $GLOBAL_END ]; do
+  U=$(curl -s -X POST -H "content-type: application/json" -d "{\"client_id\":\"$CID\"}" --max-time 15 https://auth.openai.com/api/accounts/deviceauth/usercode)
+  DA=$(echo "$U" | sed -n 's/.*"device_auth_id": *"\([^"]*\)".*/\1/p')
+  UC=$(echo "$U" | sed -n 's/.*"user_code": *"\([^"]*\)".*/\1/p')
+  [ -z "$UC" ] && { echo "$(date +%H:%M:%S) usercode fail" >> /tmp/poll_err.txt; sleep 20; continue; }
+  echo "$UC" > /tmp/current_code.txt
+  echo "code $UC" > /tmp/poll_status.txt
+  POLL_END=$(( $(date +%s) + 840 ))
+  while [ $(date +%s) -lt $POLL_END ] && [ $(date +%s) -lt $GLOBAL_END ]; do
+    R=$(curl -s -X POST -H "content-type: application/json" -d "{\"device_auth_id\":\"$DA\",\"client_id\":\"$CID\",\"user_code\":\"$UC\"}" --max-time 15 https://auth.openai.com/api/accounts/deviceauth/token)
+    case "$R" in
+      *authorization_code*)
+        echo "$R" > /tmp/auth_artifact.json
+        AC=$(echo "$R" | sed -n 's/.*"authorization_code": *"\([^"]*\)".*/\1/p')
+        CV=$(echo "$R" | sed -n 's/.*"code_verifier": *"\([^"]*\)".*/\1/p')
+        T=$(curl -s -X POST -H "content-type: application/json" --max-time 20 https://auth.openai.com/oauth/token -d "{\"grant_type\":\"authorization_code\",\"code\":\"$AC\",\"code_verifier\":\"$CV\",\"client_id\":\"$CID\",\"redirect_uri\":\"$RU\"}")
+        if echo "$T" | grep -q '"access_token"'; then
+          echo "$T" > /tmp/token_result.json
+          echo "FULL SUCCESS $(date +%H:%M:%S)" > /tmp/poll_status.txt
+          exit 0
+        else
+          echo "$(date +%H:%M:%S) exchange failed: $T" >> /tmp/poll_err.txt
+          echo "$T" > /tmp/exchange_fail.json
+          exit 1
+        fi
+        ;;
+      *pending*|*slow_down*) sleep 7;;
+      *expired*) break;;
+      *) echo "$(date +%H:%M:%S) $R" >> /tmp/poll_err.txt; sleep 9;;
+    esac
+  done
+done
+echo "GLOBAL TIMEOUT" > /tmp/poll_status.txt

--- a/codex-on-ish/scripts/write_auth_json.sh
+++ b/codex-on-ish/scripts/write_auth_json.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# write_auth_json.sh — install tokens from /tmp/token_result.json into ~/.codex/auth.json
+python3 - <<'EOF'
+import json, os, datetime
+d = json.load(open("/tmp/token_result.json"))
+auth = {
+    "OPENAI_API_KEY": None,
+    "tokens": {
+        "id_token": d["id_token"],
+        "access_token": d["access_token"],
+        "refresh_token": d["refresh_token"],
+    },
+    "last_refresh": datetime.datetime.now(datetime.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+}
+p = os.path.expanduser("~/.codex/auth.json")
+os.makedirs(os.path.dirname(p), exist_ok=True)
+open(p, "w").write(json.dumps(auth))
+os.chmod(p, 0o600)
+print("auth.json written")
+EOF
+codex login status 2>&1 | tail -1


### PR DESCRIPTION
## What

Runs OpenAI **Codex CLI natively inside the Minis iSH shell** (iOS) — something currently impossible out of the box, because Codex's Rust networking stack breaks on iSH's translated CPU:

1. `rustls`/aws-lc panics on the first TLS handshake in musl builds ≥ 0.143 (`installed rustls crypto provider must support ECDSA_NISTP521_SHA512`). v0.130 (ring provider) works — but only trusts **ECDSA P-256** certificates.
2. Async (tokio) sockets to remote hosts fail with `EHOSTUNREACH`/`error sending request`, while curl/Python/blocking sockets and loopback connections work fine.

Verified empirically on iPhone (aarch64 Alpine 3.21): official v0.144/v0.151 musl binaries panic; Termux forks ship identical TLS code and don't help.

## The stack

| Piece | What it does |
|---|---|
| `scripts/pyproxy6.py` | Local MITM proxy: P-256 certs, DNS cache + EAI_AGAIN retries, HTTP-framed relay with length-neutral client-version spoof (`0.130.0` → `0.151.0`, unlocks gpt-5.6 family), models-catalog down-translation (drops `max`/`ultra` efforts old clients can't parse, forces SSE), 501-blocks the responses-endpoint WS upgrade (codex falls back to SSE), raw-pumps other WS upgrades |
| `scripts/codex-wrapper.sh` | Refcounted wrapper: proxy starts on demand as a singleton, tears down ~8s after the last codex exits; silent to stdout |
| `scripts/setup.sh` | One-shot install (v0.130 musl binary, cert generation, wrapper, config defaults) |
| `scripts/token_poller3.sh` + `write_auth_json.sh` | curl-driven ChatGPT device-auth — codex's own login server dies to iOS background CPU-budget kills (48 CPU-s/60s), so the OAuth device flow is driven externally; artifact exchanged form-encoded with the device-flow redirect_uri |
| `references/` | Full auth protocol + troubleshooting matrix (incl. the iOS CPU-budget rules and relay internals) |

## Tested

- `codex exec` end-to-end on gpt-5.5 and gpt-5.6-sol/terra via ChatGPT account auth
- ChatGPT login completes through the curl device flow; `codex login status` → "Logged in using ChatGPT"
- Proxy singleton + teardown verified with concurrent runs
- Eval prompts in `evals/evals.json` cover install, TLS failure diagnosis, login-death, model gating, and catalog errors

No secrets are bundled — certificates and tokens are generated/fetched at install & login time on the user's device. The proxy binds 127.0.0.1 only.
