### PR TITLE
fix(bilibili-hub): correct unsatisfiable bilibili-api-python constraint

### DIFF
--- a/bilibili-hub/pyproject.toml
+++ b/bilibili-hub/pyproject.toml
@@ -3,6 +3,6 @@ name = "bilibili-hub"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "bilibili-api-python>=28.0",
+    "bilibili-api-python>=17.4.2,<18",
     "aiohttp>=3.9",
 ]


### PR DESCRIPTION
## What

Change the `bilibili-api-python` constraint in `bilibili-hub/pyproject.toml` from `>=28.0` to `>=17.4.2,<18`.

## Why

`bilibili-api-python>=28.0` is unsatisfiable — **no such version exists on PyPI**. The highest published release is `17.4.2`, and the upstream project ([Nemo2011/bilibili-api](https://github.com/Nemo2011/bilibili-api)) is archived, so no `28.x` is coming.

As a result, the documented setup step fails on a clean checkout:

```bash
cd /var/minis/skills/bilibili-hub
uv sync
```

```
× No solution found when resolving dependencies:
╰─▶ Because only bilibili-api-python<=17.4.2 is available and your project
    depends on bilibili-api-python>=28.0, we can conclude that your
    project's requirements are unsatisfiable.
```

`SKILL.md` → "Quick Start → Environment setup" instructs the agent to run exactly this command, so the skill cannot be installed as shipped.

## Changes

```diff
 dependencies = [
-    "bilibili-api-python>=28.0",
+    "bilibili-api-python>=17.4.2,<18",
     "aiohttp>=3.9",
 ]
```

`17.4.2` is the highest available release, so it is the tightest lower bound that resolves.

The `<18` upper bound was added after review: `scripts/client.py` carries explicit `17.x` compatibility shims (`# 兼容 bilibili-api-python 17.x 异常体系`, `# 17.x 中历史记录通过 user.get_self_history 获取`), so the skill is written against the 17.x API surface. Without a cap, a future `18.x` would be selected automatically and could silently break those paths.

## Verification

Ran `uv sync` on a clean checkout of this branch, then imported every symbol `scripts/client.py` uses:

```python
from bilibili_api import comment, dynamic, favorite_list, hot, rank, search, user, video
from bilibili_api.utils.network import Credential
from bilibili_api.exceptions import ApiException, ResponseCodeException
from bilibili_api.video import VideoDownloadURLDataDetecter, AudioQuality
```

All imports resolve with `bilibili-api-python==17.4.2` — no API used by the skill is missing from this version.

## Note

The same broken constraint is the only occurrence in the repo. Checked existing issues/PRs first — no duplicate report found.
